### PR TITLE
feat: engine stall detection and Claude SDK control protocol

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -44,24 +44,13 @@ const CLAUDE_MODELS: EngineModel[] = [
     isDefault: false,
   },
   { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', isDefault: true },
-  { id: 'claude-opus-4-6[1m]', name: 'Claude Opus 4.6 (1M)', isDefault: false },
+  {
+    id: 'claude-opus-4-6[1m]',
+    name: 'Claude Opus 4.6 (1M)',
+    isDefault: false,
+  },
+  { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', isDefault: false },
 ]
-
-function applyPermissionArgs(
-  builder: CommandBuilder,
-  options: Pick<SpawnOptions, 'permissionMode' | 'model'>,
-) {
-  if (options.permissionMode === 'auto') {
-    // Default to skip-permissions since AskUserQuestion is disabled —
-    // plan mode would stall waiting for user approval that never comes.
-    builder.param('--dangerously-skip-permissions')
-    return
-  }
-
-  if (options.permissionMode === 'plan') {
-    builder.param('--permission-mode', 'plan')
-  }
-}
 
 export class ClaudeCodeExecutor implements EngineExecutor {
   readonly engineType = 'claude-code' as const
@@ -76,163 +65,31 @@ export class ClaudeCodeExecutor implements EngineExecutor {
     options: SpawnOptions,
     env: ExecutionEnv,
   ): Promise<SpawnedProcess> {
-    const builder = CommandBuilder.create(BASE_COMMAND)
-      .params(['-p', '--output-format=stream-json', '--verbose', '--no-chrome'])
-      .param('--input-format', 'stream-json')
-      .env('NPM_CONFIG_LOGLEVEL', 'error')
-      .env('IS_SANDBOX', '1')
-      .cwd(options.workingDir)
+    const builder = this.createBaseBuilder(options, env)
 
     if (options.externalSessionId) {
       builder.param('--session-id', options.externalSessionId)
     }
-
-    if (options.model && options.model !== 'auto') {
-      builder.param('--model', options.model)
-    }
-
-    applyPermissionArgs(builder, options)
-
     if (options.agent) {
       builder.param('--agent', options.agent)
     }
 
-    // Disable interactive questions — the web UI cannot respond to AskUserQuestion
-    builder.param('--disallowedTools', 'AskUserQuestion')
-
-    // Apply environment variables
-    if (options.env) {
-      builder.envs(options.env)
-    }
-    if (env.vars) {
-      builder.envs(env.vars)
-    }
-
-    const cmd = builder.build()
-    logger.debug(
-      {
-        issueId: env.issueId,
-        cwd: cmd.cwd ?? options.workingDir,
-        program: cmd.program,
-        args: cmd.args,
-      },
-      'claude_spawn_command',
-    )
-
-    const proc = Bun.spawn([cmd.program, ...cmd.args], {
-      cwd: cmd.cwd ?? options.workingDir,
-      stdin: 'pipe',
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: safeEnv(cmd.env),
-    })
-
-    // Create protocol handler to manage bidirectional control protocol
-    // (tool permission requests, hook callbacks, graceful interruption)
-    const handler = new ClaudeProtocolHandler(proc.stdin)
-    handler.sendUserMessage(options.prompt)
-    logger.debug(
-      {
-        issueId: env.issueId,
-        pid: (proc as { pid?: number }).pid,
-        mode: 'spawn',
-        promptChars: options.prompt.length,
-      },
-      'claude_process_spawned',
-    )
-
-    // Wrap stdout to intercept control_request messages
-    const filteredStdout = handler.wrapStdout(
-      proc.stdout as ReadableStream<Uint8Array>,
-    )
-
-    return {
-      subprocess: proc,
-      stdout: filteredStdout,
-      stderr: proc.stderr as ReadableStream<Uint8Array>,
-      cancel: () => handler.interrupt(),
-      protocolHandler: handler,
-      spawnCommand: [cmd.program, ...cmd.args].join(' '),
-    }
+    return this.spawnProcess(builder, options, env, 'spawn')
   }
 
   async spawnFollowUp(
     options: FollowUpOptions,
     env: ExecutionEnv,
   ): Promise<SpawnedProcess> {
-    const builder = CommandBuilder.create(BASE_COMMAND)
-      .params(['-p', '--output-format=stream-json', '--verbose', '--no-chrome'])
-      .param('--input-format', 'stream-json')
+    const builder = this.createBaseBuilder(options, env)
       .param('--resume', options.sessionId)
-      .env('NPM_CONFIG_LOGLEVEL', 'error')
-      .env('IS_SANDBOX', '1')
-      .cwd(options.workingDir)
+      .param('--replay-user-messages')
 
     if (options.resetToMessageId) {
       builder.param('--resume-session-at', options.resetToMessageId)
     }
 
-    if (options.model && options.model !== 'auto') {
-      builder.param('--model', options.model)
-    }
-
-    applyPermissionArgs(builder, options)
-
-    // Disable interactive questions for follow-up turns too.
-    builder.param('--disallowedTools', 'AskUserQuestion')
-
-    if (options.env) {
-      builder.envs(options.env)
-    }
-    if (env.vars) {
-      builder.envs(env.vars)
-    }
-
-    const cmd = builder.build()
-    logger.debug(
-      {
-        issueId: env.issueId,
-        cwd: cmd.cwd ?? options.workingDir,
-        program: cmd.program,
-        args: cmd.args,
-        resumeSessionId: options.sessionId,
-      },
-      'claude_followup_command',
-    )
-
-    const proc = Bun.spawn([cmd.program, ...cmd.args], {
-      cwd: cmd.cwd ?? options.workingDir,
-      stdin: 'pipe',
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: safeEnv(cmd.env),
-    })
-
-    // Create protocol handler for follow-up session
-    const handler = new ClaudeProtocolHandler(proc.stdin)
-    handler.sendUserMessage(options.prompt)
-    logger.debug(
-      {
-        issueId: env.issueId,
-        pid: (proc as { pid?: number }).pid,
-        mode: 'followup',
-        promptChars: options.prompt.length,
-      },
-      'claude_process_spawned',
-    )
-
-    const filteredStdout = handler.wrapStdout(
-      proc.stdout as ReadableStream<Uint8Array>,
-    )
-
-    return {
-      subprocess: proc,
-      stdout: filteredStdout,
-      stderr: proc.stderr as ReadableStream<Uint8Array>,
-      cancel: () => handler.interrupt(),
-      protocolHandler: handler,
-      spawnCommand: [cmd.program, ...cmd.args].join(' '),
-    }
+    return this.spawnProcess(builder, options, env, 'followup')
   }
 
   async cancel(spawnedProcess: SpawnedProcess): Promise<void> {
@@ -363,5 +220,115 @@ export class ClaudeCodeExecutor implements EngineExecutor {
 
   createNormalizer(filterRules: WriteFilterRule[]) {
     return new ClaudeLogNormalizer(filterRules)
+  }
+
+  // ---------- Private ----------
+
+  /**
+   * Build the common CommandBuilder shared by spawn and spawnFollowUp.
+   * Adds all standard flags, model, env vars, and permission-prompt-tool=stdio
+   * (permission mode is set via SDK control protocol, not CLI flags).
+   */
+  private createBaseBuilder(
+    options: SpawnOptions,
+    env: ExecutionEnv,
+  ): CommandBuilder {
+    const builder = CommandBuilder.create(BASE_COMMAND)
+      .params(['-p', '--output-format=stream-json', '--verbose', '--no-chrome'])
+      .param('--input-format', 'stream-json')
+      // Enable SDK-based permission handling via stdin/stdout control protocol
+      // instead of CLI-level flags like --dangerously-skip-permissions.
+      .param('--permission-prompt-tool', 'stdio')
+      // Include partial messages for better streaming experience
+      .param('--include-partial-messages')
+      .env('NPM_CONFIG_LOGLEVEL', 'error')
+      .env('IS_SANDBOX', '1')
+      .cwd(options.workingDir)
+
+    if (options.model && options.model !== 'auto') {
+      builder.param('--model', options.model)
+    }
+
+    // Disable interactive questions — the web UI cannot respond to AskUserQuestion
+    builder.param('--disallowedTools', 'AskUserQuestion')
+
+    if (options.env) {
+      builder.envs(options.env)
+    }
+    if (env.vars) {
+      builder.envs(env.vars)
+    }
+
+    return builder
+  }
+
+  /**
+   * Spawn a Bun subprocess, create the protocol handler, perform the SDK
+   * init handshake (initialize → set_permission_mode → send_user_message),
+   * and return the SpawnedProcess.
+   */
+  private spawnProcess(
+    builder: CommandBuilder,
+    options: SpawnOptions,
+    env: ExecutionEnv,
+    mode: 'spawn' | 'followup',
+  ): SpawnedProcess {
+    const cmd = builder.build()
+    logger.debug(
+      {
+        issueId: env.issueId,
+        cwd: cmd.cwd ?? options.workingDir,
+        program: cmd.program,
+        args: cmd.args,
+        ...(mode === 'followup' && 'sessionId' in options
+          ? { resumeSessionId: (options as FollowUpOptions).sessionId }
+          : {}),
+      },
+      `claude_${mode}_command`,
+    )
+
+    const proc = Bun.spawn([cmd.program, ...cmd.args], {
+      cwd: cmd.cwd ?? options.workingDir,
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: safeEnv(cmd.env),
+    })
+
+    // Create protocol handler to manage bidirectional control protocol
+    // (tool permission requests, hook callbacks, graceful interruption)
+    const handler = new ClaudeProtocolHandler(proc.stdin)
+
+    // SDK init handshake: initialize → set_permission_mode → user message
+    handler.initialize()
+    handler.setPermissionMode(options.permissionMode ?? 'auto')
+    handler.sendUserMessage(options.prompt)
+
+    logger.debug(
+      {
+        issueId: env.issueId,
+        pid: (proc as { pid?: number }).pid,
+        mode,
+        promptChars: options.prompt.length,
+        permissionMode: options.permissionMode ?? 'auto',
+      },
+      'claude_process_spawned',
+    )
+
+    // Wrap stdout to intercept control_request messages
+    const filteredStdout = handler.wrapStdout(
+      proc.stdout as ReadableStream<Uint8Array>,
+    )
+
+    return {
+      subprocess: proc,
+      stdout: filteredStdout,
+      stderr: proc.stderr as ReadableStream<Uint8Array>,
+      cancel: () => {
+        void handler.interrupt().catch(() => {})
+      },
+      protocolHandler: handler,
+      spawnCommand: [cmd.program, ...cmd.args].join(' '),
+    }
   }
 }

--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -97,9 +97,9 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       { pid: (spawnedProcess.subprocess as { pid?: number }).pid },
       'claude_cancel_requested',
     )
-    // Send graceful interrupt via protocol handler first
+    // Send graceful interrupt via protocol handler (fire-and-forget write to stdin)
     if (spawnedProcess.protocolHandler) {
-      await spawnedProcess.protocolHandler.interrupt()
+      spawnedProcess.protocolHandler.interrupt()
     } else {
       spawnedProcess.cancel()
     }
@@ -324,9 +324,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       subprocess: proc,
       stdout: filteredStdout,
       stderr: proc.stderr as ReadableStream<Uint8Array>,
-      cancel: () => {
-        void handler.interrupt().catch(() => {})
-      },
+      cancel: () => handler.interrupt(),
       protocolHandler: handler,
       spawnCommand: [cmd.program, ...cmd.args].join(' '),
     }

--- a/apps/api/src/engines/executors/claude/protocol.ts
+++ b/apps/api/src/engines/executors/claude/protocol.ts
@@ -1,5 +1,6 @@
 import type { FileSink } from 'bun'
 import { ulid } from 'ulid'
+import type { PermissionPolicy } from '@/engines/types'
 import { logger } from '@/logger'
 
 const MAX_IO_LOG_CHARS = 1200
@@ -89,6 +90,10 @@ interface ControlRequest {
 export class ClaudeProtocolHandler {
   private stdin: FileSink
   private closed = false
+  /** Called when a control_request is received, signaling the process is alive.
+   *  Used by the engine layer to update lastActivityAt during tool execution
+   *  (when no normal stdout entries are emitted). */
+  onActivity?: () => void
 
   constructor(stdin: FileSink) {
     this.stdin = stdin
@@ -194,6 +199,10 @@ export class ClaudeProtocolHandler {
           'claude_protocol_control_request',
         )
       }
+      // Signal activity so the stall detector knows the process is alive
+      // (control_requests are filtered from the downstream stdout stream,
+      // so consumeStream's lastActivityAt update doesn't fire for them).
+      this.onActivity?.()
       this.handleControlRequest(request_id, request)
     } catch (error) {
       logger.warn({ error }, 'Failed to parse control request')
@@ -255,6 +264,38 @@ export class ClaudeProtocolHandler {
     })
   }
 
+  /**
+   * Send SDK initialize control request.
+   * Tells Claude Code we speak the stream-json SDK protocol and support
+   * tool_approval (can_use_tool / hook_callback control requests).
+   */
+  initialize(): void {
+    this.writeJson({
+      type: 'control_request',
+      request_id: ulid(),
+      request: {
+        subtype: 'initialize',
+      },
+    })
+  }
+
+  /**
+   * Set the SDK permission mode.
+   * This replaces CLI-level permission flags (e.g. --dangerously-skip-permissions)
+   * with a proper SDK control request.
+   */
+  setPermissionMode(policy: PermissionPolicy): void {
+    const sdkMode = mapPermissionMode(policy)
+    this.writeJson({
+      type: 'control_request',
+      request_id: ulid(),
+      request: {
+        subtype: 'set_permission_mode',
+        mode: sdkMode,
+      },
+    })
+  }
+
   sendUserMessage(content: string): void {
     this.writeJson({
       type: 'user',
@@ -293,7 +334,28 @@ export class ClaudeProtocolHandler {
       this.stdin.write(`${json}\n`)
       this.stdin.flush?.()
     } catch (error) {
-      logger.warn({ error }, 'Failed to write to Claude stdin')
+      logger.error({ error }, 'stdin_write_failed_closing')
+      // Close stdin so Claude Code detects broken pipe and exits,
+      // rather than waiting forever for a response that was never delivered.
+      this.close()
     }
+  }
+}
+
+// ---------- Helpers ----------
+
+/** Map our PermissionPolicy to Claude SDK permission mode string. */
+function mapPermissionMode(
+  policy: PermissionPolicy,
+): 'bypassPermissions' | 'plan' | 'default' {
+  switch (policy) {
+    case 'auto':
+      return 'bypassPermissions'
+    case 'plan':
+      return 'plan'
+    case 'supervised':
+      return 'default'
+    default:
+      return 'bypassPermissions'
   }
 }

--- a/apps/api/src/engines/executors/claude/protocol.ts
+++ b/apps/api/src/engines/executors/claude/protocol.ts
@@ -303,7 +303,8 @@ export class ClaudeProtocolHandler {
     })
   }
 
