### PR TITLE
feat: process management improvements

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -152,6 +152,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       stderr: proc.stderr as ReadableStream<Uint8Array>,
       cancel: () => handler.interrupt(),
       protocolHandler: handler,
+      spawnCommand: [cmd.program, ...cmd.args].join(' '),
     }
   }
 
@@ -230,6 +231,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       stderr: proc.stderr as ReadableStream<Uint8Array>,
       cancel: () => handler.interrupt(),
       protocolHandler: handler,
+      spawnCommand: [cmd.program, ...cmd.args].join(' '),
     }
   }
 

--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -393,6 +393,7 @@ export class CodexExecutor implements EngineExecutor {
       // Expose the real Codex thread ID so the issue engine stores it
       // instead of the pre-generated UUID (needed for follow-up/resume).
       externalSessionId: handler.threadId,
+      spawnCommand: cmd.join(' '),
     }
   }
 
@@ -456,6 +457,7 @@ export class CodexExecutor implements EngineExecutor {
         },
       },
       externalSessionId: handler.threadId,
+      spawnCommand: cmd.join(' '),
     }
   }
 

--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -4,4 +4,5 @@ export const MAX_AUTO_RETRIES = 1
 export const GC_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
 export const MAX_CONCURRENT_EXECUTIONS =
   Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
+export const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
 export const WORKTREE_DIR = '.bitk/worktrees'

--- a/apps/api/src/engines/issue/engine.ts
+++ b/apps/api/src/engines/issue/engine.ts
@@ -20,6 +20,7 @@ import {
   restartIssue,
   restartStaleSessions,
 } from './orchestration'
