### PR TITLE
feat: worktree system rework

### DIFF
--- a/apps/api/src/db/helpers.ts
+++ b/apps/api/src/db/helpers.ts
@@ -209,3 +209,13 @@ export async function ensureDefaultFilterRules(): Promise<void> {
     )
   }
 }
+
+// --- Worktree auto-cleanup default seeding ---
+
+export async function ensureWorktreeAutoCleanupDefault(): Promise<void> {
+  const { WORKTREE_AUTO_CLEANUP_KEY } = await import('../jobs/worktree-cleanup')
+  const existing = await getAppSetting(WORKTREE_AUTO_CLEANUP_KEY)
+  if (existing === null) {
+    await setAppSetting(WORKTREE_AUTO_CLEANUP_KEY, 'true')
+  }
+}

--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -5,4 +5,4 @@ export const GC_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
 export const MAX_CONCURRENT_EXECUTIONS =
   Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
 export const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
-export const WORKTREE_DIR = '.bitk/worktrees'
+export const WORKTREE_DIR = 'data/worktrees'

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -9,7 +9,6 @@ import type { EngineContext } from './context'
 import { emitIssueSettled, emitStateChange } from './events'
 import { withIssueLock } from './process/lock'
 import { cleanupDomainData } from './process/state'
-import { cleanupWorktree } from './utils/worktree'
 
 // ---------- Domain GC sweep ----------
 
@@ -51,14 +50,8 @@ export function gcSweep(ctx: EngineContext): void {
         },
         'idle_timeout_terminate',
       )
-      const { worktreeBaseDir, worktreePath } = managed
-      managed.worktreeBaseDir = undefined
-      managed.worktreePath = undefined // prevent double-cleanup
       ctx.pm.forceKill(entry.id)
       cleanupDomainData(ctx, managed.executionId)