-  async interrupt(): Promise<void> {
+  /** Fire-and-forget: writes the interrupt request to stdin synchronously. */
+  interrupt(): void {
     this.writeJson({
       type: 'control_request',
       request_id: ulid(),

--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -1,9 +1,11 @@
 export const MAX_LOG_ENTRIES = 10000
 export const AUTO_CLEANUP_DELAY_MS = 5 * 60 * 1000 // 5 minutes
 export const MAX_AUTO_RETRIES = 1
-export const GC_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
+// Worst-case stall-to-kill: STREAM_STALL_TIMEOUT_MS + GC_INTERVAL_MS + STALL_PROBE_GRACE_MS + GC_INTERVAL_MS ≈ 9 min
+export const GC_INTERVAL_MS = 60 * 1000 // 1 minute — frequent stall detection
 export const MAX_CONCURRENT_EXECUTIONS =
   Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
 export const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
-export const STREAM_STALL_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes — kill process if no stdout/stderr activity
+export const STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes — send interrupt probe if no stdout/stderr activity
+export const STALL_PROBE_GRACE_MS = 2 * 60 * 1000 // 2 minutes — kill process if no response after interrupt probe
 export const WORKTREE_DIR = 'data/worktrees'

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -5,7 +5,11 @@ import {
 } from '@/engines/engine-store'
 import type { ProcessStatus } from '@/engines/types'
 import { logger } from '@/logger'
-import { IDLE_TIMEOUT_MS, STREAM_STALL_TIMEOUT_MS } from './constants'
+import {
+  IDLE_TIMEOUT_MS,
+  STALL_PROBE_GRACE_MS,
+  STREAM_STALL_TIMEOUT_MS,
+} from './constants'
 import type { EngineContext } from './context'
 import { emitIssueSettled, emitStateChange } from './events'
 import { withIssueLock } from './process/lock'
@@ -120,28 +124,58 @@ export function gcSweep(ctx: EngineContext): void {
     }
 
     // --- Check 2: Stream stall detection (turn in-flight but no output) ---
-    // Catches processes stuck in "thinking" state where the engine never emits
-    // a completion entry: turnInFlight stays true, lastIdleAt is never set,
-    // and monitorCompletion() waits forever on subprocess.exited.
-    if (
-      managed.turnInFlight &&
-      now - managed.lastActivityAt.getTime() > STREAM_STALL_TIMEOUT_MS
-    ) {
-      const stallMinutes = Math.round(
-        (now - managed.lastActivityAt.getTime()) / 60000,
-      )
-      logger.warn(
-        {
-          issueId: managed.issueId,
-          executionId: managed.executionId,
-          stallMinutes,
-          lastActivityAt: managed.lastActivityAt.toISOString(),
-        },
-        'stream_stall_terminate',
-      )
-      terminateAndSettle(ctx, entry.id, managed, 'failed')
-      cleaned++
-      continue
+    // Two-tier approach to avoid killing legitimate long-running operations:
+    //   Tier 1 (STREAM_STALL_TIMEOUT_MS): Send interrupt probe to check responsiveness
+    //   Tier 2 (+ STALL_PROBE_GRACE_MS): No response after probe → force kill
+    if (managed.turnInFlight) {
+      const silenceMs = now - managed.lastActivityAt.getTime()
+
+      // Tier 2: probe was sent but process still hasn't responded
+      if (
+        managed.stallProbeAt &&
+        now - managed.stallProbeAt.getTime() > STALL_PROBE_GRACE_MS
+      ) {
+        const stallMinutes = Math.round(silenceMs / 60000)
+        logger.warn(
+          {
+            issueId: managed.issueId,
+            executionId: managed.executionId,
+            stallMinutes,
+            lastActivityAt: managed.lastActivityAt.toISOString(),
+            probeSentAt: managed.stallProbeAt.toISOString(),
+          },
+          'stream_stall_terminate',
+        )
+        managed.stallProbeAt = undefined
+        terminateAndSettle(ctx, entry.id, managed, 'failed')
+        cleaned++
+        continue
+      }
+
+      // Tier 1: no output for STREAM_STALL_TIMEOUT_MS — send interrupt probe
+      if (!managed.stallProbeAt && silenceMs > STREAM_STALL_TIMEOUT_MS) {
+        const stallMinutes = Math.round(silenceMs / 60000)
+        logger.warn(
+          {
+            issueId: managed.issueId,
+            executionId: managed.executionId,
+            stallMinutes,
+            lastActivityAt: managed.lastActivityAt.toISOString(),
+          },
+          'stream_stall_probe_sent',
+        )
+        managed.stallProbeAt = new Date()
+        // Send interrupt to probe process responsiveness. If the process is
+        // alive (e.g. waiting on a slow API call), it will respond with an
+        // error/result entry, which updates lastActivityAt and clears the stall.
+        // Fire-and-forget: Tier 2 will force-kill if no response after grace period.
+        void managed.process.protocolHandler?.interrupt().catch((err) => {
+          logger.warn(
+            { issueId: managed.issueId, executionId: managed.executionId, err },
+            'stall_probe_interrupt_failed',
+          )
+        })
+      }
     }
   }
 

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -169,14 +169,14 @@ export function gcSweep(ctx: EngineContext): void {
         // alive (e.g. waiting on a slow API call), it will respond with an
         // error/result entry, which updates lastActivityAt and clears the stall.
         // Fire-and-forget: Tier 2 will force-kill if no response after grace period.
-        try {
-          managed.process.protocolHandler?.interrupt()
-        } catch (err) {
+        // Use void+catch because the interface types interrupt() as Promise<void>
+        // (Codex's implementation is genuinely async).
+        void managed.process.protocolHandler?.interrupt().catch((err) => {
           logger.warn(
             { issueId: managed.issueId, executionId: managed.executionId, err },
             'stall_probe_interrupt_failed',
           )
-        }
+        })
       }
     }
   }

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -169,12 +169,14 @@ export function gcSweep(ctx: EngineContext): void {
         // alive (e.g. waiting on a slow API call), it will respond with an
         // error/result entry, which updates lastActivityAt and clears the stall.
         // Fire-and-forget: Tier 2 will force-kill if no response after grace period.
-        void managed.process.protocolHandler?.interrupt().catch((err) => {
+        try {
+          managed.process.protocolHandler?.interrupt()
+        } catch (err) {
           logger.warn(
             { issueId: managed.issueId, executionId: managed.executionId, err },
             'stall_probe_interrupt_failed',
           )
-        })
+        }
       }
     }
   }