+import { terminateProcess } from './process/cancel'
 import {
   cancelAll,
   getActiveProcessesList,
@@ -195,6 +196,10 @@ export class IssueEngine {
 
   async cancelAll(): Promise<void> {
     return cancelAll(this.ctx)
+  }
+
+  async terminateProcess(issueId: string): Promise<void> {
+    return terminateProcess(this.ctx, issueId)
   }
 
   // ---- Error tracking ----

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -41,9 +41,7 @@ export function gcSweep(ctx: EngineContext): void {
         {
           issueId: managed.issueId,
           executionId: managed.executionId,
-          idleMinutes: Math.round(
-            (now - managed.lastIdleAt.getTime()) / 60000,
-          ),
+          idleMinutes: Math.round((now - managed.lastIdleAt.getTime()) / 60000),
         },
         'idle_timeout_terminate',
       )

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -1,4 +1,8 @@
-import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
+import {
+  autoMoveToReview,
+  getIssueWithSession,
+  updateIssueSession,
+} from '@/engines/engine-store'
 import { logger } from '@/logger'
 import { IDLE_TIMEOUT_MS } from './constants'
 import type { EngineContext } from './context'
@@ -46,24 +50,27 @@ export function gcSweep(ctx: EngineContext): void {
         'idle_timeout_terminate',
       )
       ctx.pm.forceKill(entry.id)
-      emitStateChange(ctx, managed.issueId, managed.executionId, 'completed')
       cleanupDomainData(ctx, managed.executionId)
-      // Fire-and-forget DB update
+      // Fire-and-forget DB update — preserve prior terminal status if already set
+      const { issueId: gcIssueId, executionId: gcExecutionId } = managed
       void (async () => {
         try {
-          await updateIssueSession(managed.issueId, {
-            sessionStatus: 'completed',
-          })
-          await autoMoveToReview(managed.issueId)
-          emitIssueSettled(
-            ctx,
-            managed.issueId,
-            managed.executionId,
-            'completed',
-          )
+          const existing = await getIssueWithSession(gcIssueId)
+          const priorStatus = existing?.sessionFields.sessionStatus
+          const isTerminal =
+            priorStatus === 'failed' || priorStatus === 'cancelled'
+          const finalStatus = isTerminal ? priorStatus : 'completed'
+          emitStateChange(ctx, gcIssueId, gcExecutionId, finalStatus)
+          if (!isTerminal) {
+            await updateIssueSession(gcIssueId, {
+              sessionStatus: finalStatus,
+            })
+          }
+          await autoMoveToReview(gcIssueId)
+          emitIssueSettled(ctx, gcIssueId, gcExecutionId, finalStatus)
         } catch (err) {
           logger.error(
-            { issueId: managed.issueId, err },
+            { issueId: gcIssueId, err },
             'idle_timeout_settle_failed',
           )
         }

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -1,5 +1,8 @@
+import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
 import { logger } from '@/logger'
+import { IDLE_TIMEOUT_MS } from './constants'
 import type { EngineContext } from './context'
+import { emitIssueSettled, emitStateChange } from './events'
 import { cleanupDomainData } from './process/state'
 
 // ---------- Domain GC sweep ----------
@@ -24,6 +27,53 @@ export function gcSweep(ctx: EngineContext): void {
       cleaned++
     }
   }
+
+  // Terminate idle processes that have exceeded the idle timeout
+  const now = Date.now()
+  for (const entry of ctx.pm.getActive()) {
+    const managed = entry.meta
+    if (
+      managed.lastIdleAt &&
+      !managed.turnInFlight &&
+      now - managed.lastIdleAt.getTime() > IDLE_TIMEOUT_MS
+    ) {
+      logger.info(
+        {
+          issueId: managed.issueId,
+          executionId: managed.executionId,
+          idleMinutes: Math.round(
+            (now - managed.lastIdleAt.getTime()) / 60000,
+          ),
+        },
+        'idle_timeout_terminate',
+      )
+      ctx.pm.forceKill(entry.id)
+      emitStateChange(ctx, managed.issueId, managed.executionId, 'completed')
+      cleanupDomainData(ctx, managed.executionId)
+      // Fire-and-forget DB update
+      void (async () => {
+        try {
+          await updateIssueSession(managed.issueId, {
+            sessionStatus: 'completed',
+          })
+          await autoMoveToReview(managed.issueId)
+          emitIssueSettled(
+            ctx,
+            managed.issueId,
+            managed.executionId,
+            'completed',
+          )
+        } catch (err) {
+          logger.error(
+            { issueId: managed.issueId, err },
+            'idle_timeout_settle_failed',
+          )
+        }
+      })()
+      cleaned++
+    }
+  }
+
   if (cleaned > 0) {
     logger.debug(
       { cleaned, pmSize: ctx.pm.size(), pmActive: ctx.pm.activeCount() },

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -7,6 +7,7 @@ import { logger } from '@/logger'
 import { IDLE_TIMEOUT_MS } from './constants'
 import type { EngineContext } from './context'
 import { emitIssueSettled, emitStateChange } from './events'
+import { withIssueLock } from './process/lock'
 import { cleanupDomainData } from './process/state'
 
 // ---------- Domain GC sweep ----------
@@ -51,30 +52,33 @@ export function gcSweep(ctx: EngineContext): void {
       )
       ctx.pm.forceKill(entry.id)
       cleanupDomainData(ctx, managed.executionId)
-      // Fire-and-forget DB update — preserve prior terminal status if already set
+      // Fire-and-forget DB update — use issue lock to prevent racing with follow-up
       const { issueId: gcIssueId, executionId: gcExecutionId } = managed
-      void (async () => {
-        try {
-          const existing = await getIssueWithSession(gcIssueId)
-          const priorStatus = existing?.sessionFields.sessionStatus
-          const isTerminal =
-            priorStatus === 'failed' || priorStatus === 'cancelled'
-          const finalStatus = isTerminal ? priorStatus : 'completed'
-          emitStateChange(ctx, gcIssueId, gcExecutionId, finalStatus)
-          if (!isTerminal) {
-            await updateIssueSession(gcIssueId, {
-              sessionStatus: finalStatus,
-            })
-          }
-          await autoMoveToReview(gcIssueId)
-          emitIssueSettled(ctx, gcIssueId, gcExecutionId, finalStatus)
-        } catch (err) {
-          logger.error(
-            { issueId: gcIssueId, err },
-            'idle_timeout_settle_failed',
+      void withIssueLock(ctx, gcIssueId, async () => {
+        const existing = await getIssueWithSession(gcIssueId)
+        const priorStatus = existing?.sessionFields.sessionStatus
+        // If a follow-up already reactivated the issue, skip settlement
+        if (priorStatus === 'running' || priorStatus === 'pending') {
+          logger.debug(
+            { issueId: gcIssueId, priorStatus },
+            'idle_timeout_settle_skipped_reactivated',
           )
+          return
         }
-      })()
+        const isTerminal =
+          priorStatus === 'failed' || priorStatus === 'cancelled'
+        const finalStatus = isTerminal ? priorStatus : 'completed'
+        emitStateChange(ctx, gcIssueId, gcExecutionId, finalStatus)
+        if (!isTerminal) {
+          await updateIssueSession(gcIssueId, {
+            sessionStatus: finalStatus,
+          })
+        }
+        await autoMoveToReview(gcIssueId)
+        emitIssueSettled(ctx, gcIssueId, gcExecutionId, finalStatus)
+      }).catch((err) => {
+        logger.error({ issueId: gcIssueId, err }, 'idle_timeout_settle_failed')
+      })
       cleaned++
     }
   }

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -44,6 +44,10 @@ export function handleTurnCompleted(
   // and can receive follow-up input. Keeping state as 'running' ensures
   // getActiveProcessForIssue() can find it, preventing duplicate process spawns.
   // The turnSettled flag tells monitorCompletion() to just clean up on exit.
+
+  // Track when the process became idle for idle timeout cleanup
+  managed.lastIdleAt = new Date()
+
   const finalStatus = managed.logicalFailure ? 'failed' : 'completed'
   emitStateChange(ctx, issueId, executionId, finalStatus as ProcessStatus)
 

--- a/apps/api/src/engines/issue/orchestration/restart.ts
+++ b/apps/api/src/engines/issue/orchestration/restart.ts
@@ -1,4 +1,8 @@
 import { cleanupStaleSessions } from '@/db/helpers'
+import {
+  collectPendingWithAttachments,
+  markPendingMessagesDispatched,
+} from '@/db/pending-messages'
 import { getIssueWithSession, updateIssueSession } from '@/engines/engine-store'
 import { engineRegistry } from '@/engines/executors'
 import type { EngineContext } from '@/engines/issue/context'
@@ -39,6 +43,10 @@ export async function restartIssue(
     const executor = engineRegistry.get(engineType)
     if (!executor) throw new Error(`No executor for engine type: ${engineType}`)
 
+    // Collect pending messages to merge into the restart prompt
+    const { prompt: pendingPrompt, pendingIds } =
+      await collectPendingWithAttachments(issueId)
+
     await updateIssueSession(issueId, { sessionStatus: 'running' })
 
     const baseDir = await resolveWorkingDir(issue.projectId)
@@ -61,9 +69,14 @@ export async function restartIssue(
     const permOptions = getPermissionOptions(engineType)
     const executionId = crypto.randomUUID()
 
+    // Merge pending messages with the original prompt
+    const effectivePrompt = pendingPrompt
+      ? [issue.sessionFields.prompt, pendingPrompt].filter(Boolean).join('\n\n')
+      : issue.sessionFields.prompt
+
     const spawnOpts = {
       workingDir,
-      prompt: issue.sessionFields.prompt,
+      prompt: effectivePrompt,
       model: issue.sessionFields.model ?? undefined,
       permissionMode: permOptions.permissionMode,
       projectId: issue.projectId,
@@ -96,6 +109,15 @@ export async function restartIssue(
       () => handleTurnCompleted(ctx, issueId, executionId),
     )
     monitorCompletion(ctx, executionId, issueId, engineType, false)
+
+    // Mark pending messages as dispatched after successful spawn
+    if (pendingIds.length > 0) {
+      await markPendingMessagesDispatched(pendingIds)
+      logger.info(
+        { issueId, pendingCount: pendingIds.length },
+        'restart_pending_messages_dispatched',
+      )
+    }
 
     return { executionId }
   })

--- a/apps/api/src/engines/issue/process/cancel.ts
+++ b/apps/api/src/engines/issue/process/cancel.ts
@@ -1,6 +1,7 @@
 import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled, emitStateChange } from '@/engines/issue/events'
+import { withIssueLock } from '@/engines/issue/process/lock'
 import { cleanupDomainData } from '@/engines/issue/process/state'
 import { dispatch } from '@/engines/issue/state'
 import { getPidFromManaged } from '@/engines/issue/utils/pid'
@@ -70,28 +71,32 @@ export async function terminateProcess(
   ctx: EngineContext,
   issueId: string,
 ): Promise<void> {
-  // Kill active processes (spawning or running)
-  const active = ctx.pm.getActiveInGroup(issueId)
-  for (const entry of active) {
-    const managed = entry.meta
-    logger.info(
-      {
-        issueId,
-        executionId: entry.id,
-        pid: getPidFromManaged(managed),
-        state: entry.state,
-      },
-      'force_terminate_active_process',
-    )
-    dispatch(managed, { type: 'CLEAR_PENDING_INPUTS' })
-    managed.state = 'cancelled'
-    emitStateChange(ctx, issueId, entry.id, 'cancelled')
-    ctx.pm.forceKill(entry.id)
-    cleanupDomainData(ctx, entry.id)
-  }
+  return withIssueLock(ctx, issueId, async () => {
+    // Kill active processes (spawning or running)
+    const active = ctx.pm.getActiveInGroup(issueId)
+    let lastExecutionId = ''
+    for (const entry of active) {
+      const managed = entry.meta
+      logger.info(
+        {
+          issueId,
+          executionId: entry.id,
+          pid: getPidFromManaged(managed),
+          state: entry.state,
+        },
+        'force_terminate_active_process',
+      )
+      dispatch(managed, { type: 'CLEAR_PENDING_INPUTS' })
+      managed.state = 'cancelled'
+      emitStateChange(ctx, issueId, entry.id, 'cancelled')
+      ctx.pm.forceKill(entry.id)
+      cleanupDomainData(ctx, entry.id)
+      lastExecutionId = entry.id
+    }
 
-  await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
-  await autoMoveToReview(issueId)
-  emitIssueSettled(ctx, issueId, '', 'cancelled')
-  logger.info({ issueId }, 'force_terminate_completed')
+    await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
+    await autoMoveToReview(issueId)
+    emitIssueSettled(ctx, issueId, lastExecutionId, 'cancelled')
+    logger.info({ issueId }, 'force_terminate_completed')
+  })
 }

--- a/apps/api/src/engines/issue/process/cancel.ts
+++ b/apps/api/src/engines/issue/process/cancel.ts
@@ -1,5 +1,8 @@
+import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
-import { emitStateChange } from '@/engines/issue/events'
+import { emitIssueSettled, emitStateChange } from '@/engines/issue/events'
+import { cleanupDomainData } from '@/engines/issue/process/state'
+import { dispatch } from '@/engines/issue/state'
 import { getPidFromManaged } from '@/engines/issue/utils/pid'
 import { logger } from '@/logger'
 
@@ -54,4 +57,41 @@ export async function cancel(
     { issueId: managed.issueId, executionId, pid: getPidFromManaged(managed) },
     'issue_process_cancel_finished',
   )
+}
+
+// ---------- Force terminate ----------
+
+/**
+ * Force-terminate a process regardless of its current state.
+ * Works on running, spawning, completed, failed, or cancelled processes.
+ * Updates DB session status and moves the issue to review.
+ */
+export async function terminateProcess(
+  ctx: EngineContext,
+  issueId: string,
+): Promise<void> {
+  // Kill active processes (spawning or running)
+  const active = ctx.pm.getActiveInGroup(issueId)
+  for (const entry of active) {
+    const managed = entry.meta
+    logger.info(
+      {
+        issueId,
+        executionId: entry.id,
+        pid: getPidFromManaged(managed),
+        state: entry.state,
+      },
+      'force_terminate_active_process',
+    )
+    dispatch(managed, { type: 'CLEAR_PENDING_INPUTS' })
+    managed.state = 'cancelled'
+    emitStateChange(ctx, issueId, entry.id, 'cancelled')
+    ctx.pm.forceKill(entry.id)
+    cleanupDomainData(ctx, entry.id)
+  }
+
+  await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
+  await autoMoveToReview(issueId)
+  emitIssueSettled(ctx, issueId, '', 'cancelled')
+  logger.info({ issueId }, 'force_terminate_completed')
 }

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -42,6 +42,7 @@ export function register(
     turnSettled: false,
     metaTurn,
     slashCommands: [],
+    spawnCommand: process.spawnCommand,
     worktreePath,
     pendingInputs: [],
   }

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -1,3 +1,4 @@
+import { getAppSetting } from '@/db/helpers'
 import type { NormalizedLogEntry } from '@/engines/types'
 import type { EngineContext } from './context'
 import { getLogsFromDb } from './persistence/queries'
@@ -5,6 +6,21 @@ import { cancel } from './process/cancel'
 import { getActiveProcesses, getActiveProcessForIssue } from './process/state'
 import type { ManagedProcess } from './types'
 import { isVisibleForMode, setIssueDevMode } from './utils/visibility'
+
+const SLASH_COMMANDS_KEY = 'engine:slashCommands'
+
+/** In-memory cache for slash commands from DB, avoids async in hot path. */
+let cachedSlashCommands: string[] | null = null
+
+/** Load slash commands from DB into memory cache. Called on startup and after probe. */
+export async function refreshSlashCommandsCache(): Promise<void> {
+  const raw = await getAppSetting(SLASH_COMMANDS_KEY)
+  cachedSlashCommands = raw ? (JSON.parse(raw) as string[]) : null
+}
+
+export function getCachedSlashCommands(): string[] {
+  return cachedSlashCommands ?? []
+}
 
 // ---------- Public read-only queries ----------
 
@@ -109,7 +125,8 @@ export function getSlashCommands(
   issueId: string,
 ): string[] {
   const active = getActiveProcessForIssue(ctx, issueId)
-  return active?.slashCommands ?? []
+  if (active && active.slashCommands.length > 0) return active.slashCommands
+  return getCachedSlashCommands()
 }
 
 export async function cancelAll(ctx: EngineContext): Promise<void> {

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -15,7 +15,11 @@ let cachedSlashCommands: string[] | null = null
 /** Load slash commands from DB into memory cache. Called on startup and after probe. */
 export async function refreshSlashCommandsCache(): Promise<void> {
   const raw = await getAppSetting(SLASH_COMMANDS_KEY)
-  cachedSlashCommands = raw ? (JSON.parse(raw) as string[]) : null
+  try {
+    cachedSlashCommands = raw ? (JSON.parse(raw) as string[]) : null
+  } catch {
+    cachedSlashCommands = null
+  }
 }
 
 export function getCachedSlashCommands(): string[] {

--- a/apps/api/src/engines/issue/streams/consumer.ts
+++ b/apps/api/src/engines/issue/streams/consumer.ts
@@ -1,4 +1,5 @@
 import { setAppSetting } from '@/db/helpers'
+import { refreshSlashCommandsCache } from '@/engines/issue/queries'
 import type { ManagedProcess } from '@/engines/issue/types'
 import { normalizeStream } from '@/engines/logs'
 import type { NormalizedLogEntry } from '@/engines/types'
@@ -9,6 +10,7 @@ const SLASH_COMMANDS_KEY = 'engine:slashCommands'
 async function saveSlashCommandsToSettings(commands: string[]): Promise<void> {
   if (commands.length === 0) return
   await setAppSetting(SLASH_COMMANDS_KEY, JSON.stringify(commands))
+  await refreshSlashCommandsCache()
 }
 
 export interface StreamCallbacks {

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -29,6 +29,10 @@ export interface ManagedProcess {
    *  All log entries in this turn will be tagged with `type: 'system'` and hidden by isVisibleForMode(). */
   metaTurn: boolean
   slashCommands: string[]
+  /** The full command used to spawn this process (e.g. "claude -p --output-format=stream-json ...") */
+  spawnCommand?: string
+  /** Timestamp when the last turn completed and the process became idle */
+  lastIdleAt?: Date
   worktreePath?: string
   pendingInputs: Array<{
     prompt: string

--- a/apps/api/src/engines/types.ts
+++ b/apps/api/src/engines/types.ts
@@ -149,6 +149,8 @@ export interface SpawnedProcess {
   }
   /** Override the caller-provided externalSessionId (used by engines that generate their own session IDs, e.g. Codex thread IDs). */
   externalSessionId?: string
+  /** The full spawn command for display in the process manager */
+  spawnCommand?: string
 }
 
 // Structured tool detail (persisted in issue_logs_tools_call)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { serveStatic, websocket } from 'hono/bun'
 import app from './app'
 import { embeddedStatic } from './embedded-static'
 import { issueEngine } from './engines/issue'
+import { refreshSlashCommandsCache } from './engines/issue/queries'
 import {
   registerSettledReconciliation,
   startPeriodicReconciliation,
@@ -21,6 +22,11 @@ import {
   registerShutdownForUpgrade,
   stopPeriodicCheck,
 } from './upgrade/service'
+
+// Load cached slash commands into memory for fast lookup
+void refreshSlashCommandsCache().catch((err) => {
+  logger.error({ err }, 'slash_commands_cache_load_failed')
+})
 
 // Run startup reconciliation: mark stale sessions as failed and move
 // orphaned working issues to review.

--- a/apps/api/src/routes/issues/command.ts
+++ b/apps/api/src/routes/issues/command.ts
@@ -174,10 +174,10 @@ command.post('/:id/restart', async (c) => {
     if (!guard.ok) {
       return c.json({ success: false, error: guard.reason! }, 400)
     }
-    // Discard queued messages — restart means fresh start
+    // Collect pending messages so they are processed by the restarted session
     const { pendingIds } = await collectPendingMessages(issueId, '')
-    await markPendingMessagesDispatched(pendingIds)
     const result = await issueEngine.restartIssue(issueId)
+    await markPendingMessagesDispatched(pendingIds)
     return c.json({
       success: true,
       data: { executionId: result.executionId, issueId },

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -258,7 +258,13 @@ message.post('/:id/follow-up', async (c) => {
     }
     const { prompt: effectivePrompt, pendingIds } =
       await collectPendingMessages(issueId, fullPrompt)
-    const isCommand = prompt.startsWith('/')
+    const firstWord = prompt.split(/\s/)[0] ?? ''
+    const knownCommands = issueEngine
+      .getSlashCommands(issueId)
+      .map((cmd) => (cmd.startsWith('/') ? cmd : `/${cmd}`))
+    const isCommand =
+      firstWord.startsWith('/') &&
+      knownCommands.some((cmd) => cmd === firstWord)
     const followUpMeta: Record<string, unknown> = {
       ...attachmentsMeta,
       ...(parsed.meta

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -251,6 +251,32 @@ message.post('/:id/follow-up', async (c) => {
     return c.json({ success: true, data: { issueId, messageId, queued: true } })
   }
 
+  // When issue is in review and the session is completed/failed/cancelled,
+  // queue message as pending. It will be auto-processed on next execute/restart.
+  if (
+    issue.statusId === 'review' &&
+    issue.sessionStatus &&
+    ['completed', 'failed', 'cancelled'].includes(issue.sessionStatus) &&
+    !issueEngine.hasActiveProcessForIssue(issueId)
+  ) {
+    const messageId = await persistPendingMessage(
+      issueId,
+      prompt,
+      pendingMeta('pending'),
+    )
+    if (savedFiles.length > 0)
+      await insertAttachmentRecords(issueId, messageId, savedFiles)
+    logger.debug(
+      {
+        issueId,
+        sessionStatus: issue.sessionStatus,
+        promptChars: prompt.length,
+      },
+      'followup_queued_review_completed',
+    )
+    return c.json({ success: true, data: { issueId, messageId, queued: true } })
+  }
+
   try {
     const guard = await ensureWorking(issue)
     if (!guard.ok) {
@@ -294,6 +320,34 @@ message.post('/:id/follow-up', async (c) => {
       },
     })
   } catch (error) {
+    // When follow-up fails (e.g. process failed to start), save the current
+    // message as pending so it won't be lost. It will be auto-processed on
+    // the next execute/restart.
+    logger.warn(
+      {
+        issueId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'followup_failed_saving_as_pending',
+    )
+    try {
+      const messageId = await persistPendingMessage(
+        issueId,
+        prompt,
+        pendingMeta('pending'),
+      )
+      if (savedFiles.length > 0)
+        await insertAttachmentRecords(issueId, messageId, savedFiles)
+      return c.json({
+        success: true,
+        data: { issueId, messageId, queued: true },
+      })
+    } catch (persistError) {
+      logger.error(
+        { issueId, error: persistError },
+        'followup_failed_persist_pending_failed',
+      )
+    }
     return c.json(
       {
         success: false,

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -251,46 +251,16 @@ message.post('/:id/follow-up', async (c) => {
     return c.json({ success: true, data: { issueId, messageId, queued: true } })
   }
 
-  // When issue is in review and the session is completed/failed/cancelled,
-  // save message as pending then start a follow-up process to handle it.
-  let savedAsPending = false
-  if (
-    issue.statusId === 'review' &&
-    issue.sessionStatus &&
-    ['completed', 'failed', 'cancelled'].includes(issue.sessionStatus) &&
-    !issueEngine.hasActiveProcessForIssue(issueId)
-  ) {
-    const messageId = await persistPendingMessage(
-      issueId,
-      prompt,
-      pendingMeta('pending'),
-    )
-    if (savedFiles.length > 0)
-      await insertAttachmentRecords(issueId, messageId, savedFiles)
-    savedAsPending = true
-    logger.debug(
-      {
-        issueId,
-        sessionStatus: issue.sessionStatus,
-        promptChars: prompt.length,
-      },
-      'followup_review_pending_triggering_process',
-    )
-    // Fall through to start a process that picks up the pending message
-  }
-
   try {
     const guard = await ensureWorking(issue)
     if (!guard.ok) {
       return c.json({ success: false, error: guard.reason! }, 400)
     }
-    // When message was already saved as pending, use empty base so
-    // collectPendingMessages picks it up without duplication.
     const { prompt: effectivePrompt, pendingIds } =
-      await collectPendingMessages(issueId, savedAsPending ? '' : fullPrompt)
+      await collectPendingMessages(issueId, fullPrompt)
     const isCommand = prompt.startsWith('/')
     const followUpMeta: Record<string, unknown> = {
-      ...(savedAsPending ? {} : attachmentsMeta),
+      ...attachmentsMeta,
       ...(parsed.meta
         ? { type: 'system' }
         : isCommand
@@ -304,10 +274,8 @@ message.post('/:id/follow-up', async (c) => {
       parsed.model,
       parsed.permissionMode as 'auto' | 'supervised' | 'plan' | undefined,
       parsed.busyAction as 'queue' | 'cancel' | undefined,
-      savedAsPending
-        ? undefined
-        : (parsed.displayPrompt ??
-          (savedFiles.length > 0 ? prompt || undefined : undefined)),
+      parsed.displayPrompt ??
+        (savedFiles.length > 0 ? prompt || undefined : undefined),
       hasFollowUpMeta ? followUpMeta : undefined,
     )
     await markPendingMessagesDispatched(pendingIds)
@@ -332,18 +300,10 @@ message.post('/:id/follow-up', async (c) => {
     logger.warn(
       {
         issueId,
-        savedAsPending,
         error: error instanceof Error ? error.message : String(error),
       },
       'followup_failed_saving_as_pending',
     )
-    // If already saved as pending (review path), just return queued status
-    if (savedAsPending) {
-      return c.json({
-        success: true,
-        data: { issueId, queued: true },
-      })
-    }
     try {
       const messageId = await persistPendingMessage(
         issueId,

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -252,7 +252,8 @@ message.post('/:id/follow-up', async (c) => {
   }
 
   // When issue is in review and the session is completed/failed/cancelled,
-  // queue message as pending. It will be auto-processed on next execute/restart.
+  // save message as pending then start a follow-up process to handle it.
+  let savedAsPending = false
   if (
     issue.statusId === 'review' &&
     issue.sessionStatus &&
@@ -266,15 +267,16 @@ message.post('/:id/follow-up', async (c) => {
     )
     if (savedFiles.length > 0)
       await insertAttachmentRecords(issueId, messageId, savedFiles)
+    savedAsPending = true
     logger.debug(
       {
         issueId,
         sessionStatus: issue.sessionStatus,
         promptChars: prompt.length,
       },
-      'followup_queued_review_completed',
+      'followup_review_pending_triggering_process',
     )
-    return c.json({ success: true, data: { issueId, messageId, queued: true } })
+    // Fall through to start a process that picks up the pending message
   }
 
   try {
@@ -282,11 +284,13 @@ message.post('/:id/follow-up', async (c) => {
     if (!guard.ok) {
       return c.json({ success: false, error: guard.reason! }, 400)
     }
+    // When message was already saved as pending, use empty base so
+    // collectPendingMessages picks it up without duplication.
     const { prompt: effectivePrompt, pendingIds } =
-      await collectPendingMessages(issueId, fullPrompt)
+      await collectPendingMessages(issueId, savedAsPending ? '' : fullPrompt)
     const isCommand = prompt.startsWith('/')
     const followUpMeta: Record<string, unknown> = {
-      ...attachmentsMeta,
+      ...(savedAsPending ? {} : attachmentsMeta),
       ...(parsed.meta
         ? { type: 'system' }
         : isCommand
@@ -300,8 +304,10 @@ message.post('/:id/follow-up', async (c) => {
       parsed.model,
       parsed.permissionMode as 'auto' | 'supervised' | 'plan' | undefined,
       parsed.busyAction as 'queue' | 'cancel' | undefined,
-      parsed.displayPrompt ??
-        (savedFiles.length > 0 ? prompt || undefined : undefined),
+      savedAsPending
+        ? undefined
+        : (parsed.displayPrompt ??
+          (savedFiles.length > 0 ? prompt || undefined : undefined)),
       hasFollowUpMeta ? followUpMeta : undefined,
     )
     await markPendingMessagesDispatched(pendingIds)
@@ -326,10 +332,18 @@ message.post('/:id/follow-up', async (c) => {
     logger.warn(
       {
         issueId,
+        savedAsPending,
         error: error instanceof Error ? error.message : String(error),
       },
       'followup_failed_saving_as_pending',
     )
+    // If already saved as pending (review path), just return queued status
+    if (savedAsPending) {
+      return c.json({
+        success: true,
+        data: { issueId, queued: true },
+      })
+    }
     try {
       const messageId = await persistPendingMessage(
         issueId,

--- a/apps/api/src/routes/processes.ts
+++ b/apps/api/src/routes/processes.ts
@@ -128,10 +128,7 @@ processes.post('/:issueId/terminate', async (c) => {
     await issueEngine.terminateProcess(issueId)
     return c.json({ success: true, data: { issueId, status: 'terminated' } })
   } catch (error) {
-    logger.error(
-      { issueId, error },
-      'terminate_process_failed',
-    )
+    logger.error({ issueId, error }, 'terminate_process_failed')
     return c.json(
       {
         success: false,

--- a/apps/api/src/routes/processes.ts
+++ b/apps/api/src/routes/processes.ts
@@ -4,6 +4,7 @@ import { db } from '@/db'
 import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
+import { logger } from '@/logger'
 import { toISO } from '@/utils/date'
 
 const processes = new Hono()
@@ -29,6 +30,8 @@ processes.get('/', async (c) => {
     model: string | null
     startedAt: string | null
     turnInFlight: boolean
+    spawnCommand: string | null
+    lastIdleAt: string | null
   }> = []
 
   if (issueIds.length > 0) {
@@ -58,6 +61,8 @@ processes.get('/', async (c) => {
         model: issue.model ?? null,
         startedAt: p.startedAt.toISOString(),
         turnInFlight: p.turnInFlight,
+        spawnCommand: p.spawnCommand ?? null,
+        lastIdleAt: p.lastIdleAt?.toISOString() ?? null,
       })
     }
   }
@@ -87,10 +92,54 @@ processes.get('/', async (c) => {
       model: issue.model ?? null,
       startedAt: toISO(issue.updatedAt),
       turnInFlight: false,
+      spawnCommand: null,
+      lastIdleAt: null,
     })
   }
 
   return c.json({ success: true, data: { processes: result } })
+})
+
+// POST /api/projects/:projectId/processes/:issueId/terminate
+processes.post('/:issueId/terminate', async (c) => {
+  const projectId = c.req.param('projectId')
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404)
+  }
+
+  const issueId = c.req.param('issueId')!
+  const [issue] = await db
+    .select()
+    .from(issuesTable)
+    .where(
+      and(
+        eq(issuesTable.id, issueId),
+        eq(issuesTable.projectId, project.id),
+        eq(issuesTable.isDeleted, 0),
+      ),
+    )
+
+  if (!issue) {
+    return c.json({ success: false, error: 'Issue not found' }, 404)
+  }
+
+  try {
+    await issueEngine.terminateProcess(issueId)
+    return c.json({ success: true, data: { issueId, status: 'terminated' } })
+  } catch (error) {
+    logger.error(
+      { issueId, error },
+      'terminate_process_failed',
+    )
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Terminate failed',
+      },
+      400,
+    )
+  }
 })
 
 export default processes

--- a/apps/api/src/startup-banner.ts
+++ b/apps/api/src/startup-banner.ts
@@ -14,6 +14,7 @@ function getMode(): string {
 export function printStartupBanner(host: string, port: number) {
   const mode = getMode()
   const nodeEnv = process.env.NODE_ENV ?? 'development'
+  const logLevel = process.env.LOG_LEVEL ?? 'info'
 
   consola.box(
     [
@@ -22,6 +23,7 @@ export function printStartupBanner(host: string, port: number) {
       `  Mode:      ${mode}`,
       `  Env:       ${nodeEnv}`,
       `  Listen:    ${host}:${port}`,
+      `  Log:       ${logLevel}`,
       `  Root:      ${ROOT_DIR}`,
       `  Database:  ${dbPath}`,
       `  Runtime:   Bun ${Bun.version}`,

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -219,7 +219,11 @@ export function ChatInput({
                 size: f.size,
               }))
             : undefined
-        const isCommand = prompt.startsWith('/')
+        const firstWord = prompt.split(/\s/)[0] ?? ''
+        const isCommand =
+          firstWord.startsWith('/') &&
+          (normalizedCommands.length === 0 ||
+            normalizedCommands.some((cmd) => cmd === firstWord))
         const metadata: Record<string, unknown> | undefined = isTodo
           ? {
               type: 'pending',

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -325,7 +325,7 @@ export function ChatInput({
   )
 
   return (
-    <div className="shrink-0 w-full min-w-0 p-4 relative z-30">
+    <div className="shrink-0 w-full min-w-0 px-4 pb-2 relative z-30">
       <div
         className={`rounded-xl border bg-card/80 backdrop-blur-sm shadow-sm transition-all duration-200 focus-within:border-border focus-within:shadow-md ${
           isDragOver

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -117,7 +117,10 @@ function ProcessCard({
           </Badge>
         )}
         {idle && (
-          <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-yellow-600">
+          <Badge
+            variant="outline"
+            className="text-[10px] px-1.5 py-0 text-yellow-600"
+          >
             <Clock className="h-2.5 w-2.5 mr-0.5" />
             {t('processManager.idle')} {formatDuration(proc.lastIdleAt)}
           </Badge>

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -69,9 +69,7 @@ function formatDuration(timestamp: string | null): string {
 }
 
 function isIdle(proc: ProcessInfo): boolean {
-  return (
-    proc.sessionStatus === 'running' && !proc.turnInFlight && !!proc.lastIdleAt
-  )
+  return !proc.turnInFlight && !!proc.lastIdleAt
 }
 
 function ProcessCard({

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -1,5 +1,7 @@
 import {
   Activity,
+  ChevronDown,
+  ChevronRight,
   CircleAlert,
   CircleCheck,
   CirclePause,
@@ -7,13 +9,20 @@ import {
   Clock,
   Loader2,
   RotateCcw,
+  Skull,
   Square,
+  Terminal,
 } from 'lucide-react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { useCancelIssue, useRestartIssue } from '@/hooks/use-kanban'
+import {
+  useCancelIssue,
+  useRestartIssue,
+  useTerminateProcess,
+} from '@/hooks/use-kanban'
 import type { ProcessInfo, SessionStatus } from '@/types/kanban'
 
 function StatusIcon({ status }: { status: SessionStatus | null }) {
@@ -48,15 +57,166 @@ function statusVariant(
   }
 }
 
-function formatDuration(startedAt: string | null): string {
-  if (!startedAt) return ''
-  const diff = Date.now() - new Date(startedAt).getTime()
+function formatDuration(timestamp: string | null): string {
+  if (!timestamp) return ''
+  const diff = Date.now() - new Date(timestamp).getTime()
   const seconds = Math.floor(diff / 1000)
   if (seconds < 60) return `${seconds}s`
   const minutes = Math.floor(seconds / 60)
   if (minutes < 60) return `${minutes}m ${seconds % 60}s`
   const hours = Math.floor(minutes / 60)
   return `${hours}h ${minutes % 60}m`
+}
+
+function isIdle(proc: ProcessInfo): boolean {
+  return (
+    proc.sessionStatus === 'running' && !proc.turnInFlight && !!proc.lastIdleAt
+  )
+}
+
+function ProcessCard({
+  proc,
+  projectId,
+}: {
+  proc: ProcessInfo
+  projectId: string
+}) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const cancelMutation = useCancelIssue(projectId)
+  const restartMutation = useRestartIssue(projectId)
+  const terminateMutation = useTerminateProcess(projectId)
+  const [showCommand, setShowCommand] = useState(false)
+  const idle = isIdle(proc)
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-3 space-y-2">
+      {/* Title row */}
+      <div className="flex items-center gap-2 min-w-0">
+        <StatusIcon status={proc.sessionStatus} />
+        <button
+          type="button"
+          className="text-xs font-medium text-foreground truncate hover:underline cursor-pointer text-left min-w-0"
+          onClick={() =>
+            navigate(`/projects/${projectId}/issues/${proc.issueId}`)
+          }
+        >
+          <span className="text-muted-foreground">#{proc.issueNumber}</span>{' '}
+          {proc.issueTitle}
+        </button>
+      </div>
+
+      {/* Meta row */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {proc.sessionStatus && (
+          <Badge
+            variant={statusVariant(proc.sessionStatus)}
+            className="text-[10px] px-1.5 py-0"
+          >
+            {t(`session.status.${proc.sessionStatus}`)}
+          </Badge>
+        )}
+        {idle && (
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-yellow-600">
+            <Clock className="h-2.5 w-2.5 mr-0.5" />
+            {t('processManager.idle')} {formatDuration(proc.lastIdleAt)}
+          </Badge>
+        )}
+        {proc.engineType && (
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+            {proc.engineType}
+          </Badge>
+        )}
+        {proc.model && (
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+            {proc.model}
+          </Badge>
+        )}
+        {proc.turnInFlight && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+            <Activity className="h-2.5 w-2.5 mr-0.5" />
+            {t('processManager.turnInFlight')}
+          </Badge>
+        )}
+        {proc.startedAt && (
+          <span className="text-[10px] text-muted-foreground ml-auto tabular-nums">
+            {formatDuration(proc.startedAt)}
+          </span>
+        )}
+      </div>
+
+      {/* Spawn command (collapsible) */}
+      {proc.spawnCommand && (
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground cursor-pointer"
+            onClick={() => setShowCommand((v) => !v)}
+          >
+            {showCommand ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+            <Terminal className="h-3 w-3" />
+            {t('processManager.command')}
+          </button>
+          {showCommand && (
+            <pre className="mt-1 text-[10px] text-muted-foreground bg-muted rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-all">
+              {proc.spawnCommand}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-1.5 pt-1">
+        {(proc.sessionStatus === 'running' ||
+          proc.sessionStatus === 'pending') && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 text-[10px] gap-1"
+            disabled={cancelMutation.isPending}
+            onClick={() => cancelMutation.mutate(proc.issueId)}
+          >
+            <Square className="h-3 w-3" />
+            {cancelMutation.isPending
+              ? t('processManager.cancelling')
+              : t('processManager.cancel')}
+          </Button>
+        )}
+        {(proc.sessionStatus === 'failed' ||
+          proc.sessionStatus === 'cancelled') && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 text-[10px] gap-1"
+            disabled={restartMutation.isPending}
+            onClick={() => restartMutation.mutate(proc.issueId)}
+          >
+            <RotateCcw className="h-3 w-3" />
+            {restartMutation.isPending
+              ? t('processManager.restarting')
+              : t('processManager.restart')}
+          </Button>
+        )}
+        {/* Terminate — always available, force-kills process regardless of state */}
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 text-[10px] gap-1 text-destructive hover:text-destructive"
+          disabled={terminateMutation.isPending}
+          onClick={() => terminateMutation.mutate(proc.issueId)}
+        >
+          <Skull className="h-3 w-3" />
+          {terminateMutation.isPending
+            ? t('processManager.terminating')
+            : t('processManager.terminate')}
+        </Button>
+      </div>
+    </div>
+  )
 }
 
 export function ProcessList({
@@ -66,105 +226,10 @@ export function ProcessList({
   processes: ProcessInfo[]
   projectId: string
 }) {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const cancelMutation = useCancelIssue(projectId)
-  const restartMutation = useRestartIssue(projectId)
-
   return (
     <div className="flex flex-col gap-2">
       {processes.map((proc) => (
-        <div
-          key={proc.issueId}
-          className="rounded-lg border border-border bg-card p-3 space-y-2"
-        >
-          {/* Title row */}
-          <div className="flex items-center gap-2 min-w-0">
-            <StatusIcon status={proc.sessionStatus} />
-            <button
-              type="button"
-              className="text-xs font-medium text-foreground truncate hover:underline cursor-pointer text-left min-w-0"
-              onClick={() =>
-                navigate(`/projects/${projectId}/issues/${proc.issueId}`)
-              }
-            >
-              <span className="text-muted-foreground">#{proc.issueNumber}</span>{' '}
-              {proc.issueTitle}
-            </button>
-          </div>
-
-          {/* Meta row */}
-          <div className="flex flex-wrap items-center gap-1.5">
-            {proc.sessionStatus && (
-              <Badge
-                variant={statusVariant(proc.sessionStatus)}
-                className="text-[10px] px-1.5 py-0"
-              >
-                {t(`session.status.${proc.sessionStatus}`)}
-              </Badge>
-            )}
-            {proc.engineType && (
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                {proc.engineType}
-              </Badge>
-            )}
-            {proc.model && (
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                {proc.model}
-              </Badge>
-            )}
-            {proc.turnInFlight && (
-              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                <Activity className="h-2.5 w-2.5 mr-0.5" />
-                {t('processManager.turnInFlight')}
-              </Badge>
-            )}
-            {proc.startedAt && (
-              <span className="text-[10px] text-muted-foreground ml-auto tabular-nums">
-                {formatDuration(proc.startedAt)}
-              </span>
-            )}
-          </div>
-
-          {/* Actions — cancel for running/pending, restart for failed/cancelled */}
-          {(proc.sessionStatus === 'running' ||
-            proc.sessionStatus === 'pending' ||
-            proc.sessionStatus === 'failed' ||
-            proc.sessionStatus === 'cancelled') && (
-            <div className="flex items-center gap-1.5 pt-1">
-              {(proc.sessionStatus === 'running' ||
-                proc.sessionStatus === 'pending') && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-6 text-[10px] gap-1"
-                  disabled={cancelMutation.isPending}
-                  onClick={() => cancelMutation.mutate(proc.issueId)}
-                >
-                  <Square className="h-3 w-3" />
-                  {cancelMutation.isPending
-                    ? t('processManager.cancelling')
-                    : t('processManager.cancel')}
-                </Button>
-              )}
-              {(proc.sessionStatus === 'failed' ||
-                proc.sessionStatus === 'cancelled') && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-6 text-[10px] gap-1"
-                  disabled={restartMutation.isPending}
-                  onClick={() => restartMutation.mutate(proc.issueId)}
-                >
-                  <RotateCcw className="h-3 w-3" />
-                  {restartMutation.isPending
-                    ? t('processManager.restarting')
-                    : t('processManager.restart')}
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
+        <ProcessCard key={proc.issueId} proc={proc} projectId={projectId} />
       ))}
     </div>
   )

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -557,3 +557,16 @@ export function useProjectProcesses(projectId: string, enabled = true) {
     refetchInterval: 5000,
   })
 }
+
+export function useTerminateProcess(projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (issueId: string) =>
+      kanbanApi.terminateProcess(projectId, issueId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.projectProcesses(projectId),
+      })
+    },
+  })
+}

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -330,6 +330,9 @@
     "cancelling": "Cancelling...",
     "restart": "Restart",
     "restarting": "Restarting...",
+    "terminate": "Terminate",
+    "terminating": "Terminating...",
+    "command": "Command",
     "turnInFlight": "Processing",
     "idle": "Idle",
     "stale": "Stale"

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -330,6 +330,9 @@
     "cancelling": "取消中...",
     "restart": "重启",
     "restarting": "重启中...",
+    "terminate": "强制终止",
+    "terminating": "终止中...",
+    "command": "启动命令",
     "turnInFlight": "处理中",
     "idle": "空闲",
     "stale": "异常"

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -330,6 +330,12 @@ export const kanbanApi = {
   getProjectProcesses: (projectId: string) =>
     get<ProjectProcessesResponse>(`/api/projects/${projectId}/processes`),
 
+  terminateProcess: (projectId: string, issueId: string) =>
+    post<{ issueId: string; status: string }>(
+      `/api/projects/${projectId}/processes/${issueId}/terminate`,
+      {},
+    ),
+
   rawFileUrl: (projectId: string, path: string) => {
     const encodedPath = path.split('/').map(encodeURIComponent).join('/')
     return `/api/projects/${projectId}/files/raw/${encodedPath}`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -230,6 +230,8 @@ export interface ProcessInfo {
   model: string | null
   startedAt: string | null
   turnInFlight: boolean
+  spawnCommand: string | null
+  lastIdleAt: string | null
 }
 
 export interface ProjectProcessesResponse {


### PR DESCRIPTION
## Summary

- **Force-terminate endpoint**: New `POST /api/processes/:issueId/terminate` to kill stuck processes regardless of state (running, idle, completed). Frontend shows a red "Terminate" button on every process card.
- **Spawn command display**: Capture the full CLI command used to spawn each process (Claude Code, Codex). Shown as a collapsible section in the process manager UI.
- **Idle timeout (30 min)**: Track `lastIdleAt` on turn completion. GC sweep auto-terminates processes idle >30 minutes. Idle badge with duration shown in the UI.
- **Pending messages on review**: When an issue is in `review` status with a completed/failed/cancelled session, new messages are queued as pending instead of failing.
- **Pending messages on failure**: If a follow-up spawn fails, the message is saved as pending so it won't be lost.
- **Auto-process pending on restart**: Pending messages are collected and merged into the restart prompt automatically.

## Files changed (20)

**Backend**: `cancel.ts` (terminate), `gc.ts` (idle sweep), `turn-completion.ts` (lastIdleAt), `restart.ts` (pending merge), `message.ts` (pending queue), `processes.ts` (terminate route), `types.ts` (spawnCommand/lastIdleAt fields), executors (command capture)

**Frontend**: `ProcessList.tsx` (terminate button, command display, idle badge), `use-kanban.ts` (useTerminateProcess hook), `kanban-api.ts` (terminateProcess), i18n files

**Shared**: `index.ts` (ProcessInfo type updates)

## Test plan

- [ ] Start a process, verify spawn command appears in process manager (click to expand)
- [ ] Cancel a running process via Cancel button — verify it stops
- [ ] Use Terminate button on a running/completed/stuck process — verify force-kill works
- [ ] Wait for process to become idle — verify "Idle Xm" badge appears
- [ ] Send a message to an issue in review status with completed session — verify it's queued as pending
- [ ] Restart a failed issue that has pending messages — verify they're included in the prompt
- [ ] Verify idle timeout: after 30 min idle, process is auto-terminated (can test by lowering IDLE_TIMEOUT_MS)