-      if (worktreeBaseDir && worktreePath) {
-        cleanupWorktree(worktreeBaseDir, managed.issueId, worktreePath)
-      }
       // Fire-and-forget DB update — use issue lock to prevent racing with follow-up
       const { issueId: gcIssueId, executionId: gcExecutionId } = managed
       void withIssueLock(ctx, gcIssueId, async () => {

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -9,6 +9,7 @@ import type { EngineContext } from './context'
 import { emitIssueSettled, emitStateChange } from './events'
 import { withIssueLock } from './process/lock'
 import { cleanupDomainData } from './process/state'
+import { cleanupWorktree } from './utils/worktree'
 
 // ---------- Domain GC sweep ----------
 
@@ -50,8 +51,14 @@ export function gcSweep(ctx: EngineContext): void {
         },
         'idle_timeout_terminate',
       )
+      const { worktreeBaseDir, worktreePath } = managed
+      managed.worktreeBaseDir = undefined
+      managed.worktreePath = undefined // prevent double-cleanup
       ctx.pm.forceKill(entry.id)
       cleanupDomainData(ctx, managed.executionId)
+      if (worktreeBaseDir && worktreePath) {
+        cleanupWorktree(worktreeBaseDir, managed.issueId, worktreePath)
+      }
       // Fire-and-forget DB update — use issue lock to prevent racing with follow-up
       const { issueId: gcIssueId, executionId: gcExecutionId } = managed
       void withIssueLock(ctx, gcIssueId, async () => {

--- a/apps/api/src/engines/issue/index.ts
+++ b/apps/api/src/engines/issue/index.ts
@@ -1,3 +1,7 @@
 export { IssueEngine, issueEngine } from './engine'
 export { setIssueDevMode } from './utils/visibility'
-export { removeWorktree } from './utils/worktree'
+export {
+  cleanupWorktree,
+  removeWorktree,
+  resolveWorktreePath,
+} from './utils/worktree'

--- a/apps/api/src/engines/issue/index.ts
+++ b/apps/api/src/engines/issue/index.ts
@@ -1,7 +1,2 @@
 export { IssueEngine, issueEngine } from './engine'
 export { setIssueDevMode } from './utils/visibility'
-export {
-  cleanupWorktree,
-  removeWorktree,
-  resolveWorktreePath,
-} from './utils/worktree'

--- a/apps/api/src/engines/issue/lifecycle/settle.ts
+++ b/apps/api/src/engines/issue/lifecycle/settle.ts
@@ -6,9 +6,8 @@ import { cleanupDomainData } from '@/engines/issue/process/state'
 /** Common settle flow: persist status, auto-move, clean domain data, emit event.
  *
  * NOTE: Worktree cleanup is NOT done here. Worktrees are preserved across
- * completed/failed settlements so follow-ups can reuse them. Cleanup only
- * happens on terminal lifecycle transitions (done/cancel) via update.ts
- * and cancel.ts respectively.
+ * completed/failed settlements so follow-ups can reuse them. Cleanup is
+ * handled by the periodic background job in jobs/worktree-cleanup.ts.
  */
 export async function settleIssue(
   ctx: EngineContext,

--- a/apps/api/src/engines/issue/lifecycle/settle.ts
+++ b/apps/api/src/engines/issue/lifecycle/settle.ts
@@ -2,6 +2,7 @@ import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled } from '@/engines/issue/events'
 import { cleanupDomainData } from '@/engines/issue/process/state'
+import { cleanupWorktree } from '@/engines/issue/utils/worktree'
 
 /** Common settle flow: persist status, auto-move, clean domain data, emit event. */
 export async function settleIssue(
@@ -10,8 +11,20 @@ export async function settleIssue(
   executionId: string,
   status: string,
 ): Promise<void> {
+  // Grab worktree info before domain data cleanup removes the entry,
+  // then clear it to prevent double-cleanup from other exit paths.
+  const managed = ctx.pm.get(executionId)?.meta
+  const worktreeBaseDir = managed?.worktreeBaseDir
+  const worktreePath = managed?.worktreePath
+  if (managed) {
+    managed.worktreeBaseDir = undefined
+    managed.worktreePath = undefined
+  }
   await updateIssueSession(issueId, { sessionStatus: status })
   await autoMoveToReview(issueId)
   cleanupDomainData(ctx, executionId)
   emitIssueSettled(ctx, issueId, executionId, status)
+  if (worktreeBaseDir && worktreePath) {
+    cleanupWorktree(worktreeBaseDir, issueId, worktreePath)
+  }
 }

--- a/apps/api/src/engines/issue/lifecycle/settle.ts
+++ b/apps/api/src/engines/issue/lifecycle/settle.ts
@@ -2,29 +2,22 @@ import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled } from '@/engines/issue/events'
 import { cleanupDomainData } from '@/engines/issue/process/state'
-import { cleanupWorktree } from '@/engines/issue/utils/worktree'
 
-/** Common settle flow: persist status, auto-move, clean domain data, emit event. */
+/** Common settle flow: persist status, auto-move, clean domain data, emit event.
+ *
+ * NOTE: Worktree cleanup is NOT done here. Worktrees are preserved across
+ * completed/failed settlements so follow-ups can reuse them. Cleanup only
+ * happens on terminal lifecycle transitions (done/cancel) via update.ts
+ * and cancel.ts respectively.
+ */
 export async function settleIssue(
   ctx: EngineContext,
   issueId: string,
   executionId: string,
   status: string,
 ): Promise<void> {
-  // Grab worktree info before domain data cleanup removes the entry,
-  // then clear it to prevent double-cleanup from other exit paths.
-  const managed = ctx.pm.get(executionId)?.meta
-  const worktreeBaseDir = managed?.worktreeBaseDir
-  const worktreePath = managed?.worktreePath
-  if (managed) {
-    managed.worktreeBaseDir = undefined
-    managed.worktreePath = undefined
-  }
   await updateIssueSession(issueId, { sessionStatus: status })
   await autoMoveToReview(issueId)
   cleanupDomainData(ctx, executionId)
   emitIssueSettled(ctx, issueId, executionId, status)
-  if (worktreeBaseDir && worktreePath) {
-    cleanupWorktree(worktreeBaseDir, issueId, worktreePath)
-  }
 }

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -1,8 +1,6 @@
 import { stat } from 'node:fs/promises'
-import { join } from 'node:path'
 import { getIssueWithSession, updateIssueSession } from '@/engines/engine-store'
 import { engineRegistry } from '@/engines/executors'
-import { WORKTREE_DIR } from '@/engines/issue/constants'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitStateChange } from '@/engines/issue/events'
 import { getNextTurnIndex } from '@/engines/issue/persistence/queries'
@@ -20,7 +18,10 @@ import {
 import { createLogNormalizer } from '@/engines/issue/utils/normalizer'
 import { getPidFromSubprocess } from '@/engines/issue/utils/pid'
 import { setIssueDevMode } from '@/engines/issue/utils/visibility'
-import { createWorktree } from '@/engines/issue/utils/worktree'
+import {
+  createWorktree,
+  resolveWorktreePath,
+} from '@/engines/issue/utils/worktree'
 import type {
   EngineType,
   PermissionPolicy,
@@ -239,7 +240,7 @@ export async function spawnFollowUpProcess(
   let workingDir = baseDir
   let worktreePath: string | undefined
   if (issue.useWorktree) {
-    const candidatePath = join(baseDir, WORKTREE_DIR, issueId)
+    const candidatePath = resolveWorktreePath(issue.projectId, issueId)
     try {
       const s = await stat(candidatePath)
       if (s.isDirectory()) {
@@ -249,7 +250,7 @@ export async function spawnFollowUpProcess(
     } catch {
       // Worktree dir doesn't exist — create fresh
       try {
-        worktreePath = await createWorktree(baseDir, issueId)
+        worktreePath = await createWorktree(baseDir, issue.projectId, issueId)
         workingDir = worktreePath
       } catch (wtErr) {
         logger.warn(
@@ -301,6 +302,7 @@ export async function spawnFollowUpProcess(
     worktreePath,
     metadata?.type === 'system',
     () => handleTurnCompleted(ctx, issueId, executionId),
+    worktreePath ? baseDir : undefined,
   )
   // User message already persisted above (before spawn)
   monitorCompletion(ctx, executionId, issueId, engineType, false)

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -141,7 +141,24 @@ export async function spawnRetry(
   const executor = engineRegistry.get(engineType)
   if (!executor) throw new Error(`No executor for engine type: ${engineType}`)
 
-  const workingDir = await resolveWorkingDir(issue.projectId)
+  const baseDir = await resolveWorkingDir(issue.projectId)
+
+  // Resolve worktree if the issue uses one
+  let workingDir = baseDir
+  let worktreePath: string | undefined
+  if (issue.useWorktree) {
+    const candidatePath = resolveWorktreePath(issue.projectId, issueId)
+    try {
+      const s = await stat(candidatePath)
+      if (s.isDirectory()) {
+        worktreePath = candidatePath
+        workingDir = candidatePath
+      }
+    } catch {
+      // Worktree doesn't exist — retry in base dir
+    }
+  }
+
   const permOptions = getPermissionOptions(engineType)
   const executionId = crypto.randomUUID()
 
@@ -169,9 +186,10 @@ export async function spawnRetry(
     spawned,
     (line) => normalizer.parse(line),
     turnIndex,
-    undefined,
+    worktreePath,
     false,
     () => handleTurnCompleted(ctx, issueId, executionId),
+    worktreePath ? baseDir : undefined,
   )
   monitorCompletion(ctx, executionId, issueId, engineType, true)
   logger.debug(

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -20,6 +20,7 @@ import { getPidFromSubprocess } from '@/engines/issue/utils/pid'
 import { setIssueDevMode } from '@/engines/issue/utils/visibility'
 import {
   createWorktree,
+  isWorktreeRegistered,
   resolveWorktreePath,
 } from '@/engines/issue/utils/worktree'
 import type {
@@ -151,11 +152,19 @@ export async function spawnRetry(
     try {
       const s = await stat(candidatePath)
       if (s.isDirectory()) {
-        worktreePath = candidatePath
-        workingDir = candidatePath
+        // Verify the worktree belongs to the current project repo
+        if (await isWorktreeRegistered(baseDir, candidatePath)) {
+          worktreePath = candidatePath
+          workingDir = candidatePath
+        } else {
+          logger.warn(
+            { issueId, candidatePath, baseDir },
+            'worktree_not_registered_follow_up_fallback',
+          )
+        }
       }
     } catch {
-      // Worktree doesn't exist — retry in base dir
+      // Worktree doesn't exist — follow-up in base dir
     }
   }
 
@@ -262,8 +271,19 @@ export async function spawnFollowUpProcess(
     try {
       const s = await stat(candidatePath)
       if (s.isDirectory()) {
-        worktreePath = candidatePath
-        workingDir = candidatePath
+        // Verify the worktree is registered under the current project repo;
+        // if the project directory was changed, the old worktree is stale.
+        if (await isWorktreeRegistered(baseDir, candidatePath)) {
+          worktreePath = candidatePath
+          workingDir = candidatePath
+        } else {
+          logger.warn(
+            { issueId, candidatePath, baseDir },
+            'worktree_not_registered_recreating',
+          )
+          worktreePath = await createWorktree(baseDir, issue.projectId, issueId)
+          workingDir = worktreePath
+        }
       }
     } catch {
       // Worktree dir doesn't exist — create fresh

--- a/apps/api/src/engines/issue/orchestration/execute.ts
+++ b/apps/api/src/engines/issue/orchestration/execute.ts
@@ -66,7 +66,7 @@ export async function executeIssue(
 
     if (issue.useWorktree) {
       try {
-        worktreePath = await createWorktree(baseDir, issueId)
+        worktreePath = await createWorktree(baseDir, issue.projectId, issueId)
         workingDir = worktreePath
       } catch (error) {
         logger.warn(
@@ -129,6 +129,7 @@ export async function executeIssue(
       worktreePath,
       false,
       () => handleTurnCompleted(ctx, issueId, executionId),
+      worktreePath ? baseDir : undefined,
     )
     const messageId = persistUserMessage(ctx, issueId, executionId, opts.prompt)
     monitorCompletion(ctx, executionId, issueId, opts.engineType, false)

--- a/apps/api/src/engines/issue/orchestration/restart.ts
+++ b/apps/api/src/engines/issue/orchestration/restart.ts
@@ -56,7 +56,7 @@ export async function restartIssue(
     // Create git worktree if enabled for this issue
     if (issue.useWorktree) {
       try {
-        worktreePath = await createWorktree(baseDir, issueId)
+        worktreePath = await createWorktree(baseDir, issue.projectId, issueId)
         workingDir = worktreePath
       } catch (error) {
         logger.warn(
@@ -107,6 +107,7 @@ export async function restartIssue(
       worktreePath,
       false,
       () => handleTurnCompleted(ctx, issueId, executionId),
+      worktreePath ? baseDir : undefined,
     )
     monitorCompletion(ctx, executionId, issueId, engineType, false)
 

--- a/apps/api/src/engines/issue/process/cancel.ts
+++ b/apps/api/src/engines/issue/process/cancel.ts
@@ -5,6 +5,7 @@ import { withIssueLock } from '@/engines/issue/process/lock'
 import { cleanupDomainData } from '@/engines/issue/process/state'
 import { dispatch } from '@/engines/issue/state'
 import { getPidFromManaged } from '@/engines/issue/utils/pid'
+import { cleanupWorktree } from '@/engines/issue/utils/worktree'
 import { logger } from '@/logger'
 
 // ---------- Cancel ----------
@@ -75,6 +76,7 @@ export async function terminateProcess(
     // Kill active processes (spawning or running)
     const active = ctx.pm.getActiveInGroup(issueId)
     let lastExecutionId = ''
+    const worktreeEntries: Array<{ baseDir: string; path: string }> = []
     for (const entry of active) {
       const managed = entry.meta
       logger.info(
@@ -86,6 +88,14 @@ export async function terminateProcess(
         },
         'force_terminate_active_process',
       )
+      if (managed.worktreeBaseDir && managed.worktreePath) {
+        worktreeEntries.push({
+          baseDir: managed.worktreeBaseDir,
+          path: managed.worktreePath,
+        })
+        managed.worktreeBaseDir = undefined
+        managed.worktreePath = undefined // prevent double-cleanup
+      }
       dispatch(managed, { type: 'CLEAR_PENDING_INPUTS' })
       managed.state = 'cancelled'
       emitStateChange(ctx, issueId, entry.id, 'cancelled')
@@ -97,6 +107,9 @@ export async function terminateProcess(
     await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
     await autoMoveToReview(issueId)
     emitIssueSettled(ctx, issueId, lastExecutionId, 'cancelled')
+    for (const wt of worktreeEntries) {
+      cleanupWorktree(wt.baseDir, issueId, wt.path)
+    }
     logger.info({ issueId }, 'force_terminate_completed')
   })
 }

--- a/apps/api/src/engines/issue/process/cancel.ts
+++ b/apps/api/src/engines/issue/process/cancel.ts
@@ -5,7 +5,6 @@ import { withIssueLock } from '@/engines/issue/process/lock'
 import { cleanupDomainData } from '@/engines/issue/process/state'
 import { dispatch } from '@/engines/issue/state'
 import { getPidFromManaged } from '@/engines/issue/utils/pid'
-import { cleanupWorktree } from '@/engines/issue/utils/worktree'
 import { logger } from '@/logger'
 
 // ---------- Cancel ----------
@@ -76,7 +75,6 @@ export async function terminateProcess(
     // Kill active processes (spawning or running)
     const active = ctx.pm.getActiveInGroup(issueId)
     let lastExecutionId = ''
-    const worktreeEntries: Array<{ baseDir: string; path: string }> = []
     for (const entry of active) {
       const managed = entry.meta
       logger.info(
@@ -88,14 +86,6 @@ export async function terminateProcess(
         },
         'force_terminate_active_process',
       )
-      if (managed.worktreeBaseDir && managed.worktreePath) {
-        worktreeEntries.push({
-          baseDir: managed.worktreeBaseDir,
-          path: managed.worktreePath,
-        })
-        managed.worktreeBaseDir = undefined
-        managed.worktreePath = undefined // prevent double-cleanup
-      }
       dispatch(managed, { type: 'CLEAR_PENDING_INPUTS' })
       managed.state = 'cancelled'
       emitStateChange(ctx, issueId, entry.id, 'cancelled')
@@ -107,9 +97,6 @@ export async function terminateProcess(
     await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
     await autoMoveToReview(issueId)
     emitIssueSettled(ctx, issueId, lastExecutionId, 'cancelled')
-    for (const wt of worktreeEntries) {
-      cleanupWorktree(wt.baseDir, issueId, wt.path)
-    }
     logger.info({ issueId }, 'force_terminate_completed')
   })
 }

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -26,6 +26,7 @@ export function register(
   worktreePath: string | undefined,
   metaTurn: boolean,
   onTurnCompleted: () => void,
+  worktreeBaseDir?: string,
 ): ManagedProcess {
   const managed: ManagedProcess = {
     executionId,
@@ -43,6 +44,7 @@ export function register(
     metaTurn,
     slashCommands: [],
     spawnCommand: process.spawnCommand,
+    worktreeBaseDir,
     worktreePath,
     pendingInputs: [],
   }

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -33,6 +33,8 @@ export interface ManagedProcess {
   spawnCommand?: string
   /** Timestamp when the last turn completed and the process became idle */
   lastIdleAt?: Date
+  /** Git repo directory that owns this worktree (needed for `git worktree remove`) */
+  worktreeBaseDir?: string
   worktreePath?: string
   pendingInputs: Array<{
     prompt: string

--- a/apps/api/src/engines/issue/utils/index.ts
+++ b/apps/api/src/engines/issue/utils/index.ts
@@ -12,7 +12,6 @@ export {
   setIssueDevMode,
 } from './visibility'
 export {
-  cleanupWorktree,
   createWorktree,
   removeWorktree,
   resolveWorktreePath,

--- a/apps/api/src/engines/issue/utils/index.ts
+++ b/apps/api/src/engines/issue/utils/index.ts
@@ -11,4 +11,9 @@ export {
   isVisibleForMode,
   setIssueDevMode,
 } from './visibility'
-export { createWorktree, removeWorktree } from './worktree'
+export {
+  cleanupWorktree,
+  createWorktree,
+  removeWorktree,
+  resolveWorktreePath,
+} from './worktree'

--- a/apps/api/src/engines/issue/utils/worktree.ts
+++ b/apps/api/src/engines/issue/utils/worktree.ts
@@ -1,8 +1,11 @@
 import { mkdir, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { WORKTREE_DIR } from '@/engines/issue/constants'
 import { logger } from '@/logger'
 import { ROOT_DIR } from '@/root'
+
+/** Safe root for rm fallback — never delete outside this directory */
+const WORKTREE_SAFE_ROOT = join(ROOT_DIR, WORKTREE_DIR)
 
 // ---------- Git worktree helpers ----------
 
@@ -62,28 +65,66 @@ export async function removeWorktree(
   baseDir: string,
   worktreeDir: string,
 ): Promise<void> {
+  const resolved = resolve(worktreeDir)
   try {
-    const proc = Bun.spawn(
-      ['git', 'worktree', 'remove', '--force', worktreeDir],
-      {
-        cwd: baseDir,
-        stdout: 'pipe',
-        stderr: 'pipe',
-      },
-    )
+    const proc = Bun.spawn(['git', 'worktree', 'remove', '--force', resolved], {
+      cwd: baseDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
     const code = await proc.exited
     if (code !== 0) {
       throw new Error(`git worktree remove exited with code ${code}`)
     }
-    logger.debug({ worktreeDir }, 'worktree_removed')
+    logger.debug({ worktreeDir: resolved }, 'worktree_removed')
   } catch (error) {
-    logger.warn({ worktreeDir, error }, 'worktree_remove_failed')
+    logger.warn({ worktreeDir: resolved, error }, 'worktree_remove_failed')
+    // Containment guard: never rm outside the managed worktree directory
+    if (!resolved.startsWith(WORKTREE_SAFE_ROOT + sep)) {
+      logger.error(
+        { worktreeDir: resolved, safeRoot: WORKTREE_SAFE_ROOT },
+        'worktree_remove_path_escape_rejected',
+      )
+      return
+    }
     // Fallback: just delete the directory
     try {
-      await rm(worktreeDir, { recursive: true, force: true })
+      await rm(resolved, { recursive: true, force: true })
     } catch {
       /* best effort */
     }
+  }
+}
+
+/**
+ * Verify that a worktree directory is registered under the given git repo.
+ * Returns `true` if `git worktree list` from `baseDir` includes `worktreeDir`.
+ */
+export async function isWorktreeRegistered(
+  baseDir: string,
+  worktreeDir: string,
+): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(['git', 'worktree', 'list', '--porcelain'], {
+      cwd: baseDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    // Read stdout concurrently with waiting for exit to avoid pipe buffer deadlock
+    const [output] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ])
+    if (proc.exitCode !== 0) return false
+    // Each worktree block starts with "worktree <absolute-path>"
+    for (const line of output.split('\n')) {
+      if (line.startsWith('worktree ') && line.slice(9) === worktreeDir) {
+        return true
+      }
+    }
+    return false
+  } catch {
+    return false
   }
 }
 

--- a/apps/api/src/engines/issue/utils/worktree.ts
+++ b/apps/api/src/engines/issue/utils/worktree.ts
@@ -2,16 +2,28 @@ import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { WORKTREE_DIR } from '@/engines/issue/constants'
 import { logger } from '@/logger'
+import { ROOT_DIR } from '@/root'
 
 // ---------- Git worktree helpers ----------
 
+/**
+ * Deterministic worktree path: `<ROOT_DIR>/data/worktrees/<projectId>/<issueId>/`
+ */
+export function resolveWorktreePath(
+  projectId: string,
+  issueId: string,
+): string {
+  return join(ROOT_DIR, WORKTREE_DIR, projectId, issueId)
+}
+
 export async function createWorktree(
   baseDir: string,
+  projectId: string,
   issueId: string,
 ): Promise<string> {
   const branchName = `bitk/${issueId}`
-  const worktreeDir = join(baseDir, WORKTREE_DIR, issueId)
-  await mkdir(join(baseDir, WORKTREE_DIR), { recursive: true })
+  const worktreeDir = resolveWorktreePath(projectId, issueId)
+  await mkdir(join(ROOT_DIR, WORKTREE_DIR, projectId), { recursive: true })
 
   // Create worktree with a new branch off HEAD
   const proc = Bun.spawn(
@@ -59,7 +71,10 @@ export async function removeWorktree(
         stderr: 'pipe',
       },
     )
-    await proc.exited
+    const code = await proc.exited
+    if (code !== 0) {
+      throw new Error(`git worktree remove exited with code ${code}`)
+    }
     logger.debug({ worktreeDir }, 'worktree_removed')
   } catch (error) {
     logger.warn({ worktreeDir, error }, 'worktree_remove_failed')
@@ -70,4 +85,18 @@ export async function removeWorktree(
       /* best effort */
     }
   }
+}
+
+/**
+ * Fire-and-forget worktree cleanup.
+ * @param baseDir - The git repo directory that owns this worktree
+ */
+export function cleanupWorktree(
+  baseDir: string,
+  issueId: string,
+  worktreePath: string,
+): void {
+  void removeWorktree(baseDir, worktreePath).catch((error) => {
+    logger.warn({ issueId, worktreePath, error }, 'worktree_cleanup_failed')
+  })
 }

--- a/apps/api/src/engines/reconciler.ts
+++ b/apps/api/src/engines/reconciler.ts
@@ -1,7 +1,10 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import { cacheDel } from '@/cache'
 import { db } from '@/db'
-import { ensureDefaultFilterRules } from '@/db/helpers'
+import {
+  ensureDefaultFilterRules,
+  ensureWorktreeAutoCleanupDefault,
+} from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
 import { emitIssueUpdated } from '@/events/issue-events'
 import { logger } from '@/logger'
@@ -98,8 +101,9 @@ function hasActiveProcess(issueId: string): boolean {
  * whose sessions were running/pending when the server last stopped.
  */
 export async function startupReconciliation(): Promise<void> {
-  // Seed default write-filter rules if not present
+  // Seed defaults if not present
   await ensureDefaultFilterRules()
+  await ensureWorktreeAutoCleanupDefault()
 
   // First, mark stale sessions (running/pending sessionStatus) as failed.
   // This was previously done by cleanupStaleSessions in db/helpers.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from './engines/reconciler'
 import { startChangesSummaryWatcher } from './events/changes-summary'
 import { startUploadCleanup } from './jobs/upload-cleanup'
+import { startWorktreeCleanup } from './jobs/worktree-cleanup'
 import { logger } from './logger'
 import { APP_DIR, ROOT_DIR } from './root'
 import { printStartupBanner } from './startup-banner'
@@ -106,10 +107,14 @@ printStartupBanner(listenHost, listenPort)
 // Start periodic upload cleanup (removes files older than 7 days)
 const stopUploadCleanup = startUploadCleanup()
 
+// Start periodic worktree cleanup (removes worktrees for done issues older than 1 day)
+const stopWorktreeCleanup = startWorktreeCleanup()
+
 // Register shutdown callback for upgrade restarts (stops server + cancels engines)
 registerShutdownForUpgrade(async () => {
   stopPeriodicReconciliation()
   stopUploadCleanup()
+  stopWorktreeCleanup()
   stopPeriodicCheck()
   await issueEngine.cancelAll()
   http.stop()
@@ -134,6 +139,7 @@ async function shutdown(signal: string) {
   // Stop periodic jobs before cancelling processes
   stopPeriodicReconciliation()
   stopUploadCleanup()
+  stopWorktreeCleanup()
   stopPeriodicCheck()
 
   // Cancel all active engine processes before shutting down

--- a/apps/api/src/jobs/worktree-cleanup.ts
+++ b/apps/api/src/jobs/worktree-cleanup.ts
@@ -1,0 +1,139 @@
+import { readdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { and, eq, inArray, isNull, lte, notInArray, or } from 'drizzle-orm'
+import { db } from '@/db'
+import { getAppSetting } from '@/db/helpers'
+import { issues as issuesTable, projects as projectsTable } from '@/db/schema'
+import { WORKTREE_DIR } from '@/engines/issue/constants'
+import { removeWorktree } from '@/engines/issue/utils/worktree'
+import { logger } from '@/logger'
+import { ROOT_DIR } from '@/root'
+
+export const WORKTREE_AUTO_CLEANUP_KEY = 'worktree:autoCleanup'
+
+/** Default interval: every 30 minutes */
+const DEFAULT_INTERVAL_MS = 30 * 60 * 1000
+
+/** Only clean up worktrees for issues that have been done for at least 1 day */
+const DONE_AGE_MS = 24 * 60 * 60 * 1000
+
+/** Max entries per inArray batch to stay within SQLite variable limits */
+const MAX_BATCH = 500
+
+async function isAutoCleanupEnabled(): Promise<boolean> {
+  const value = await getAppSetting(WORKTREE_AUTO_CLEANUP_KEY)
+  return value === 'true'
+}
+
+async function runWorktreeCleanup(): Promise<void> {
+  if (!(await isAutoCleanupEnabled())) return
+
+  const worktreeBaseDir = join(ROOT_DIR, WORKTREE_DIR)
+  let projectEntries: import('node:fs').Dirent[]
+  try {
+    projectEntries = await readdir(worktreeBaseDir, { withFileTypes: true })
+  } catch {
+    return // No worktree directory at all
+  }
+
+  const projectDirNames = projectEntries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .slice(0, MAX_BATCH)
+
+  if (projectDirNames.length === 0) return
+
+  // Batch-fetch all project directories upfront to avoid N+1 queries
+  const projectRows = await db
+    .select({ id: projectsTable.id, directory: projectsTable.directory })
+    .from(projectsTable)
+    .where(inArray(projectsTable.id, projectDirNames))
+  const projectMap = new Map(projectRows.map((p) => [p.id, p.directory]))
+
+  const cutoff = new Date(Date.now() - DONE_AGE_MS)
+  let cleaned = 0
+
+  for (const projectDirName of projectDirNames) {
+    const projectWorktreeDir = join(worktreeBaseDir, projectDirName)
+
+    // List worktree subdirectories (issue IDs)
+    let issueEntries: import('node:fs').Dirent[]
+    try {
+      issueEntries = await readdir(projectWorktreeDir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+
+    const issueIds = issueEntries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .slice(0, MAX_BATCH)
+
+    if (issueIds.length === 0) continue
+
+    // Batch-query DB: find issues that are done + not deleted + use worktree + statusUpdatedAt <= cutoff
+    const doneIssues = await db
+      .select({
+        id: issuesTable.id,
+        projectId: issuesTable.projectId,
+      })
+      .from(issuesTable)
+      .where(
+        and(
+          inArray(issuesTable.id, issueIds),
+          eq(issuesTable.statusId, 'done'),
+          eq(issuesTable.isDeleted, 0),
+          eq(issuesTable.useWorktree, true),
+          lte(issuesTable.statusUpdatedAt, cutoff),
+          // Only clean worktrees when no active session exists
+          or(
+            isNull(issuesTable.sessionStatus),
+            notInArray(issuesTable.sessionStatus, ['running', 'pending']),
+          ),
+        ),
+      )
+
+    if (doneIssues.length === 0) continue
+
+    const directory = projectMap.get(projectDirName)
+    const baseDir = directory ? resolve(directory) : process.cwd()
+
+    for (const issue of doneIssues) {
+      const worktreePath = join(projectWorktreeDir, issue.id)
+
+      try {
+        await removeWorktree(baseDir, worktreePath)
+        cleaned++
+        logger.debug(
+          { projectId: issue.projectId, issueId: issue.id, worktreePath },
+          'worktree_auto_cleaned',
+        )
+      } catch (err) {
+        logger.warn(
+          { projectId: issue.projectId, issueId: issue.id, err },
+          'worktree_auto_cleanup_failed',
+        )
+      }
+    }
+  }
+
+  if (cleaned > 0) {
+    logger.info({ cleaned }, 'worktree_auto_cleanup_done')
+  }
+}
+
+export function startWorktreeCleanup(
+  intervalMs = DEFAULT_INTERVAL_MS,
+): () => void {
+  // Run once immediately on startup to clean stale worktrees from before restart
+  void runWorktreeCleanup().catch((err) => {
+    logger.error({ err }, 'worktree_cleanup_job_error')
+  })
+  const timer = setInterval(() => {
+    void runWorktreeCleanup().catch((err) => {
+      logger.error({ err }, 'worktree_cleanup_job_error')
+    })
+  }, intervalMs)
+  if (timer && typeof timer === 'object' && 'unref' in timer) timer.unref()
+  return () => clearInterval(timer)
+}

--- a/apps/api/src/routes/api.ts
+++ b/apps/api/src/routes/api.ts
@@ -7,6 +7,7 @@ import git from './git'
 import issues from './issues'
 import processes from './processes'
 import projects from './projects'
+import worktrees from './worktrees'
 
 const apiRoutes = new Hono()
 
@@ -15,6 +16,7 @@ apiRoutes.route('/projects', projects)
 apiRoutes.route('/projects/:projectId/issues', issues)
 apiRoutes.route('/projects/:projectId/files', files)
 apiRoutes.route('/projects/:projectId/processes', processes)
+apiRoutes.route('/projects/:projectId/worktrees', worktrees)
 
 // Infrastructure routes
 apiRoutes.route('/filesystem', filesystem)

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -3,6 +3,7 @@ import { resolve, sep } from 'node:path'
 import { Hono } from 'hono'
 import { cacheGetOrSet } from '@/cache'
 import { findProject } from '@/db/helpers'
+import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
 import { getProjectOwnedIssue } from './_shared'
 
 // ---------- Types ----------
@@ -50,6 +51,27 @@ async function resolveProjectDir(projectId: string): Promise<string> {
   if (!s.isDirectory())
     throw new Error(`Project directory is not a directory: ${root}`)
   return root
+}
+
+/**
+ * If the issue has a worktree and its directory exists, use it.
+ * Otherwise fall back to the project root.
+ */
+async function resolveChangesDir(
+  projectId: string,
+  issueId: string,
+  useWorktree: boolean,
+  projectRoot: string,
+): Promise<string> {
+  if (!useWorktree) return projectRoot
+  const wtPath = resolveWorktreePath(projectId, issueId)
+  try {
+    const s = await stat(wtPath)
+    if (s.isDirectory()) return wtPath
+  } catch {
+    // worktree dir doesn't exist — fall back
+  }
+  return projectRoot
 }
 
 async function runGit(
@@ -164,7 +186,13 @@ changes.get('/:id/changes', async (c) => {
   const issue = await getProjectOwnedIssue(project.id, issueId)
   if (!issue) return c.json({ success: false, error: 'Issue not found' }, 404)
 
-  const root = await resolveProjectDir(project.id)
+  const projectRoot = await resolveProjectDir(project.id)
+  const root = await resolveChangesDir(
+    project.id,
+    issueId,
+    issue.useWorktree,
+    projectRoot,
+  )
   const gitRepo = await isGitRepo(root)
   if (!gitRepo) {
     return c.json({
@@ -223,9 +251,15 @@ changes.get('/:id/changes/file', async (c) => {
     )
   }
 
-  const root = await resolveProjectDir(project.id)
+  const projectRoot = await resolveProjectDir(project.id)
+  const root = await resolveChangesDir(
+    project.id,
+    issueId,
+    issue.useWorktree,
+    projectRoot,
+  )
 
-  // SEC-019: Validate path is inside project root on ALL code paths
+  // SEC-019: Validate path is inside working directory on ALL code paths
   if (!isPathInsideRoot(root, path)) {
     return c.json({ success: false, error: 'Invalid path' }, 400)
   }

--- a/apps/api/src/routes/issues/update.ts
+++ b/apps/api/src/routes/issues/update.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'node:path'
 import { zValidator } from '@hono/zod-validator'
 import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
@@ -6,12 +5,7 @@ import { cacheDel, cacheDelByPrefix, cacheGetOrSet } from '@/cache'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
-import {
-  issueEngine,
-  removeWorktree,
-  resolveWorktreePath,
-  setIssueDevMode,
-} from '@/engines/issue'
+import { issueEngine, setIssueDevMode } from '@/engines/issue'
 import { emitIssueUpdated } from '@/events/issue-events'
 import { logger } from '@/logger'
 import {
@@ -21,24 +15,6 @@ import {
   triggerIssueExecution,
   updateIssueSchema,
 } from './_shared'
-
-/** Fire-and-forget worktree cleanup for done transitions */
-function cleanupWorktreeOnDone(
-  projectId: string,
-  issueId: string,
-  projectDirectory: string | null,
-  useWorktree: boolean,
-): void {
-  if (!useWorktree) return
-  const baseDir = projectDirectory ? resolve(projectDirectory) : process.cwd()
-  const worktreePath = resolveWorktreePath(projectId, issueId)
-  void removeWorktree(baseDir, worktreePath).catch((err) => {
-    logger.debug(
-      { issueId, worktreePath, err },
-      'done_transition_worktree_cleanup',
-    )
-  })
-}
 
 const update = new Hono()
 
@@ -94,8 +70,8 @@ update.patch(
     }> = []
     // Collect issues that already have a session but need pending messages flushed
     const toFlush: Array<{ id: string; model: string | null }> = []
-    // Collect issues transitioning to done that need active processes cancelled + worktree cleanup
-    const toCancel: Array<{ id: string; useWorktree: boolean }> = []
+    // Collect issues transitioning to done that need active processes cancelled
+    const toCancel: string[] = []
 
     await db.transaction(async (tx) => {
       for (const u of body.updates) {
@@ -149,9 +125,9 @@ update.patch(
           }
         }
 
-        // Check if transitioning to done → cancel active processes + cleanup worktree
+        // Check if transitioning to done → cancel active processes
         if (u.statusId === 'done' && existing && existing.statusId !== 'done') {
-          toCancel.push({ id: u.id, useWorktree: existing.useWorktree })
+          toCancel.push(u.id)
         }
 
         const [row] = await tx
@@ -177,12 +153,11 @@ update.patch(
     for (const issue of toFlush) {
       flushPendingAsFollowUp(issue.id, issue)
     }
-    // Cancel active processes and cleanup worktrees for issues that transitioned to done
-    for (const { id, useWorktree } of toCancel) {
+    // Cancel active processes for issues that transitioned to done
+    for (const id of toCancel) {
       void issueEngine.cancelIssue(id).catch((err) => {
         logger.error({ issueId: id, err }, 'done_transition_cancel_failed')
       })
-      cleanupWorktreeOnDone(project.id, id, project.directory, useWorktree)
     }
 
     // Invalidate issue caches after bulk update
@@ -346,17 +321,11 @@ update.patch(
       flushPendingAsFollowUp(issueId, { model: existing.model })
     }
 
-    // Fire-and-forget cancel + worktree cleanup for done transition
+    // Fire-and-forget cancel for done transition
     if (transitioningToDone) {
       void issueEngine.cancelIssue(issueId).catch((err) => {
         logger.error({ issueId, err }, 'done_transition_cancel_failed')
       })
-      cleanupWorktreeOnDone(
-        project.id,
-        issueId,
-        project.directory,
-        existing.useWorktree,
-      )
     }
 
     return c.json({ success: true, data: serializeIssue(row) })

--- a/apps/api/src/routes/issues/update.ts
+++ b/apps/api/src/routes/issues/update.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import { zValidator } from '@hono/zod-validator'
 import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
@@ -5,7 +6,12 @@ import { cacheDel, cacheDelByPrefix, cacheGetOrSet } from '@/cache'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
-import { issueEngine, setIssueDevMode } from '@/engines/issue'
+import {
+  issueEngine,
+  removeWorktree,
+  resolveWorktreePath,
+  setIssueDevMode,
+} from '@/engines/issue'
 import { emitIssueUpdated } from '@/events/issue-events'
 import { logger } from '@/logger'
 import {
@@ -15,6 +21,24 @@ import {
   triggerIssueExecution,
   updateIssueSchema,
 } from './_shared'
+
+/** Fire-and-forget worktree cleanup for done transitions */
+function cleanupWorktreeOnDone(
+  projectId: string,
+  issueId: string,
+  projectDirectory: string | null,
+  useWorktree: boolean,
+): void {
+  if (!useWorktree) return
+  const baseDir = projectDirectory ? resolve(projectDirectory) : process.cwd()
+  const worktreePath = resolveWorktreePath(projectId, issueId)
+  void removeWorktree(baseDir, worktreePath).catch((err) => {
+    logger.debug(
+      { issueId, worktreePath, err },
+      'done_transition_worktree_cleanup',
+    )
+  })
+}
 
 const update = new Hono()
 
@@ -70,8 +94,8 @@ update.patch(
     }> = []
     // Collect issues that already have a session but need pending messages flushed
     const toFlush: Array<{ id: string; model: string | null }> = []
-    // Collect issues transitioning to done that need active processes cancelled
-    const toCancel: string[] = []
+    // Collect issues transitioning to done that need active processes cancelled + worktree cleanup
+    const toCancel: Array<{ id: string; useWorktree: boolean }> = []
 
     await db.transaction(async (tx) => {
       for (const u of body.updates) {
@@ -125,9 +149,9 @@ update.patch(
           }
         }
 
-        // Check if transitioning to done → cancel active processes
+        // Check if transitioning to done → cancel active processes + cleanup worktree
         if (u.statusId === 'done' && existing && existing.statusId !== 'done') {
-          toCancel.push(u.id)
+          toCancel.push({ id: u.id, useWorktree: existing.useWorktree })
         }
 
         const [row] = await tx
@@ -153,11 +177,12 @@ update.patch(
     for (const issue of toFlush) {
       flushPendingAsFollowUp(issue.id, issue)
     }
-    // Cancel active processes for issues that transitioned to done
-    for (const issueId of toCancel) {
-      void issueEngine.cancelIssue(issueId).catch((err) => {
-        logger.error({ issueId, err }, 'done_transition_cancel_failed')
+    // Cancel active processes and cleanup worktrees for issues that transitioned to done
+    for (const { id, useWorktree } of toCancel) {
+      void issueEngine.cancelIssue(id).catch((err) => {
+        logger.error({ issueId: id, err }, 'done_transition_cancel_failed')
       })
+      cleanupWorktreeOnDone(project.id, id, project.directory, useWorktree)
     }
 
     // Invalidate issue caches after bulk update
@@ -321,11 +346,17 @@ update.patch(
       flushPendingAsFollowUp(issueId, { model: existing.model })
     }
 
-    // Fire-and-forget cancel for done transition
+    // Fire-and-forget cancel + worktree cleanup for done transition
     if (transitioningToDone) {
       void issueEngine.cancelIssue(issueId).catch((err) => {
         logger.error({ issueId, err }, 'done_transition_cancel_failed')
       })
+      cleanupWorktreeOnDone(
+        project.id,
+        issueId,
+        project.directory,
+        existing.useWorktree,
+      )
     }
 
     return c.json({ success: true, data: serializeIssue(row) })

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_FILTER_RULES,
   WRITE_FILTER_RULES_KEY,
 } from '@/engines/write-filter'
+import { WORKTREE_AUTO_CLEANUP_KEY } from '@/jobs/worktree-cleanup'
 
 const settings = new Hono()
 
@@ -113,6 +114,25 @@ settings.patch(
       success: true,
       data: updatedRules.find((r) => r.id === ruleId),
     })
+  },
+)
+
+// --- Worktree Auto-Cleanup ---
+
+// GET /api/settings/worktree-auto-cleanup
+settings.get('/worktree-auto-cleanup', async (c) => {
+  const value = await getAppSetting(WORKTREE_AUTO_CLEANUP_KEY)
+  return c.json({ success: true, data: { enabled: value === 'true' } })
+})
+
+// PATCH /api/settings/worktree-auto-cleanup
+settings.patch(
+  '/worktree-auto-cleanup',
+  zValidator('json', z.object({ enabled: z.boolean() })),
+  async (c) => {
+    const { enabled } = c.req.valid('json')
+    await setAppSetting(WORKTREE_AUTO_CLEANUP_KEY, String(enabled))
+    return c.json({ success: true, data: { enabled } })
   },
 )
 

--- a/apps/api/src/routes/worktrees.ts
+++ b/apps/api/src/routes/worktrees.ts
@@ -1,0 +1,116 @@
+import { readdir, stat } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { Hono } from 'hono'
+import { findProject } from '@/db/helpers'
+import { WORKTREE_DIR } from '@/engines/issue/constants'
+import { removeWorktree } from '@/engines/issue/utils/worktree'
+import { logger } from '@/logger'
+import { ROOT_DIR } from '@/root'
+
+interface WorktreeEntry {
+  issueId: string
+  path: string
+  branch: string | null
+}
+
+async function listProjectWorktrees(
+  projectId: string,
+): Promise<WorktreeEntry[]> {
+  const projectDir = join(ROOT_DIR, WORKTREE_DIR, projectId)
+  let entries: string[]
+  try {
+    entries = await readdir(projectDir)
+  } catch {
+    return []
+  }
+
+  const results: WorktreeEntry[] = []
+  for (const name of entries) {
+    const fullPath = join(projectDir, name)
+    try {
+      const s = await stat(fullPath)
+      if (!s.isDirectory()) continue
+    } catch {
+      continue
+    }
+
+    // Try to read the branch from git HEAD
+    let branch: string | null = null
+    try {
+      const gitFile = Bun.file(join(fullPath, '.git'))
+      const content = await gitFile.text()
+      // .git file in worktree contains "gitdir: ..." pointer
+      if (content.startsWith('gitdir:')) {
+        // Read HEAD from the main repo's worktrees/<name>/HEAD
+        const gitdir = content.replace('gitdir:', '').trim()
+        const headFile = Bun.file(join(gitdir, 'HEAD'))
+        const head = await headFile.text()
+        if (head.startsWith('ref: refs/heads/')) {
+          branch = head.replace('ref: refs/heads/', '').trim()
+        }
+      }
+    } catch {
+      // Not a valid git worktree — still list it
+    }
+
+    results.push({ issueId: name, path: fullPath, branch })
+  }
+
+  return results.sort((a, b) => a.issueId.localeCompare(b.issueId))
+}
+
+const worktrees = new Hono()
+
+// GET /api/projects/:projectId/worktrees — List worktrees for a project
+worktrees.get('/', async (c) => {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404)
+  }
+
+  const entries = await listProjectWorktrees(project.id)
+  return c.json({ success: true, data: entries })
+})
+
+// DELETE /api/projects/:projectId/worktrees/:issueId — Force delete a worktree
+worktrees.delete('/:issueId', async (c) => {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404)
+  }
+
+  const issueId = c.req.param('issueId')!
+  const worktreePath = join(ROOT_DIR, WORKTREE_DIR, project.id, issueId)
+
+  // Verify the worktree directory exists
+  try {
+    const s = await stat(worktreePath)
+    if (!s.isDirectory()) {
+      return c.json({ success: false, error: 'Worktree not found' }, 404)
+    }
+  } catch {
+    return c.json({ success: false, error: 'Worktree not found' }, 404)
+  }
+
+  const baseDir = project.directory ? resolve(project.directory) : process.cwd()
+
+  try {
+    await removeWorktree(baseDir, worktreePath)
+    logger.info(
+      { projectId: project.id, issueId, worktreePath },
+      'worktree_force_deleted',
+    )
+  } catch (err) {
+    logger.error(
+      { projectId: project.id, issueId, worktreePath, err },
+      'worktree_force_delete_failed',
+    )
+    return c.json({ success: false, error: 'Failed to delete worktree' }, 500)
+  }
+
+  return c.json({ success: true, data: { issueId } })
+})
+
+export default worktrees

--- a/apps/api/src/routes/worktrees.ts
+++ b/apps/api/src/routes/worktrees.ts
@@ -1,11 +1,14 @@
 import { readdir, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { Hono } from 'hono'
 import { findProject } from '@/db/helpers'
 import { WORKTREE_DIR } from '@/engines/issue/constants'
 import { removeWorktree } from '@/engines/issue/utils/worktree'
 import { logger } from '@/logger'
 import { ROOT_DIR } from '@/root'
+
+/** Only accept IDs that match the nanoid/ULID patterns used in the project */
+const VALID_ID = /^[a-zA-Z0-9_-]{4,32}$/
 
 interface WorktreeEntry {
   issueId: string
@@ -26,6 +29,9 @@ async function listProjectWorktrees(
 
   const results: WorktreeEntry[] = []
   for (const name of entries) {
+    // Skip entries that don't match expected ID format
+    if (!VALID_ID.test(name)) continue
+
     const fullPath = join(projectDir, name)
     try {
       const s = await stat(fullPath)
@@ -82,7 +88,22 @@ worktrees.delete('/:issueId', async (c) => {
   }
 
   const issueId = c.req.param('issueId')!
-  const worktreePath = join(ROOT_DIR, WORKTREE_DIR, project.id, issueId)
+
+  // Validate issueId format to prevent path traversal
+  if (!VALID_ID.test(issueId)) {
+    return c.json({ success: false, error: 'Invalid issueId' }, 400)
+  }
+
+  const baseWorktreeDir = resolve(join(ROOT_DIR, WORKTREE_DIR, project.id))
+  const worktreePath = resolve(join(baseWorktreeDir, issueId))
+
+  // Ensure resolved path stays within the project worktree directory
+  if (
+    !worktreePath.startsWith(baseWorktreeDir + sep) &&
+    worktreePath !== baseWorktreeDir
+  ) {
+    return c.json({ success: false, error: 'Invalid issueId' }, 400)
+  }
 
   // Verify the worktree directory exists
   try {

--- a/apps/api/test/worktree.test.ts
+++ b/apps/api/test/worktree.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import {
+  cleanupWorktree,
+  createWorktree,
+  removeWorktree,
+  resolveWorktreePath,
+} from '@/engines/issue/utils/worktree'
+import { ROOT_DIR } from '@/root'
+
+/**
+ * Worktree utility tests — verifies:
+ * 1. resolveWorktreePath returns deterministic path under ROOT_DIR/data/worktrees/
+ * 2. createWorktree creates a git worktree and returns its path
+ * 3. removeWorktree removes the git worktree and cleans up the directory
+ * 4. removeWorktree falls back to directory deletion when git command fails
+ * 5. cleanupWorktree calls removeWorktree (fire-and-forget)
+ *
+ * These tests use the actual git repo since worktree operations require it.
+ */
+
+// Git repo root (2 levels up from apps/api/test/)
+const GIT_ROOT = resolve(import.meta.dir, '../../..')
+const TEST_PROJECT_ID = 'test-project'
+const TEST_ISSUE_ID = `test-wt-${Date.now()}`
+
+afterAll(() => {
+  // Clean up any leftover worktrees and branches
+  const wtDir = resolveWorktreePath(TEST_PROJECT_ID, TEST_ISSUE_ID)
+  try {
+    if (existsSync(wtDir)) {
+      Bun.spawnSync(['git', 'worktree', 'remove', '--force', wtDir], {
+        cwd: GIT_ROOT,
+      })
+    }
+  } catch {
+    /* best effort */
+  }
+  try {
+    Bun.spawnSync(['git', 'branch', '-D', `bitk/${TEST_ISSUE_ID}`], {
+      cwd: GIT_ROOT,
+    })
+  } catch {
+    /* best effort */
+  }
+  // Clean up the test project directory under data/worktrees/
+  try {
+    const projectDir = join(ROOT_DIR, 'data/worktrees', TEST_PROJECT_ID)
+    if (existsSync(projectDir)) {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  } catch {
+    /* best effort */
+  }
+})
+
+describe('resolveWorktreePath', () => {
+  test('returns deterministic path under ROOT_DIR/data/worktrees/', () => {
+    const path = resolveWorktreePath('proj-1', 'issue-abc')
+    expect(path).toBe(join(ROOT_DIR, 'data/worktrees', 'proj-1', 'issue-abc'))
+  })
+})
+
+describe('createWorktree', () => {
+  test('creates a worktree directory with the expected path', async () => {
+    const worktreeDir = await createWorktree(
+      GIT_ROOT,
+      TEST_PROJECT_ID,
+      TEST_ISSUE_ID,
+    )
+    expect(worktreeDir).toBe(
+      resolveWorktreePath(TEST_PROJECT_ID, TEST_ISSUE_ID),
+    )
+    expect(existsSync(worktreeDir)).toBe(true)
+
+    // Verify it's a valid git worktree (has .git file)
+    expect(existsSync(join(worktreeDir, '.git'))).toBe(true)
+  })
+
+  test('retries with existing branch on second call', async () => {
+    // The branch already exists from the first test — createWorktree
+    // should handle this gracefully by retrying without -b
+    const wtDir = resolveWorktreePath(TEST_PROJECT_ID, TEST_ISSUE_ID)
+    await removeWorktree(GIT_ROOT, wtDir)
+
+    const worktreeDir = await createWorktree(
+      GIT_ROOT,
+      TEST_PROJECT_ID,
+      TEST_ISSUE_ID,
+    )
+    expect(existsSync(worktreeDir)).toBe(true)
+  })
+})
+
+describe('removeWorktree', () => {
+  test('removes worktree via git command', async () => {
+    const wtDir = resolveWorktreePath(TEST_PROJECT_ID, TEST_ISSUE_ID)
+    expect(existsSync(wtDir)).toBe(true)
+
+    await removeWorktree(GIT_ROOT, wtDir)
+    expect(existsSync(wtDir)).toBe(false)
+  })
+
+  test('falls back to directory deletion for non-git worktree dirs', async () => {
+    const fakeDir = join(
+      ROOT_DIR,
+      'data/worktrees',
+      TEST_PROJECT_ID,
+      'fake-worktree',
+    )
+    mkdirSync(fakeDir, { recursive: true })
+    writeFileSync(join(fakeDir, 'test.txt'), 'test')
+    expect(existsSync(fakeDir)).toBe(true)
+
+    await removeWorktree(GIT_ROOT, fakeDir)
+    expect(existsSync(fakeDir)).toBe(false)
+  })
+})
+
+describe('cleanupWorktree', () => {
+  test('calls removeWorktree as fire-and-forget', async () => {
+    const cleanupIssueId = `test-cleanup-${Date.now()}`
+    const wtDir = await createWorktree(
+      GIT_ROOT,
+      TEST_PROJECT_ID,
+      cleanupIssueId,
+    )
+
+    expect(existsSync(wtDir)).toBe(true)
+
+    // cleanupWorktree is fire-and-forget — pass baseDir explicitly
+    cleanupWorktree(GIT_ROOT, cleanupIssueId, wtDir)
+
+    // Wait for the async cleanup to complete
+    await Bun.sleep(1000)
+
+    expect(existsSync(wtDir)).toBe(false)
+
+    // Clean up branch
+    Bun.spawnSync(['git', 'branch', '-D', `bitk/${cleanupIssueId}`], {
+      cwd: GIT_ROOT,
+    })
+  })
+})

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -41,6 +41,7 @@ import {
   useProbeEngines,
   useRestartWithUpgrade,
   useSetUpgradeEnabled,
+  useSetWorktreeAutoCleanup,
   useUpdateDefaultEngine,
   useUpdateEngineModelSetting,
   useUpdateWorkspacePath,
@@ -48,6 +49,7 @@ import {
   useUpgradeEnabled,
   useVersionInfo,
   useWorkspacePath,
+  useWorktreeAutoCleanup,
 } from '@/hooks/use-kanban'
 import { useTheme } from '@/hooks/use-theme'
 import { LANGUAGES } from '@/lib/constants'
@@ -95,6 +97,9 @@ export function AppSettingsDialog({
   const { data: wsData } = useWorkspacePath(open)
   const updateWsPath = useUpdateWorkspacePath()
   const [dirPickerOpen, setDirPickerOpen] = useState(false)
+
+  const { data: worktreeCleanupData } = useWorktreeAutoCleanup(open)
+  const setWorktreeAutoCleanup = useSetWorktreeAutoCleanup()
 
   const handleSelectWorkspace = (path: string) => {
     updateWsPath.mutate(path)
@@ -183,6 +188,25 @@ export function AppSettingsDialog({
                     </SelectContent>
                   </Select>
                 </Field>
+              </div>
+
+              {/* Worktree Auto-Cleanup */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-sm font-medium">
+                    {t('settings.worktreeAutoCleanup')}
+                  </span>
+                  <p className="text-[11px] text-muted-foreground">
+                    {t('settings.worktreeAutoCleanupHint')}
+                  </p>
+                </div>
+                <Switch
+                  size="sm"
+                  checked={worktreeCleanupData?.enabled ?? false}
+                  onCheckedChange={(checked) =>
+                    setWorktreeAutoCleanup.mutate(checked)
+                  }
+                />
               </div>
 
               {/* About & Upgrade section */}

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, Loader2 } from 'lucide-react'
+import { FolderOpen, GitBranch, Loader2, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -15,8 +15,14 @@ import {
 import { Field, FieldGroup } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
-import { useDeleteProject, useUpdateProject } from '@/hooks/use-kanban'
+import {
+  useDeleteProject,
+  useDeleteWorktree,
+  useProjectWorktrees,
+  useUpdateProject,
+} from '@/hooks/use-kanban'
 import { kanbanApi } from '@/lib/kanban-api'
 import type { Project } from '@/types/kanban'
 
@@ -92,6 +98,81 @@ function DeleteProjectDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function WorktreeTab({ project }: { project: Project }) {
+  const { t } = useTranslation()
+  const { data: worktrees, isLoading } = useProjectWorktrees(project.id)
+  const deleteWorktree = useDeleteWorktree()
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        {t('project.worktreeLoading')}
+      </div>
+    )
+  }
+
+  if (!worktrees || worktrees.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        {t('project.worktreeEmpty')}
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {worktrees.map((wt) => (
+        <div
+          key={wt.issueId}
+          className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
+        >
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="truncate text-sm font-medium font-mono">
+              {wt.issueId}
+            </p>
+            {wt.branch ? (
+              <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                <GitBranch className="size-3" />
+                <span className="truncate">{wt.branch}</span>
+              </p>
+            ) : null}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 text-muted-foreground hover:text-destructive"
+            disabled={deleteWorktree.isPending && deletingId === wt.issueId}
+            onClick={() => {
+              if (
+                !window.confirm(
+                  t('project.worktreeDeleteConfirm', {
+                    issueId: wt.issueId,
+                  }),
+                )
+              ) {
+                return
+              }
+              setDeletingId(wt.issueId)
+              deleteWorktree.mutate(
+                { projectId: project.id, issueId: wt.issueId },
+                { onSettled: () => setDeletingId(null) },
+              )
+            }}
+          >
+            {deleteWorktree.isPending && deletingId === wt.issueId ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Trash2 className="size-4" />
+            )}
+          </Button>
+        </div>
+      ))}
+    </div>
   )
 }
 
@@ -172,120 +253,142 @@ export function ProjectSettingsDialog({
             </div>
           </DialogHeader>
 
-          <FieldGroup>
-            <Field>
-              <Label>
-                {t('project.name')} <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={t('project.namePlaceholder')}
-                autoFocus
-                className="w-full"
-              />
-            </Field>
+          <Tabs defaultValue="general">
+            <TabsList>
+              <TabsTrigger value="general">
+                {t('project.tabGeneral')}
+              </TabsTrigger>
+              <TabsTrigger value="worktrees">
+                {t('project.tabWorktrees')}
+              </TabsTrigger>
+            </TabsList>
 
-            <Field>
-              <Label>{t('project.description')}</Label>
-              <Textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder={t('project.descriptionPlaceholder')}
-                rows={3}
-                className="w-full resize-none"
-              />
-            </Field>
+            <TabsContent value="general">
+              <FieldGroup>
+                <Field>
+                  <Label>
+                    {t('project.name')}{' '}
+                    <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder={t('project.namePlaceholder')}
+                    autoFocus
+                    className="w-full"
+                  />
+                </Field>
 
-            <Field>
-              <Label>{t('project.directory')}</Label>
-              <div className="flex gap-1.5">
-                <Input
-                  type="text"
-                  value={directory}
-                  onChange={(e) => setDirectory(e.target.value)}
-                  placeholder={t('project.directoryPlaceholder')}
-                  className="w-full"
-                />
+                <Field>
+                  <Label>{t('project.description')}</Label>
+                  <Textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder={t('project.descriptionPlaceholder')}
+                    rows={3}
+                    className="w-full resize-none"
+                  />
+                </Field>
+
+                <Field>
+                  <Label>{t('project.directory')}</Label>
+                  <div className="flex gap-1.5">
+                    <Input
+                      type="text"
+                      value={directory}
+                      onChange={(e) => setDirectory(e.target.value)}
+                      placeholder={t('project.directoryPlaceholder')}
+                      className="w-full"
+                    />
+                    <Button
+                      onClick={() => setDirPickerOpen(true)}
+                      variant="outline"
+                      size="icon"
+                      title={t('project.browseDirectories')}
+                    >
+                      <FolderOpen className="size-4 text-muted-foreground" />
+                    </Button>
+                  </div>
+                  <DirectoryPicker
+                    open={dirPickerOpen}
+                    onOpenChange={setDirPickerOpen}
+                    initialPath={directory || undefined}
+                    onSelect={setDirectory}
+                  />
+                </Field>
+
+                <Field className="space-y-1.5">
+                  <Label>{t('project.repositoryUrl')}</Label>
+                  <div className="flex gap-1.5">
+                    <Input
+                      type="text"
+                      value={repositoryUrl}
+                      onChange={(e) => setRepositoryUrl(e.target.value)}
+                      placeholder={t('project.repositoryUrlPlaceholder')}
+                      className="w-full"
+                    />
+                    <Button
+                      onClick={async () => {
+                        const dir = directory.trim()
+                        if (!dir) return
+                        setDetectingRemote(true)
+                        try {
+                          const result = await kanbanApi.detectGitRemote(dir)
+                          setRepositoryUrl(result.url)
+                        } catch {
+                          // silently ignore — directory may not be a git repo
+                        } finally {
+                          setDetectingRemote(false)
+                        }
+                      }}
+                      variant="outline"
+                      type="button"
+                      disabled={!directory.trim() || detectingRemote}
+                      title={t('project.detectGitRemote')}
+                      className="shrink-0"
+                    >
+                      {detectingRemote ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        'Auto'
+                      )}
+                    </Button>
+                  </div>
+                </Field>
+
+                {error ? (
+                  <p className="text-sm text-destructive">{error}</p>
+                ) : null}
+              </FieldGroup>
+
+              <DialogFooter className="mt-4">
                 <Button
-                  onClick={() => setDirPickerOpen(true)}
-                  variant="outline"
-                  size="icon"
-                  title={t('project.browseDirectories')}
+                  variant="destructive"
+                  onClick={() => setDeleteDialogOpen(true)}
                 >
-                  <FolderOpen className="size-4 text-muted-foreground" />
+                  {t('project.delete')}
                 </Button>
-              </div>
-              <DirectoryPicker
-                open={dirPickerOpen}
-                onOpenChange={setDirPickerOpen}
-                initialPath={directory || undefined}
-                onSelect={setDirectory}
-              />
-            </Field>
-
-            <Field className="space-y-1.5">
-              <Label>{t('project.repositoryUrl')}</Label>
-              <div className="flex gap-1.5">
-                <Input
-                  type="text"
-                  value={repositoryUrl}
-                  onChange={(e) => setRepositoryUrl(e.target.value)}
-                  placeholder={t('project.repositoryUrlPlaceholder')}
-                  className="w-full"
-                />
+                <Button variant="outline" onClick={() => onOpenChange(false)}>
+                  {t('common.cancel')}
+                </Button>
                 <Button
-                  onClick={async () => {
-                    const dir = directory.trim()
-                    if (!dir) return
-                    setDetectingRemote(true)
-                    try {
-                      const result = await kanbanApi.detectGitRemote(dir)
-                      setRepositoryUrl(result.url)
-                    } catch {
-                      // silently ignore — directory may not be a git repo
-                    } finally {
-                      setDetectingRemote(false)
-                    }
-                  }}
-                  variant="outline"
-                  type="button"
-                  disabled={!directory.trim() || detectingRemote}
-                  title={t('project.detectGitRemote')}
-                  className="shrink-0"
+                  onClick={handleSave}
+                  disabled={
+                    updateProject.isPending || !name.trim() || !hasChanges
+                  }
                 >
-                  {detectingRemote ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    'Auto'
-                  )}
+                  {updateProject.isPending
+                    ? t('project.saving')
+                    : t('project.saveChanges')}
                 </Button>
-              </div>
-            </Field>
+              </DialogFooter>
+            </TabsContent>
 
-            {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          </FieldGroup>
-
-          <DialogFooter>
-            <Button
-              variant="destructive"
-              onClick={() => setDeleteDialogOpen(true)}
-            >
-              {t('project.delete')}
-            </Button>
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
-              {t('common.cancel')}
-            </Button>
-            <Button
-              onClick={handleSave}
-              disabled={updateProject.isPending || !name.trim() || !hasChanges}
-            >
-              {updateProject.isPending
-                ? t('project.saving')
-                : t('project.saveChanges')}
-            </Button>
-          </DialogFooter>
+            <TabsContent value="worktrees">
+              <WorktreeTab project={project} />
+            </TabsContent>
+          </Tabs>
         </DialogContent>
       </Dialog>
 

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -90,7 +90,7 @@ export function CreateIssueForm({
   const [engineType, setEngineType] = useState('')
   const [modelId, setModelId] = useState('')
   const [permission, setPermission] = useState<PermissionId>('auto')
-  const [useWorktree, setUseWorktree] = useState(false)
+  const [useWorktree, setUseWorktree] = useState(true)
 
   // Resolve the effective engine type ('' means use system default)
   const resolvedEngineType = useMemo(() => {
@@ -148,7 +148,7 @@ export function CreateIssueForm({
           setModelId('')
           setPriority('medium')
           setPermission('auto')
-          setUseWorktree(false)
+          setUseWorktree(true)
           onCreated?.()
         },
       },

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -34,6 +34,8 @@ export const queryKeys = {
     ['projects', projectId, 'files', path, { hideIgnored }] as const,
   projectProcesses: (projectId: string) =>
     ['projects', projectId, 'processes'] as const,
+  projectWorktrees: (projectId: string) =>
+    ['projects', projectId, 'worktrees'] as const,
   upgradeVersion: () => ['upgrade', 'version'] as const,
   upgradeEnabled: () => ['upgrade', 'enabled'] as const,
   upgradeCheck: () => ['upgrade', 'check'] as const,
@@ -91,6 +93,27 @@ export function useDeleteProject() {
     mutationFn: (id: string) => kanbanApi.deleteProject(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.projects() })
+    },
+  })
+}
+
+export function useProjectWorktrees(projectId: string) {
+  return useQuery({
+    queryKey: queryKeys.projectWorktrees(projectId),
+    queryFn: () => kanbanApi.getWorktrees(projectId),
+    enabled: !!projectId,
+  })
+}
+
+export function useDeleteWorktree() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: { projectId: string; issueId: string }) =>
+      kanbanApi.deleteWorktree(data.projectId, data.issueId),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.projectWorktrees(variables.projectId),
+      })
     },
   })
 }

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -36,6 +36,7 @@ export const queryKeys = {
     ['projects', projectId, 'processes'] as const,
   projectWorktrees: (projectId: string) =>
     ['projects', projectId, 'worktrees'] as const,
+  worktreeAutoCleanup: () => ['settings', 'worktreeAutoCleanup'] as const,
   upgradeVersion: () => ['upgrade', 'version'] as const,
   upgradeEnabled: () => ['upgrade', 'enabled'] as const,
   upgradeCheck: () => ['upgrade', 'check'] as const,
@@ -464,6 +465,29 @@ export function useUpdateWorkspacePath() {
     mutationFn: (path: string) => kanbanApi.updateWorkspacePath(path),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.workspacePath() })
+    },
+  })
+}
+
+// --- Worktree Auto-Cleanup hooks ---
+
+export function useWorktreeAutoCleanup(enabled = false) {
+  return useQuery({
+    queryKey: queryKeys.worktreeAutoCleanup(),
+    queryFn: () => kanbanApi.getWorktreeAutoCleanup(),
+    enabled,
+    staleTime: Infinity,
+  })
+}
+
+export function useSetWorktreeAutoCleanup() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (enabled: boolean) => kanbanApi.setWorktreeAutoCleanup(enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.worktreeAutoCleanup(),
+      })
     },
   })
 }

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -264,6 +264,8 @@
     "buildId": "Build",
     "devBuild": "Development build",
     "packageMode": "Package",
+    "worktreeAutoCleanup": "Auto-cleanup worktrees",
+    "worktreeAutoCleanupHint": "Automatically remove worktrees for issues that have been done for more than 1 day",
     "upgradeEnabled": "Auto-upgrade",
     "upgradeEnabledHint": "Automatically check for and download new versions",
     "upgradeChecking": "Checking for updates...",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -36,7 +36,17 @@
     "deleteConfirm": "Are you sure you want to delete this project? All issues will also be deleted. This action cannot be undone.",
     "deleting": "Deleting...",
     "deleteConfirmPlaceholder": "Type project name to confirm",
-    "deleteConfirmHint": "Please type \"{{name}}\" to confirm deletion"
+    "deleteConfirmHint": "Please type \"{{name}}\" to confirm deletion",
+    "tabGeneral": "General",
+    "tabWorktrees": "Worktrees",
+    "worktrees": "Worktrees",
+    "worktreeEmpty": "No worktrees found for this project.",
+    "worktreeIssueId": "Issue",
+    "worktreeBranch": "Branch",
+    "worktreeDelete": "Delete",
+    "worktreeDeleting": "Deleting...",
+    "worktreeDeleteConfirm": "Delete worktree for issue {{issueId}}?",
+    "worktreeLoading": "Loading worktrees..."
   },
   "kanban": {
     "newIssue": "New Issue",
@@ -271,9 +281,7 @@
     "upgradeChecksumFailed": "Checksum mismatch",
     "upgradeRestart": "Restart to upgrade",
     "upgradeRestarting": "Restarting...",
-    "upgradeLastChecked": "Last checked: {{time}}",
-    "tabGeneral": "General",
-    "tabModels": "Models"
+    "upgradeLastChecked": "Last checked: {{time}}"
   },
   "error": {
     "title": "Something went wrong",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -36,7 +36,17 @@
     "deleteConfirm": "确定要删除此项目吗？所有任务也将一并删除，此操作无法撤销。",
     "deleting": "删除中...",
     "deleteConfirmPlaceholder": "输入项目名称以确认",
-    "deleteConfirmHint": "请输入 \"{{name}}\" 以确认删除"
+    "deleteConfirmHint": "请输入 \"{{name}}\" 以确认删除",
+    "tabGeneral": "常规",
+    "tabWorktrees": "工作树",
+    "worktrees": "工作树",
+    "worktreeEmpty": "该项目暂无工作树。",
+    "worktreeIssueId": "任务",
+    "worktreeBranch": "分支",
+    "worktreeDelete": "删除",
+    "worktreeDeleting": "删除中...",
+    "worktreeDeleteConfirm": "确定删除任务 {{issueId}} 的工作树吗？",
+    "worktreeLoading": "加载工作树中..."
   },
   "kanban": {
     "newIssue": "新建任务",
@@ -271,9 +281,7 @@
     "upgradeChecksumFailed": "校验不匹配",
     "upgradeRestart": "重启升级",
     "upgradeRestarting": "重启中...",
-    "upgradeLastChecked": "上次检查：{{time}}",
-    "tabGeneral": "通用",
-    "tabModels": "模型"
+    "upgradeLastChecked": "上次检查：{{time}}"
   },
   "error": {
     "title": "出错了",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -264,6 +264,8 @@
     "buildId": "构建",
     "devBuild": "开发构建",
     "packageMode": "包模式",
+    "worktreeAutoCleanup": "自动清理工作区",
+    "worktreeAutoCleanupHint": "自动清理已完成超过 1 天的工作区",
     "upgradeEnabled": "自动升级",
     "upgradeEnabledHint": "自动检查并下载新版本",
     "upgradeChecking": "正在检查更新...",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -256,6 +256,12 @@ export const kanbanApi = {
   getWorkspacePath: () => get<{ path: string }>('/api/settings/workspace-path'),
   updateWorkspacePath: (path: string) =>
     patch<{ path: string }>('/api/settings/workspace-path', { path }),
+  getWorktreeAutoCleanup: () =>
+    get<{ enabled: boolean }>('/api/settings/worktree-auto-cleanup'),
+  setWorktreeAutoCleanup: (enabled: boolean) =>
+    patch<{ enabled: boolean }>('/api/settings/worktree-auto-cleanup', {
+      enabled,
+    }),
 
   // Upgrade
   getVersionInfo: () =>

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -90,6 +90,14 @@ export const kanbanApi = {
   ) => patch<Project>(`/api/projects/${id}`, data),
   deleteProject: (id: string) => del<{ id: string }>(`/api/projects/${id}`),
 
+  // Worktrees
+  getWorktrees: (projectId: string) =>
+    get<Array<{ issueId: string; path: string; branch: string | null }>>(
+      `/api/projects/${projectId}/worktrees`,
+    ),
+  deleteWorktree: (projectId: string, issueId: string) =>
+    del<{ issueId: string }>(`/api/projects/${projectId}/worktrees/${issueId}`),
+
   // Issues
   getIssues: (projectId: string) =>
     get<Issue[]>(`/api/projects/${projectId}/issues`),

--- a/docs/plan/PLAN-005.md
+++ b/docs/plan/PLAN-005.md
@@ -1,0 +1,102 @@
+# PLAN-005 重构 Worktree 系统
+
+- **status**: proposed
+- **task**: WT-001
+- **owner**: claude
+- **created**: 2026-03-02
+
+## 背景
+
+当前 worktree 系统存在 5 个核心问题：目录位置在仓库内部、路径未持久化到数据库、默认不启用、状态转换时缺少生命周期管理、文件变更跟踪使用主仓库而非 worktree 目录。
+
+## 调查发现
+
+### 现状架构
+
+- **目录位置**: `<baseDir>/.bitk/worktrees/<issueId>` — 在仓库 `.bitk/` 子目录下
+- **常量**: `WORKTREE_DIR = '.bitk/worktrees'` (constants.ts)
+- **路径构造**: `join(baseDir, WORKTREE_DIR, issueId)` (worktree.ts)
+- **DB 字段**: `useWorktree: boolean` — 仅有开关，无路径存储
+- **默认值**: `useWorktree = false`（schema.ts、create route、前端 useState）
+- **生命周期**: 仅在 execute/followUp/restart 时创建，无清理逻辑
+- **文件跟踪**: `changes.ts` 路由始终使用 `resolveProjectDir()` 返回的主仓库目录
+
+### 关键调用链
+
+1. **创建**: `createWorktree(baseDir, issueId)` → `git worktree add -b bitk/<issueId> <dir>`
+2. **使用位置**: `execute.ts`、`spawn.ts:spawnFollowUpProcess`、`restart.ts`
+3. **内存跟踪**: `ManagedProcess.worktreePath` — 仅运行时保持，重启丢失
+4. **文件变更**: `changes.ts:resolveProjectDir(projectId)` → 始终返回 `project.directory || cwd()`
+5. **状态转换**: `update.ts` 处理 done→cancel，但不处理 worktree 清理
+
+### 涉及文件清单
+
+**后端**:
+- `apps/api/src/db/schema.ts` — 添加 worktreeDir 字段
+- `apps/api/drizzle/` — 新迁移文件
+- `apps/api/src/engines/issue/constants.ts` — 修改 WORKTREE_DIR 常量
+- `apps/api/src/engines/issue/utils/worktree.ts` — 重写路径构造
+- `apps/api/src/engines/issue/orchestration/execute.ts` — 持久化 worktreeDir
+- `apps/api/src/engines/issue/lifecycle/spawn.ts` — 使用 DB 中的 worktreeDir
+- `apps/api/src/engines/issue/orchestration/restart.ts` — 使用 DB 中的 worktreeDir
+- `apps/api/src/engines/issue/lifecycle/settle.ts` — 清理逻辑（已在本 worktree 添加）
+- `apps/api/src/engines/issue/gc.ts` — 清理逻辑（已在本 worktree 添加）
+- `apps/api/src/engines/issue/process/cancel.ts` — 清理逻辑（已在本 worktree 添加）
+- `apps/api/src/engines/engine-store.ts` — updateIssueSession 添加 worktreeDir
+- `apps/api/src/routes/issues/update.ts` — 状态转换时管理 worktree
+- `apps/api/src/routes/issues/changes.ts` — 使用 worktreeDir
+- `apps/api/src/routes/issues/create.ts` — 默认 useWorktree=true
+- `apps/api/src/routes/issues/_shared.ts` — serializeIssue 输出 worktreeDir
+
+**前端**:
+- `apps/frontend/src/components/kanban/CreateIssueDialog.tsx` — 默认 true
+- `packages/shared/src/index.ts` — Issue 类型添加 worktreeDir
+
+## 方案
+
+### 步骤 1: DB 迁移
+
+- `issues` 表新增 `worktree_dir TEXT` 列（可空，无 worktree 时为 null）
+- `useWorktree` 默认值改为 `true`
+
+### 步骤 2: Worktree 路径重构
+
+- 常量 `WORKTREE_DIR` 改为 `data/worktrees`
+- 新路径: `<ROOT_DIR>/data/worktrees/<projectId>/<issueId>/`
+- `createWorktree(baseDir, projectId, issueId)` 签名变更
+- `cleanupWorktree` 简化为读取 DB 中的 worktreeDir + baseDir
+
+### 步骤 3: 持久化 worktreeDir
+
+- `execute.ts`: 创建 worktree 后调用 `updateIssueWorktreeDir(issueId, path)`
+- `spawnFollowUpProcess`: 从 DB 读取 `worktreeDir` 而非拼接路径
+- `restart.ts`: 同上
+
+### 步骤 4: 状态转换生命周期
+
+在 `update.ts`（单个 + 批量）中：
+- **→ done**: 清理 worktree（调用 `removeWorktree`），清空 DB `worktreeDir`
+- **→ working**: 确保 worktree 存在（ensure）— 仅当 `useWorktree && worktreeDir 目录不存在` 时才创建并持久化，已存在则跳过
+- **→ review**: 保留 worktree（不清理）
+
+### 步骤 5: 文件变更跟踪
+
+- `changes.ts`: 如果 issue 有 `worktreeDir`，使用该目录代替 `resolveProjectDir()`
+- 同时影响 `listChangedFiles`、`summarizeFileLines`、`isGitRepo` 的 cwd 参数
+
+### 步骤 6: 前端 + 共享类型
+
+- `Issue` 类型添加 `worktreeDir: string | null`
+- `CreateIssueDialog`: `useState(true)` 默认启用
+- `serializeIssue`: 输出 worktreeDir
+
+## 风险
+
+1. **迁移兼容性**: 已有 issues 的 `useWorktree=false` 不受新默认值影响
+2. **路径变更**: 旧路径 `.bitk/worktrees/` 下的 worktree 需要手动清理或忽略
+3. **Git 命令 cwd**: `removeWorktree` 的 cwd 必须是主仓库目录，新路径在 `data/` 下也能正常工作因为 git worktree remove 接受绝对路径
+4. **重启恢复**: 有了 DB 持久化的 worktreeDir，reconciler 可在启动时清理孤儿 worktree
+
+## 范围
+
+约 15 个文件变更，1 个新迁移文件。不改变 engine executor 接口，不影响前端路由。

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -1,7 +1,8 @@
 # Plan Index
 
-> Updated: 2026-03-01 06:00 UTC
+> Updated: 2026-03-02 17:00 UTC
 
+- [ ] **PLAN-005 重构 Worktree 系统** - task: `WT-001` - owner: claude - file: `docs/plan/PLAN-005.md`
 - [x] **PLAN-004 GitHub 风格项目文件浏览器** - task: `FILE-001` - owner: claude - file: `docs/plan/PLAN-004.md`
 
 - [x] **PLAN-002 Frontend bundle-size optimization for Shiki and terminal** - task: `ENG-006` - owner: codex - file: `docs/plan/PLAN-002.md`

--- a/docs/task/WT-001.md
+++ b/docs/task/WT-001.md
@@ -1,0 +1,24 @@
+# WT-001 重构 Worktree 系统
+
+- **status**: in_progress
+- **priority**: P1
+- **owner**: claude
+- **created**: 2026-03-02
+- **plan**: PLAN-005
+
+## 描述
+
+对 worktree 系统进行全面重构，解决 5 个核心问题：
+1. Worktree 目录位置不合理（当前在仓库内部）
+2. 缺少持久化 worktree 路径的数据库字段
+3. 创建任务默认未启用 worktree
+4. 状态转换时缺少 worktree 的清理/重建逻辑
+5. 文件变更跟踪未考虑 worktree 目录
+
+## 验收标准
+
+- [ ] Worktree 创建在 `data/worktrees/:projectId/:issueId/` 下
+- [ ] issues 表新增 `worktree_dir` 字段持久化路径
+- [ ] 创建 issue 默认 `useWorktree = true`
+- [ ] done 状态时清理 worktree；working 状态时重建
+- [ ] 文件变更 API 使用 worktree 目录

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -1,7 +1,8 @@
 # Task Index
 
-> Updated: 2026-03-01 06:00 UTC
+> Updated: 2026-03-02 17:00 UTC
 
+- [-] **WT-001 重构 Worktree 系统** `P1` - owner: claude - file: `docs/task/WT-001.md`
 - [x] **FILE-001 添加 GitHub 风格的项目文件浏览器** `P1` - owner: claude - file: `docs/task/FILE-001.md`
 
 - [x] **ENG-006 Optimize frontend bundle size and heavy chunks** `P1` - owner: codex - file: `docs/task/ENG-006.md`


### PR DESCRIPTION
## Summary

- **Deterministic worktree paths**: moved from `.bitk/worktrees/<issueId>` to `data/worktrees/<projectId>/<issueId>/`, enabling multi-project isolation and predictable path resolution via `resolveWorktreePath()`
- **Lifecycle cleanup**: worktrees are now cleaned up on done/cancel status transitions, idle GC, and process settle — with `worktreeBaseDir` threaded through `ManagedProcess` for proper `git worktree remove` from outside the repo
- **Default useWorktree to true**: `CreateIssueDialog` now enables worktree by default
- **Worktree management UI**: new Worktrees tab in Project Settings dialog listing existing worktrees with force-delete capability
- **Backend API**: `GET/DELETE /api/projects/:projectId/worktrees` for listing and removing worktrees
- **Fix duplicate i18n keys**: removed pre-existing `tabGeneral`/`tabModels` duplicates in en.json and zh.json

### Files changed (27 files, +830 / -145)

**Engine layer** — path refactor + worktreeBaseDir threading:
- `constants.ts`, `types.ts`, `register.ts`, `execute.ts`, `spawn.ts`, `restart.ts`, `settle.ts`, `gc.ts`, `cancel.ts`, `worktree.ts`, `utils/index.ts`, `engines/issue/index.ts`

**Routes** — cleanup on status change + new worktree API:
- `routes/issues/update.ts`, `routes/issues/changes.ts`, `routes/worktrees.ts`, `routes/api.ts`

**Frontend** — UI + hooks + API client:
- `ProjectSettingsDialog.tsx`, `CreateIssueDialog.tsx`, `use-kanban.ts`, `kanban-api.ts`, `en.json`, `zh.json`

**Tests & docs**:
- `test/worktree.test.ts`, `docs/plan/PLAN-005.md`, `docs/task/WT-001.md`, `docs/plan/index.md`, `docs/task/index.md`

## Test plan

- [x] 240 backend tests pass (`bun run test:api`)
- [x] 26 frontend tests pass (`bun run test:frontend`)
- [x] Lint clean (`bunx biome check .` — 0 errors)
- [ ] Manual: create issue with worktree enabled, verify worktree created at `data/worktrees/<projectId>/<issueId>/`
- [ ] Manual: complete issue → verify worktree auto-cleaned
- [ ] Manual: open Project Settings → Worktrees tab → verify list + delete