--- a/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
+++ b/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
@@ -203,11 +203,18 @@ export function monitorCompletion(
           await settleIssue(ctx, issueId, executionId, 'failed')
         }
       }
-    } catch {
+    } catch (outerErr) {
+      logger.error({ issueId, executionId, err: outerErr }, 'monitor_completion_outer_error')
       dispatch(managed, { type: 'MARK_FAILED' })
       syncPmState(ctx, executionId, 'failed')
       emitStateChange(issueId, executionId, 'failed')
-      await settleIssue(ctx, issueId, executionId, 'failed')
+      // settleIssue has its own try-finally that always calls emitIssueSettled,
+      // but wrap in try-catch to prevent unhandled rejection in the void async.
+      try {
+        await settleIssue(ctx, issueId, executionId, 'failed')
+      } catch (settleErr) {
+        logger.error({ issueId, executionId, err: settleErr }, 'monitor_completion_settle_failed')
+      }
     }
   })()
 }

--- a/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
+++ b/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
@@ -204,7 +204,10 @@ export function monitorCompletion(
         }
       }
     } catch (outerErr) {
-      logger.error({ issueId, executionId, err: outerErr }, 'monitor_completion_outer_error')
+      logger.error(
+        { issueId, executionId, err: outerErr },
+        'monitor_completion_outer_error',
+      )
       dispatch(managed, { type: 'MARK_FAILED' })
       syncPmState(ctx, executionId, 'failed')
       emitStateChange(issueId, executionId, 'failed')
@@ -213,7 +216,10 @@ export function monitorCompletion(
       try {
         await settleIssue(ctx, issueId, executionId, 'failed')
       } catch (settleErr) {
-        logger.error({ issueId, executionId, err: settleErr }, 'monitor_completion_settle_failed')
+        logger.error(
+          { issueId, executionId, err: settleErr },
+          'monitor_completion_settle_failed',
+        )
       }
     }
   })()

