### PR TITLE
feat(ui): enhance chat input and fix dropdown selection

### DIFF
--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -155,7 +155,9 @@ export function AppSettingsDialog({
                   <Label>{t('settings.language')}</Label>
                   <Select
                     value={i18n.language}
-                    onValueChange={(value) => i18n.changeLanguage(value ?? undefined)}
+                    onValueChange={(value) =>
+                      i18n.changeLanguage(value ?? undefined)
+                    }
                   >
                     <SelectTrigger>
                       <SelectValue />

--- a/apps/frontend/src/components/DirectoryPicker.tsx
+++ b/apps/frontend/src/components/DirectoryPicker.tsx
@@ -102,9 +102,7 @@ export function DirectoryPicker({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange} disablePointerDismissal>
-      <DialogContent
-        className="max-w-[calc(100%-2rem)] md:max-w-md"
-      >
+      <DialogContent className="max-w-[calc(100%-2rem)] md:max-w-md">
         <DialogHeader>
           <div>
             <DialogTitle>{t('directory.browse')}</DialogTitle>

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -265,6 +265,7 @@ export function ChatBody({
       {/* Issue metadata bar — fixed above input */}
       <IssueDetail
         issue={issue}
+        projectId={projectId}
         status={STATUS_MAP.get(issue.statusId)}
         onUpdate={(fields) => updateIssue.mutate({ id: issueId, ...fields })}
         onDelete={handleDelete}
@@ -283,7 +284,6 @@ export function ChatBody({
         sessionStatus={issue.sessionStatus}
         statusId={issue.statusId}
         isThinking={isThinking}
-        useWorktree={issue.useWorktree}
         slashCommands={slashCommands}
         onMessageSent={(messageId, prompt, metadata) => {
           appendServerMessage(messageId, prompt, metadata)

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -138,6 +138,7 @@ export function ChatInput({
   const isSendingRef = useRef(false)
   const [textareaH, setTextareaH] = useState(36)
   const dragRef = useRef({ active: false, startY: 0, startH: 0 })
+  const dragCleanupRef = useRef<(() => void) | null>(null)
 
   const followUp = useFollowUpIssue(projectId ?? '')
   const changesSummary = useChangesSummary(projectId, issueId ?? undefined)
@@ -293,9 +294,12 @@ export function ChatInput({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       setSendError(msg)
-      // Restore input and files on failure
-      setInput(prompt)
-      setAttachedFiles(filesToSend)
+      // Restore input and files on failure — only if still on the same issue
+      const currentKey = issueId ? `bitk:draft:${issueId}` : null
+      if (currentKey === draftKey) {
+        setInput(prompt)
+        setAttachedFiles(filesToSend)
+      }
       setTimeout(() => setSendError(null), 5000)
     } finally {
       isSendingRef.current = false
@@ -372,6 +376,8 @@ export function ChatInput({
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
+      // Clean up any previous drag listeners (shouldn't happen, but be safe)
+      dragCleanupRef.current?.()
       dragRef.current = {
         active: true,
         startY: e.clientY,
@@ -384,16 +390,24 @@ export function ChatInput({
           Math.max(36, Math.min(480, dragRef.current.startH + delta)),
         )
       }
-      const onUp = () => {
+      const cleanup = () => {
         dragRef.current.active = false
         document.removeEventListener('mousemove', onMove)
-        document.removeEventListener('mouseup', onUp)
+        document.removeEventListener('mouseup', cleanup)
+        dragCleanupRef.current = null
       }
+      dragCleanupRef.current = cleanup
       document.addEventListener('mousemove', onMove)
-      document.addEventListener('mouseup', onUp)
+      document.addEventListener('mouseup', cleanup)
     },
     [textareaH],
   )
+  // Clean up drag listeners on unmount
+  useEffect(() => {
+    return () => {
+      dragCleanupRef.current?.()
+    }
+  }, [])
 
   return (
     <div className="shrink-0 w-full min-w-0 px-2 pb-2 relative z-30">

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -6,13 +6,7 @@ import {
   SlashSquare,
   X,
 } from 'lucide-react'
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { EngineIcon } from '@/components/EngineIcons'
 import { Button } from '@/components/ui/button'
@@ -111,14 +105,18 @@ export function ChatInput({
       } else {
         localStorage.removeItem(draftKey)
       }
-    } catch { /* quota exceeded — ignore */ }
+    } catch {
+      /* quota exceeded — ignore */
+    }
   }, [draftKey, input])
   // Restore draft when switching issues
   useEffect(() => {
     if (!draftKey) return
     try {
       setInput(localStorage.getItem(draftKey) ?? '')
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }, [draftKey])
   const [sendError, setSendError] = useState<string | null>(null)
   const [attachedFiles, setAttachedFiles] = useState<File[]>([])
@@ -226,7 +224,11 @@ export function ChatInput({
     setInput('')
     // Clear persisted draft
     if (draftKey) {
-      try { localStorage.removeItem(draftKey) } catch { /* ignore */ }
+      try {
+        localStorage.removeItem(draftKey)
+      } catch {
+        /* ignore */
+      }
     }
     setAttachedFiles([])
     setSendError(null)
@@ -367,7 +369,9 @@ export function ChatInput({
       const onMove = (ev: MouseEvent) => {
         if (!dragRef.current.active) return
         const delta = dragRef.current.startY - ev.clientY
-        setTextareaH(Math.max(36, Math.min(480, dragRef.current.startH + delta)))
+        setTextareaH(
+          Math.max(36, Math.min(480, dragRef.current.startH + delta)),
+        )
       }
       const onUp = () => {
         dragRef.current.active = false
@@ -691,7 +695,9 @@ function EngineInfo({ engineType }: { engineType: string }) {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger render={<Button variant="ghost" size="icon" title={engineName} />}>
+      <PopoverTrigger
+        render={<Button variant="ghost" size="icon" title={engineName} />}
+      >
         <EngineIcon engineType={engineType} className="size-4" />
       </PopoverTrigger>
       <PopoverContent
@@ -774,7 +780,11 @@ function CommandPicker({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger render={<Button variant="ghost" size="icon" title={t('chat.commands')} />}>
+      <PopoverTrigger
+        render={
+          <Button variant="ghost" size="icon" title={t('chat.commands')} />
+        }
+      >
         <SlashSquare className="size-4" />
       </PopoverTrigger>
       <PopoverContent side="top" align="start" className="w-[260px] p-0">

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -1,13 +1,18 @@
 import {
   FileText,
-  GitBranch,
   Image as ImageIcon,
   Loader2,
   Paperclip,
   SlashSquare,
   X,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { EngineIcon } from '@/components/EngineIcons'
 import { Button } from '@/components/ui/button'
@@ -67,7 +72,6 @@ export function ChatInput({
   sessionStatus,
   statusId,
   isThinking = false,
-  useWorktree = false,
   onMessageSent,
   slashCommands = [],
 }: {
@@ -81,7 +85,6 @@ export function ChatInput({
   sessionStatus?: SessionStatus | null
   statusId?: string
   isThinking?: boolean
-  useWorktree?: boolean
   onMessageSent?: (
     messageId: string,
     prompt: string,
@@ -90,7 +93,33 @@ export function ChatInput({
   slashCommands?: string[]
 }) {
   const { t } = useTranslation()
-  const [input, setInput] = useState('')
+  const draftKey = issueId ? `bitk:draft:${issueId}` : null
+  const [input, setInput] = useState(() => {
+    if (!draftKey) return ''
+    try {
+      return localStorage.getItem(draftKey) ?? ''
+    } catch {
+      return ''
+    }
+  })
+  // Persist draft to localStorage on change
+  useEffect(() => {
+    if (!draftKey) return
+    try {
+      if (input) {
+        localStorage.setItem(draftKey, input)
+      } else {
+        localStorage.removeItem(draftKey)
+      }
+    } catch { /* quota exceeded — ignore */ }
+  }, [draftKey, input])
+  // Restore draft when switching issues
+  useEffect(() => {
+    if (!draftKey) return
+    try {
+      setInput(localStorage.getItem(draftKey) ?? '')
+    } catch { /* ignore */ }
+  }, [draftKey])
   const [sendError, setSendError] = useState<string | null>(null)
   const [attachedFiles, setAttachedFiles] = useState<File[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
@@ -98,6 +127,8 @@ export function ChatInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const isSendingRef = useRef(false)
+  const [textareaH, setTextareaH] = useState(36)
+  const dragRef = useRef({ active: false, startY: 0, startH: 0 })
 
   const followUp = useFollowUpIssue(projectId ?? '')
   const changesSummary = useChangesSummary(projectId, issueId ?? undefined)
@@ -193,11 +224,11 @@ export function ChatInput({
     const prompt = normalizedPrompt
     const filesToSend = [...attachedFiles]
     setInput('')
-    setAttachedFiles([])
-    // Reset textarea height
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto'
+    // Clear persisted draft
+    if (draftKey) {
+      try { localStorage.removeItem(draftKey) } catch { /* ignore */ }
     }
+    setAttachedFiles([])
     setSendError(null)
     try {
       const isTodo = statusId === 'todo'
@@ -249,7 +280,8 @@ export function ChatInput({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       setSendError(msg)
-      // Restore files on failure
+      // Restore input and files on failure
+      setInput(prompt)
       setAttachedFiles(filesToSend)
       setTimeout(() => setSendError(null), 5000)
     } finally {
@@ -259,10 +291,7 @@ export function ChatInput({
 
   const selectSlashCommand = useCallback((cmd: string) => {
     setInput(cmd)
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto'
-      textareaRef.current.focus()
-    }
+    textareaRef.current?.focus()
   }, [])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -274,11 +303,7 @@ export function ChatInput({
 
   const handleInput = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const val = e.target.value
-      setInput(val)
-      const el = e.target
-      el.style.height = 'auto'
-      el.style.height = `${Math.min(el.scrollHeight, 120)}px`
+      setInput(e.target.value)
     },
     [],
   )
@@ -331,8 +356,32 @@ export function ChatInput({
     [addFiles],
   )
 
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      dragRef.current = {
+        active: true,
+        startY: e.clientY,
+        startH: textareaH,
+      }
+      const onMove = (ev: MouseEvent) => {
+        if (!dragRef.current.active) return
+        const delta = dragRef.current.startY - ev.clientY
+        setTextareaH(Math.max(36, Math.min(480, dragRef.current.startH + delta)))
+      }
+      const onUp = () => {
+        dragRef.current.active = false
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+      }
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+    },
+    [textareaH],
+  )
+
   return (
-    <div className="shrink-0 w-full min-w-0 px-4 pb-2 relative z-30">
+    <div className="shrink-0 w-full min-w-0 px-2 pb-2 relative z-30">
       <div
         className={`rounded-xl border bg-card/80 backdrop-blur-sm shadow-sm transition-all duration-200 focus-within:border-border focus-within:shadow-md ${
           isDragOver
@@ -343,6 +392,14 @@ export function ChatInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
+        {/* Resize handle */}
+        <div
+          onMouseDown={handleResizeStart}
+          className="flex items-center justify-center h-2 cursor-ns-resize group/resize"
+        >
+          <div className="w-8 h-0.5 rounded-full bg-border/30 group-hover/resize:bg-border/60 transition-colors" />
+        </div>
+
         {/* Drag overlay hint */}
         {isDragOver ? (
           <div className="flex items-center justify-center py-4 text-xs text-primary font-medium">
@@ -351,7 +408,7 @@ export function ChatInput({
         ) : null}
 
         {/* Status bar */}
-        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/30">
+        <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border/30">
           <button
             type="button"
             onClick={onToggleDiff}
@@ -384,21 +441,18 @@ export function ChatInput({
                 onChange={setSelectedModel}
               />
             ) : null}
-            {useWorktree && projectId && issueId ? (
-              <WorktreeIndicator projectId={projectId} issueId={issueId} />
-            ) : null}
           </div>
         </div>
 
         {/* Error banner */}
         {sendError ? (
-          <div className="mx-3 mt-2 rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
+          <div className="mx-2 mt-2 rounded-lg bg-destructive/10 border border-destructive/20 px-2 py-2 text-xs text-destructive">
             {sendError}
           </div>
         ) : null}
 
         {/* Textarea — shadcn Textarea, style overrides to match original */}
-        <div className="px-3 py-2.5">
+        <div className="px-2 py-2">
           <Textarea
             ref={textareaRef}
             value={input}
@@ -419,13 +473,14 @@ export function ChatInput({
                 : t('chat.placeholder')
             }
             rows={1}
-            className="w-full bg-transparent text-base md:text-sm resize-none outline-none border-none shadow-none placeholder:text-muted-foreground/40 leading-relaxed focus-visible:ring-0"
+            style={{ height: `${textareaH}px` }}
+            className="w-full bg-transparent text-base md:text-sm resize-none outline-none border-none shadow-none placeholder:text-muted-foreground/40 leading-relaxed focus-visible:ring-0 overflow-y-auto"
           />
         </div>
 
         {/* File preview bar — below textarea */}
         {attachedFiles.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5 px-3 pb-1.5">
+          <div className="flex flex-wrap gap-1.5 px-2 pb-1.5">
             {attachedFiles.map((file, idx) => (
               <div
                 key={`${file.name}-${file.size}`}
@@ -467,7 +522,7 @@ export function ChatInput({
         />
 
         {/* Toolbar */}
-        <div className="flex items-center justify-between px-2.5 pb-2.5 pt-0.5">
+        <div className="flex items-center justify-between px-2 pb-2 pt-0.5">
           <div className="flex items-center gap-0.5">
             {engineType ? <EngineInfo engineType={engineType} /> : null}
             <Button
@@ -701,63 +756,6 @@ function ModelSelect({
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
-  )
-}
-
-// ─── WorktreeIndicator ────────────────────────────────────────────────────────
-
-function WorktreeIndicator({
-  projectId,
-  issueId,
-}: {
-  projectId: string
-  issueId: string
-}) {
-  const { t } = useTranslation()
-  const worktreePath = `data/worktrees/${projectId}/${issueId}`
-  const branch = `bitk/${issueId}`
-
-  return (
-    <Popover>
-      <PopoverTrigger
-        render={
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 px-2 text-xs text-muted-foreground gap-1"
-            title={t('chat.worktree')}
-          />
-        }
-      >
-        <GitBranch className="h-3 w-3" />
-      </PopoverTrigger>
-      <PopoverContent
-        side="top"
-        align="end"
-        className="w-auto max-w-[360px] px-3 py-2.5 text-xs space-y-1.5"
-      >
-        <div className="flex items-center gap-1.5 text-muted-foreground">
-          <GitBranch className="h-3 w-3 shrink-0" />
-          <span className="font-medium text-foreground">
-            {t('chat.worktree')}
-          </span>
-        </div>
-        <div className="space-y-1 text-muted-foreground">
-          <div className="flex items-start gap-2">
-            <span className="shrink-0">{t('chat.worktreeBranch')}:</span>
-            <code className="font-mono text-foreground/80 break-all">
-              {branch}
-            </code>
-          </div>
-          <div className="flex items-start gap-2">
-            <span className="shrink-0">{t('chat.worktreePath')}:</span>
-            <code className="font-mono text-foreground/80 break-all">
-              {worktreePath}
-            </code>
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
   )
 }
 

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -96,8 +96,28 @@ export function ChatInput({
       return ''
     }
   })
-  // Persist draft to localStorage on change
+  // Guard: skip one persist cycle after draftKey changes to avoid
+  // writing stale input (from previous issue) into the new key.
+  const skipPersistRef = useRef(false)
+  // Restore draft when switching issues
   useEffect(() => {
+    skipPersistRef.current = true
+    if (!draftKey) {
+      setInput('')
+      return
+    }
+    try {
+      setInput(localStorage.getItem(draftKey) ?? '')
+    } catch {
+      setInput('')
+    }
+  }, [draftKey])
+  // Persist draft to localStorage on input change
+  useEffect(() => {
+    if (skipPersistRef.current) {
+      skipPersistRef.current = false
+      return
+    }
     if (!draftKey) return
     try {
       if (input) {
@@ -109,15 +129,6 @@ export function ChatInput({
       /* quota exceeded — ignore */
     }
   }, [draftKey, input])
-  // Restore draft when switching issues
-  useEffect(() => {
-    if (!draftKey) return
-    try {
-      setInput(localStorage.getItem(draftKey) ?? '')
-    } catch {
-      /* ignore */
-    }
-  }, [draftKey])
   const [sendError, setSendError] = useState<string | null>(null)
   const [attachedFiles, setAttachedFiles] = useState<File[]>([])
   const [isDragOver, setIsDragOver] = useState(false)

--- a/apps/frontend/src/components/issue-detail/IssueDetail.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueDetail.tsx
@@ -1,9 +1,10 @@
-import { Bug, Calendar, ChevronDown, Trash2 } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { Bug, ChevronDown, GitBranch, Trash2 } from 'lucide-react'
+import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PriorityIcon } from '@/components/kanban/PriorityIcon'
 import { Button } from '@/components/ui/button'
 import { useClickOutside } from '@/hooks/use-click-outside'
+import { useProjectWorktrees } from '@/hooks/use-kanban'
 import { tPriority, tStatus } from '@/lib/i18n-utils'
 import type { StatusDefinition, StatusId } from '@/lib/statuses'
 import { STATUSES } from '@/lib/statuses'
@@ -17,24 +18,16 @@ export const badgeBase =
 const badgeButtonBase =
   'h-[22px] rounded-full px-2 text-[11px] leading-none font-medium gap-1'
 
-function formatDate(iso: string, lang: string) {
-  const d = new Date(iso)
-  return d.toLocaleDateString(lang === 'zh' ? 'zh-CN' : 'en-US', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
-
 export function IssueDetail({
   issue,
+  projectId,
   status,
   onUpdate,
   onDelete,
   isDeleting = false,
 }: {
   issue: Issue
+  projectId?: string
   status?: StatusDefinition
   onUpdate?: (
     fields: Partial<Pick<Issue, 'statusId' | 'priority' | 'devMode'>>,
@@ -42,7 +35,18 @@ export function IssueDetail({
   onDelete?: () => void
   isDeleting?: boolean
 }) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
+  const [showWorktree, setShowWorktree] = useState(false)
+  const worktreeRef = useRef<HTMLDivElement>(null)
+  useClickOutside(worktreeRef, showWorktree, () => setShowWorktree(false))
+
+  const { data: worktrees } = useProjectWorktrees(projectId ?? '')
+  const worktreeEntry = useMemo(
+    () => worktrees?.find((w) => w.issueId === issue.id),
+    [worktrees, issue.id],
+  )
+  const worktreePath = worktreeEntry?.path ?? ''
+  const worktreeBranch = worktreeEntry?.branch ?? (issue.id ? `bitk/${issue.id}` : '')
 
   return (
     <div className="shrink-0 relative z-20 flex items-center gap-1.5 px-4 py-1.5 border-t border-border/40 bg-muted/20">
@@ -74,7 +78,7 @@ export function IssueDetail({
         </Button>
       ) : null}
 
-      {/* Dev mode toggle + Created (right side) */}
+      {/* Dev mode toggle + Worktree (right side) */}
       <div className="ml-auto flex items-center gap-1.5">
         <Button
           type="button"
@@ -91,12 +95,36 @@ export function IssueDetail({
           <Bug className="h-3 w-3" />
           <span>{t('issue.dev')}</span>
         </Button>
-        <span
-          className={`${badgeBase} border-border/50 bg-muted/20 text-muted-foreground/80`}
-        >
-          <Calendar className="h-3 w-3" />
-          {formatDate(issue.createdAt, i18n.language)}
-        </span>
+        {issue.useWorktree ? (
+          <div ref={worktreeRef} className="relative flex">
+            <button
+              type="button"
+              onClick={() => setShowWorktree((v) => !v)}
+              className={`${badgeBase} cursor-pointer transition-colors border-emerald-400/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 hover:opacity-80`}
+            >
+              <GitBranch className="h-3 w-3" />
+              {t('chat.worktree')}
+            </button>
+            {showWorktree ? (
+              <div className="absolute right-0 bottom-full mb-1.5 z-50 min-w-[240px] rounded-xl border border-border/60 bg-popover/95 backdrop-blur-sm py-2 px-3 shadow-xl text-xs text-popover-foreground space-y-1.5">
+                <div className="flex items-center gap-1.5 text-muted-foreground">
+                  <GitBranch className="h-3 w-3 shrink-0" />
+                  <span className="font-medium text-foreground">{t('chat.worktree')}</span>
+                </div>
+                <div className="space-y-1 text-muted-foreground">
+                  <div className="flex items-start gap-2">
+                    <span className="shrink-0">{t('chat.worktreeBranch')}:</span>
+                    <code className="font-mono text-foreground/80 break-all">{worktreeBranch}</code>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="shrink-0">{t('chat.worktreePath')}:</span>
+                    <code className="font-mono text-foreground/80 break-all">{worktreePath}</code>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/issue-detail/IssueDetail.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueDetail.tsx
@@ -46,7 +46,8 @@ export function IssueDetail({
     [worktrees, issue.id],
   )
   const worktreePath = worktreeEntry?.path ?? ''
-  const worktreeBranch = worktreeEntry?.branch ?? (issue.id ? `bitk/${issue.id}` : '')
+  const worktreeBranch =
+    worktreeEntry?.branch ?? (issue.id ? `bitk/${issue.id}` : '')
 
   return (
     <div className="shrink-0 relative z-20 flex items-center gap-1.5 px-4 py-1.5 border-t border-border/40 bg-muted/20">
@@ -109,16 +110,24 @@ export function IssueDetail({
               <div className="absolute right-0 bottom-full mb-1.5 z-50 min-w-[240px] rounded-xl border border-border/60 bg-popover/95 backdrop-blur-sm py-2 px-3 shadow-xl text-xs text-popover-foreground space-y-1.5">
                 <div className="flex items-center gap-1.5 text-muted-foreground">
                   <GitBranch className="h-3 w-3 shrink-0" />
-                  <span className="font-medium text-foreground">{t('chat.worktree')}</span>
+                  <span className="font-medium text-foreground">
+                    {t('chat.worktree')}
+                  </span>
                 </div>
                 <div className="space-y-1 text-muted-foreground">
                   <div className="flex items-start gap-2">
-                    <span className="shrink-0">{t('chat.worktreeBranch')}:</span>
-                    <code className="font-mono text-foreground/80 break-all">{worktreeBranch}</code>
+                    <span className="shrink-0">
+                      {t('chat.worktreeBranch')}:
+                    </span>
+                    <code className="font-mono text-foreground/80 break-all">
+                      {worktreeBranch}
+                    </code>
                   </div>
                   <div className="flex items-start gap-2">
                     <span className="shrink-0">{t('chat.worktreePath')}:</span>
-                    <code className="font-mono text-foreground/80 break-all">{worktreePath}</code>
+                    <code className="font-mono text-foreground/80 break-all">
+                      {worktreePath}
+                    </code>
                   </div>
                 </div>
               </div>

--- a/apps/frontend/src/components/issue-detail/SubIssueDialog.tsx
+++ b/apps/frontend/src/components/issue-detail/SubIssueDialog.tsx
@@ -17,10 +17,7 @@ export function SubIssueDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange} disablePointerDismissal>
-      <DialogContent
-        className="md:max-w-[580px]"
-        aria-describedby={undefined}
-      >
+      <DialogContent className="md:max-w-[580px]" aria-describedby={undefined}>
         <DialogTitle>{t('issue.createSubIssue')}</DialogTitle>
 
         <CreateIssueForm

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -591,9 +591,7 @@ function PermissionSelect({
         }
       >
         <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        <span className="truncate">
-          {t(`createIssue.perm.${current.id}`)}
-        </span>
+        <span className="truncate">{t(`createIssue.perm.${current.id}`)}</span>
         <ChevronDown className="h-3 w-3 text-muted-foreground ml-auto shrink-0" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[140px]">

--- a/apps/frontend/src/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/src/components/ui/dropdown-menu.tsx
@@ -75,11 +75,22 @@ function DropdownMenuItem({
   className,
   inset,
   variant = "default",
+  onSelect,
+  onClick,
   ...props
 }: MenuPrimitive.Item.Props & {
   inset?: boolean
   variant?: "default" | "destructive"
+  /** Radix-compatible onSelect — mapped to onClick for base-ui */
+  onSelect?: (() => void) | ((event: React.MouseEvent) => void)
 }) {
+  const handleClick: MenuPrimitive.Item.Props['onClick'] = onSelect
+    ? (e) => {
+        onClick?.(e)
+        ;(onSelect as (event?: unknown) => void)(e)
+      }
+    : onClick
+
   return (
     <MenuPrimitive.Item
       data-slot="dropdown-menu-item"
@@ -89,6 +100,7 @@ function DropdownMenuItem({
         "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className
       )}
+      onClick={handleClick}
       {...props}
     />
   )

--- a/apps/frontend/src/hooks/use-mobile.ts
+++ b/apps/frontend/src/hooks/use-mobile.ts
@@ -1,4 +1,4 @@
-import * as React from "react"
+import * as React from 'react'
 
 const MOBILE_BREAKPOINT = 768
 
@@ -10,9 +10,9 @@ export function useIsMobile() {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
-    mql.addEventListener("change", onChange)
+    mql.addEventListener('change', onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
+    return () => mql.removeEventListener('change', onChange)
   }, [])
 
   return !!isMobile

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -73,10 +73,7 @@ const config = defineConfig(() => {
               return 'vendor-router'
             if (pkg === '@tanstack/react-query') return 'vendor-query'
             if (pkg.startsWith('@dnd-kit/')) return 'vendor-dnd'
-            if (
-              pkg.startsWith('@base-ui/') ||
-              pkg === 'lucide-react'
-            )
+            if (pkg.startsWith('@base-ui/') || pkg === 'lucide-react')
               return 'vendor-ui'
             if (pkg === '@pierre/diffs') return 'vendor-diff'
             if (pkg === 'shiki' || pkg.startsWith('@shikijs/'))


### PR DESCRIPTION
## Summary

- **ChatInput drag-to-resize**: Add a drag handle at the top of ChatInput for resizing textarea height (36–480px range)
- **Draft persistence**: Save unsent chat input to localStorage per issue; restore on switch or page reload; clear on successful send; restore on failure
- **Padding reduction**: Tighten ChatInput left/right padding (`px-4` → `px-2`, etc.)
- **Worktree indicator**: Replace date badge in IssueDetail with a clickable worktree badge (green, only shown when `useWorktree=true`); displays full absolute path and branch from the worktrees API
- **Fix DropdownMenuItem onSelect**: Map Radix-compatible `onSelect` to base-ui `onClick` — fixes all dropdown selections broken after the base-ui migration (create dialog status/priority/engine/model/permission, ChatInput mode/model/busy-action)
- **Remove duplicate WorktreeIndicator** from ChatInput (now handled by IssueDetail)

## Test plan

- [ ] Open create issue dialog, verify status/priority/engine/model/permission dropdowns all work
- [ ] Open an issue chat, verify mode and model selects in ChatInput status bar work
- [ ] Type in ChatInput, refresh page — draft should restore
- [ ] Send a message — draft should clear
- [ ] Drag the resize handle on ChatInput — textarea height should change
- [ ] Open an issue with `useWorktree=true` — verify green worktree badge appears next to dev mode
- [ ] Click worktree badge — verify full absolute path and branch are shown