--- a/apps/api/src/engines/issue/lifecycle/settle.ts
+++ b/apps/api/src/engines/issue/lifecycle/settle.ts
@@ -2,12 +2,18 @@ import { autoMoveToReview, updateIssueSession } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled } from '@/engines/issue/events'
 import { cleanupDomainData } from '@/engines/issue/process/state'
+import { logger } from '@/logger'
 
 /** Common settle flow: persist status, auto-move, clean domain data, emit event.
  *
  * NOTE: Worktree cleanup is NOT done here. Worktrees are preserved across
  * completed/failed settlements so follow-ups can reuse them. Cleanup is
  * handled by the periodic background job in jobs/worktree-cleanup.ts.
+ *
+ * IMPORTANT: emitIssueSettled() MUST always fire — the SSE route filters
+ * terminal states from the 'state' subscriber and only sends them via the
+ * 'done' subscriber. If emitIssueSettled is skipped, the frontend never
+ * receives a terminal event and stays stuck in "thinking" state forever.
  */
 export async function settleIssue(
   ctx: EngineContext,
@@ -15,8 +21,13 @@ export async function settleIssue(
   executionId: string,
   status: string,
 ): Promise<void> {
-  await updateIssueSession(issueId, { sessionStatus: status })
-  await autoMoveToReview(issueId)
-  cleanupDomainData(ctx, executionId)
-  emitIssueSettled(issueId, executionId, status)
+  try {
+    await updateIssueSession(issueId, { sessionStatus: status })
+    await autoMoveToReview(issueId)
+  } catch (err) {
+    logger.error({ issueId, executionId, status, err }, 'settle_issue_partial_failure')
+  } finally {
+    cleanupDomainData(ctx, executionId)
+    emitIssueSettled(issueId, executionId, status)
+  }
 }

--- a/apps/api/src/engines/issue/lifecycle/settle.ts
+++ b/apps/api/src/engines/issue/lifecycle/settle.ts
@@ -25,7 +25,10 @@ export async function settleIssue(
     await updateIssueSession(issueId, { sessionStatus: status })
     await autoMoveToReview(issueId)
   } catch (err) {
-    logger.error({ issueId, executionId, status, err }, 'settle_issue_partial_failure')
+    logger.error(
+      { issueId, executionId, status, err },
+      'settle_issue_partial_failure',
+    )
   } finally {
     cleanupDomainData(ctx, executionId)
     emitIssueSettled(issueId, executionId, status)

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -136,18 +136,24 @@ export function handleTurnCompleted(
       // 'done' SSE event and stays stuck in "thinking" state indefinitely
       // (terminal states are filtered from the 'state' subscriber).
       //
-      // Guard: check if a follow-up has reactivated the issue. If so, do NOT
-      // overwrite the new run's 'running'/'pending' status with our stale
-      // finalStatus, and skip the settled event to avoid confusing the frontend.
+      // Guard: check if a follow-up has reactivated the issue by verifying
+      // BOTH a running/pending status AND an active PM process. If the DB
+      // simply shows 'running' because our updateIssueSession failed (not
+      // because a follow-up started), we must still emit the settled event.
       try {
         const freshIssue = await getIssueWithSession(issueId)
         const currentStatus = freshIssue?.sessionFields.sessionStatus
         if (currentStatus === 'running' || currentStatus === 'pending') {
-          logger.debug(
-            { issueId, executionId, finalStatus, currentStatus },
-            'issue_turn_settle_catch_skipped_reactivated',
-          )
-          return
+          const hasActiveProcess = ctx.pm
+            .getActive()
+            .some((e) => e.meta.issueId === issueId)
+          if (hasActiveProcess) {
+            logger.debug(
+              { issueId, executionId, finalStatus, currentStatus },
+              'issue_turn_settle_catch_skipped_reactivated',
+            )
+            return
+          }
         }
         await updateIssueSession(issueId, { sessionStatus: finalStatus })
       } catch {

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -136,24 +136,33 @@ export function handleTurnCompleted(
       // 'done' SSE event and stays stuck in "thinking" state indefinitely
       // (terminal states are filtered from the 'state' subscriber).
       //
-      // Guard: check if a follow-up has reactivated the issue by verifying
-      // BOTH a running/pending status AND an active PM process. If the DB
-      // simply shows 'running' because our updateIssueSession failed (not
-      // because a follow-up started), we must still emit the settled event.
+      // Guard: skip if a follow-up has reactivated the issue.
+      // Check for a DIFFERENT active PM process for this issue (not our own
+      // executionId). Also check if DB status already diverged to a terminal
+      // state we didn't set.
       try {
         const freshIssue = await getIssueWithSession(issueId)
         const currentStatus = freshIssue?.sessionFields.sessionStatus
-        if (currentStatus === 'running' || currentStatus === 'pending') {
-          const hasActiveProcess = ctx.pm
-            .getActive()
-            .some((e) => e.meta.issueId === issueId)
-          if (hasActiveProcess) {
-            logger.debug(
-              { issueId, executionId, finalStatus, currentStatus },
-              'issue_turn_settle_catch_skipped_reactivated',
-            )
-            return
-          }
+        const hasOtherActive = ctx.pm
+          .getActive()
+          .some((e) => e.meta.issueId === issueId && e.id !== executionId)
+        if (
+          hasOtherActive ||
+          (currentStatus !== finalStatus &&
+            currentStatus !== 'running' &&
+            currentStatus !== 'pending')
+        ) {
+          logger.debug(
+            {
+              issueId,
+              executionId,
+              finalStatus,
+              currentStatus,
+              hasOtherActive,
+            },
+            'issue_turn_settle_catch_skipped_reactivated',
+          )
+          return
         }
         await updateIssueSession(issueId, { sessionStatus: finalStatus })
       } catch {

--- a/apps/api/src/engines/issue/orchestration/cancel.ts
+++ b/apps/api/src/engines/issue/orchestration/cancel.ts
@@ -27,15 +27,20 @@ export async function cancelIssue(
       })
     }
     if (active.length > 0) {
-      // Persist cancelled immediately so process restarts/stale cleanup
-      // cannot flip this user-initiated cancel into failed.
-      await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
+      // Soft cancel: interrupt sent, process stays alive.
+      // Do NOT set sessionStatus to 'cancelled' here — the turn-completion
+      // flow (handleTurnCompleted) will settle the issue to 'completed' after
+      // the engine responds to the interrupt. Writing 'cancelled' here races
+      // with the turn-completion DB write and can cause the settlement guard
+      // to skip emitIssueSettled, permanently sticking the frontend.
+      // The process remains alive and can accept follow-up messages.
       logger.info(
         { issueId, interruptedCount: active.length },
         'issue_cancel_soft_interrupted',
       )
       return 'interrupted'
     }
+    // No active processes — mark as cancelled in DB
     await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
     logger.info({ issueId, cancelledCount: 0 }, 'issue_cancel_completed')
     return 'cancelled'

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -93,15 +93,14 @@ export function register(
   // (filtered from the downstream stdout stream) still update lastActivityAt.
   // This prevents false stall detection during long-running tool executions
   // where the process is alive but not producing normal log entries.
-  if (process.protocolHandler?.onActivity === undefined) {
+  // Wire once — guard prevents overwriting if register() is called multiple times.
+  if (process.protocolHandler && !process.protocolHandler.onActivity) {
     const getManagedRef = stdoutCallbacks.getManaged
-    if (process.protocolHandler) {
-      process.protocolHandler.onActivity = () => {
-        const m = getManagedRef()
-        if (m) {
-          m.lastActivityAt = new Date()
-          if (m.stallProbeAt) m.stallProbeAt = undefined
-        }
+    process.protocolHandler.onActivity = () => {
+      const m = getManagedRef()
+      if (m) {
+        m.lastActivityAt = new Date()
+        if (m.stallProbeAt) m.stallProbeAt = undefined
       }
     }
   }

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -89,6 +89,23 @@ export function register(
       handleStderrEntry(issueId, executionId, entry),
   }
 
+  // Wire up protocol handler activity callback so control_request messages
+  // (filtered from the downstream stdout stream) still update lastActivityAt.
+  // This prevents false stall detection during long-running tool executions
+  // where the process is alive but not producing normal log entries.
+  if (process.protocolHandler?.onActivity === undefined) {
+    const getManagedRef = stdoutCallbacks.getManaged
+    if (process.protocolHandler) {
+      process.protocolHandler.onActivity = () => {
+        const m = getManagedRef()
+        if (m) {
+          m.lastActivityAt = new Date()
+          if (m.stallProbeAt) m.stallProbeAt = undefined
+        }
+      }
+    }
+  }
+
   consumeStream(
     executionId,
     issueId,

--- a/apps/api/src/engines/issue/state/index.ts
+++ b/apps/api/src/engines/issue/state/index.ts
@@ -22,6 +22,9 @@ export function dispatch(managed: ManagedProcess, action: ManagedAction): void {
       managed.queueCancelRequested = false
       managed.metaTurn = false
       managed.turnSettled = true
+      // cancelledByUser is NOT reset here — it stays true through the full
+      // stream drain cycle so isCancelledNoiseEntry filtering works. It is
+      // reset in START_TURN when the next turn begins.
       break
     case 'SET_EXIT_CODE':
       managed.exitCode = action.exitCode

--- a/apps/api/src/engines/issue/streams/consumer.ts
+++ b/apps/api/src/engines/issue/streams/consumer.ts
@@ -55,6 +55,8 @@ export async function consumeStream(
       const managed = callbacks.getManaged()
       if (!managed) break
       managed.lastActivityAt = new Date()
+      // Clear stall probe if activity resumed after the GC-sent interrupt
+      if (managed.stallProbeAt) managed.stallProbeAt = undefined
       const turnIdx = callbacks.getTurnIndex()
 
       const entry: NormalizedLogEntry = {

--- a/apps/api/src/engines/issue/streams/consumer.ts
+++ b/apps/api/src/engines/issue/streams/consumer.ts
@@ -127,6 +127,7 @@ export async function consumeStderr(
         const managed = callbacks.getManaged()
         if (!managed) return
         managed.lastActivityAt = new Date()
+        if (managed.stallProbeAt) managed.stallProbeAt = undefined
         pushStderrEntry(line, callbacks.getTurnIndex(), callbacks.onEntry)
       }
     }

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -37,6 +37,10 @@ export interface ManagedProcess {
   lastIdleAt?: Date
   /** Timestamp of the last stdout/stderr activity (updated on every stream entry) */
   lastActivityAt: Date
+  /** Timestamp when a stall-probe interrupt was sent (set by gcSweep).
+   *  If activity resumes after the probe, this is cleared in consumeStream.
+   *  If still no activity after STALL_PROBE_GRACE_MS, the process is force-killed. */
+  stallProbeAt?: Date
   /** Git repo directory that owns this worktree (needed for `git worktree remove`) */
   worktreeBaseDir?: string
   worktreePath?: string

--- a/apps/api/src/engines/types.ts
+++ b/apps/api/src/engines/types.ts
@@ -146,6 +146,7 @@ export interface SpawnedProcess {
     interrupt: () => Promise<void>
     close: () => void
     sendUserMessage?: (content: string) => void
+    onActivity?: () => void
   }
   /** Override the caller-provided externalSessionId (used by engines that generate their own session IDs, e.g. Codex thread IDs). */
   externalSessionId?: string

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -63,7 +63,7 @@ function buildFileContext(savedFiles: SavedFile[]): string {
   if (savedFiles.length === 0) return ''
   const parts = savedFiles.map(
     (f) =>
-      `[Attached file: ${f.originalName.replace(/[\r\n]/g, ' ').slice(0, 255)} at ${f.absolutePath}]`,
+      `[Attached file: ${f.originalName.replace(/[\r\n]/g, ' ').slice(0, 255)} at ${f.absolutePath.replace(/[\r\n]/g, '')}]`,
   )
   return `\n\n--- Attached files ---\n${parts.join('\n')}`
 }

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -63,7 +63,7 @@ function buildFileContext(savedFiles: SavedFile[]): string {
   if (savedFiles.length === 0) return ''
   const parts = savedFiles.map(
     (f) =>
-      `[Attached file: ${f.originalName.replace(/[\r\n]/g, ' ').slice(0, 255)}]`,
+      `[Attached file: ${f.originalName.replace(/[\r\n]/g, ' ').slice(0, 255)} at ${f.absolutePath}]`,
   )
   return `\n\n--- Attached files ---\n${parts.join('\n')}`
 }

--- a/apps/api/test/gc-stall-detection.test.ts
+++ b/apps/api/test/gc-stall-detection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test'
 import {
   IDLE_TIMEOUT_MS,
+  STALL_PROBE_GRACE_MS,
   STREAM_STALL_TIMEOUT_MS,
 } from '@/engines/issue/constants'
 import type { EngineContext } from '@/engines/issue/context'
@@ -9,10 +10,10 @@ import type { ManagedProcess } from '@/engines/issue/types'
 
 /**
  * GC sweep stall detection tests — verifies:
- * 1. Processes stuck "thinking" (turnInFlight=true, no output) are killed after STREAM_STALL_TIMEOUT_MS
+ * 1. Two-tier stall detection: probe first (interrupt), kill if no response
  * 2. Active processes with recent output are NOT killed
  * 3. Idle processes are killed after IDLE_TIMEOUT_MS (existing behavior)
- * 4. Active processes with turnInFlight=true but recent activity are NOT killed
+ * 4. Stall probe is cleared when activity resumes
  */
 
 // ---------- Mock helpers ----------
@@ -79,13 +80,37 @@ function makeContext(entries: MockEntry[]): {
 // ---------- Tests ----------
 
 describe('gcSweep — stream stall detection', () => {
-  test('kills process stuck thinking for longer than STREAM_STALL_TIMEOUT_MS', () => {
-    const stalledAt = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS - 60_000) // 11 min ago
+  test('Tier 1: sends probe (sets stallProbeAt) but does NOT kill on first detection', () => {
+    const stalledAt = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS - 60_000)
     const managed = makeManagedProcess({
       issueId: 'issue-1',
       executionId: 'exec-1',
       turnInFlight: true,
       lastActivityAt: stalledAt,
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-1', meta: managed },
+    ])
+
+    gcSweep(ctx)
+
+    // Should NOT be killed yet — only probed
+    expect(forceKillCalls).not.toContain('exec-1')
+    // stallProbeAt should be set
+    expect(managed.stallProbeAt).toBeDefined()
+  })
+
+  test('Tier 2: kills process if no response after probe grace period', () => {
+    const stalledAt = new Date(
+      Date.now() - STREAM_STALL_TIMEOUT_MS - STALL_PROBE_GRACE_MS - 60_000,
+    )
+    const probeAt = new Date(Date.now() - STALL_PROBE_GRACE_MS - 60_000)
+    const managed = makeManagedProcess({
+      issueId: 'issue-1',
+      executionId: 'exec-1',
+      turnInFlight: true,
+      lastActivityAt: stalledAt,
+      stallProbeAt: probeAt,
     })
     const { ctx, forceKillCalls } = makeContext([
       { id: 'exec-1', meta: managed },
@@ -167,7 +192,7 @@ describe('gcSweep — stream stall detection', () => {
     expect(forceKillCalls).not.toContain('exec-5')
   })
 
-  test('handles multiple processes — kills only stalled ones', () => {
+  test('handles multiple processes — probes stalled, skips active and idle', () => {
     const stalledManaged = makeManagedProcess({
       issueId: 'issue-stalled',
       executionId: 'exec-stalled',
@@ -195,8 +220,67 @@ describe('gcSweep — stream stall detection', () => {
 
     gcSweep(ctx)
 
+    // Tier 1: stalled is probed, not killed
+    expect(forceKillCalls).not.toContain('exec-stalled')
+    expect(stalledManaged.stallProbeAt).toBeDefined()
+    // Others untouched
+    expect(forceKillCalls).not.toContain('exec-active')
+    expect(forceKillCalls).not.toContain('exec-idle')
+  })
+
+  test('handles multiple processes — kills stalled after probe grace, skips others', () => {
+    const stalledManaged = makeManagedProcess({
+      issueId: 'issue-stalled',
+      executionId: 'exec-stalled',
+      turnInFlight: true,
+      lastActivityAt: new Date(
+        Date.now() - STREAM_STALL_TIMEOUT_MS - STALL_PROBE_GRACE_MS - 120_000,
+      ),
+      stallProbeAt: new Date(Date.now() - STALL_PROBE_GRACE_MS - 120_000),
+    })
+    const activeManaged = makeManagedProcess({
+      issueId: 'issue-active',
+      executionId: 'exec-active',
+      turnInFlight: true,
+      lastActivityAt: new Date(), // just now
+    })
+    const idleManaged = makeManagedProcess({
+      issueId: 'issue-idle',
+      executionId: 'exec-idle',
+      turnInFlight: false,
+      lastIdleAt: new Date(Date.now() - 5 * 60_000),
+      lastActivityAt: new Date(Date.now() - 5 * 60_000),
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-stalled', meta: stalledManaged },
+      { id: 'exec-active', meta: activeManaged },
+      { id: 'exec-idle', meta: idleManaged },
+    ])
+
+    gcSweep(ctx)
+
+    // Tier 2: stalled is killed after probe grace period
     expect(forceKillCalls).toContain('exec-stalled')
     expect(forceKillCalls).not.toContain('exec-active')
     expect(forceKillCalls).not.toContain('exec-idle')
+  })
+
+  test('does NOT probe or kill process within stall timeout even with probe set', () => {
+    // Edge case: stallProbeAt set but process produced output since then
+    // (probe was sent, process responded — activity cleared stallProbeAt in consumer)
+    const managed = makeManagedProcess({
+      issueId: 'issue-recovered',
+      executionId: 'exec-recovered',
+      turnInFlight: true,
+      lastActivityAt: new Date(Date.now() - 60_000), // 1 min ago — within threshold
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-recovered', meta: managed },
+    ])
+
+    gcSweep(ctx)
+
+    expect(forceKillCalls).not.toContain('exec-recovered')
+    expect(managed.stallProbeAt).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- **Two-tier stall detection**: Tier 1 sends interrupt probe after 5 min silence; Tier 2 force-kills after additional 2 min grace period. Prevents false-positive kills on slow API calls while catching true deadlocks.
- **Settlement guarantees**: `settleIssue` wrapped in try-finally so `emitIssueSettled` always fires — fixes frontend permanently stuck in "AI thinking" state.
- **Cancel race fix**: soft cancel no longer writes `sessionStatus: 'cancelled'` to DB, letting turn-completion settle naturally as `completed`. `cancelledByUser` reset moved from `TURN_COMPLETED` to `START_TURN` to preserve noise filtering through full stream drain.
- **Claude executor SDK migration** (ref: BloopAI/vibe-kanban): replaces `--dangerously-skip-permissions` with `--permission-prompt-tool=stdio` + SDK `initialize`/`set_permission_mode` handshake. Adds `--include-partial-messages` and `--replay-user-messages` flags. Extracts `createBaseBuilder`/`spawnProcess` to eliminate spawn duplication. Adds `claude-haiku-4-5` model.

## Test plan

- [x] All 260 API tests pass (0 failures)
- [x] Biome lint clean on changed files
- [ ] Manual test: execute issue → verify no "AI thinking" stuck state
- [ ] Manual test: cancel during thinking → verify process stays alive for follow-up
- [ ] Manual test: verify permission auto-approval works with SDK protocol