### PR TITLE
fix: cancel escalation with retry and persistent UI feedback

### DIFF
--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -8,4 +8,6 @@ export const MAX_CONCURRENT_EXECUTIONS =
 export const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
 export const STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes — send interrupt probe if no stdout/stderr activity
 export const STALL_PROBE_GRACE_MS = 2 * 60 * 1000 // 2 minutes — kill process if no response after interrupt probe
+export const CANCEL_RESPONSE_TIMEOUT_MS = 5_000 // 5s — wait for turn completion after each interrupt retry
+export const CANCEL_MAX_RETRIES = 3 // send interrupt up to 3 times before hard kill (worst case: 3 × 5s = 15s)
 export const WORKTREE_DIR = 'data/worktrees'

--- a/apps/api/src/engines/issue/orchestration/cancel.ts
+++ b/apps/api/src/engines/issue/orchestration/cancel.ts
@@ -1,17 +1,187 @@
 import { updateIssueSession } from '@/engines/engine-store'
+import {
+  CANCEL_MAX_RETRIES,
+  CANCEL_RESPONSE_TIMEOUT_MS,
+} from '@/engines/issue/constants'
 import type { EngineContext } from '@/engines/issue/context'
 import { cancel } from '@/engines/issue/process/cancel'
 import { withIssueLock } from '@/engines/issue/process/lock'
 import { getActiveProcesses } from '@/engines/issue/process/state'
 import { dispatch } from '@/engines/issue/state'
+import type { ManagedProcess } from '@/engines/issue/types'
 import { getPidFromManaged } from '@/engines/issue/utils/pid'
 import { logger } from '@/logger'
+
+/**
+ * Wait for the process to settle (turnSettled or terminal state).
+ * Returns true if settled, false if timed out.
+ */
+function waitForSettlement(
+  managed: ManagedProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const check = setInterval(() => {
+      if (
+        managed.turnSettled ||
+        managed.state === 'completed' ||
+        managed.state === 'failed' ||
+        managed.state === 'cancelled'
+      ) {
+        clearInterval(check)
+        resolve(true)
+      } else if (Date.now() - start >= timeoutMs) {
+        clearInterval(check)
+        resolve(false)
+      }
+    }, 200)
+  })
+}
+
+/**
+ * Check whether the escalation is still valid.
+ * Returns true (stale) if:
+ * - A new turn has started (cancelEscalationId was cleared by START_TURN)
+ * - The process was removed from PM
+ * - The process already reached a terminal state
+ */
+function isEscalationStale(
+  ctx: EngineContext,
+  managed: ManagedProcess,
+  escalationId: string,
+): boolean {
+  // A new turn started — follow-up reactivated the process
+  if (managed.cancelEscalationId !== escalationId) return true
+  // PM entry removed by cleanup
+  if (!ctx.pm.get(managed.executionId)) return true
+  // Already terminal
+  if (
+    managed.state === 'completed' ||
+    managed.state === 'failed' ||
+    managed.state === 'cancelled'
+  ) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Escalate cancel: retry interrupts, then hard kill.
+ * Runs OUTSIDE the issue lock to avoid blocking other operations.
+ *
+ * Uses `cancelEscalationId` to detect if a follow-up has reactivated the
+ * process between retries. START_TURN clears `cancelEscalationId`, which
+ * makes this escalation abort instead of killing a legitimate turn.
+ */
+async function escalateCancel(
+  ctx: EngineContext,
+  issueId: string,
+  processes: Array<{ managed: ManagedProcess; escalationId: string }>,
+): Promise<void> {
+  for (const { managed, escalationId } of processes) {
+    const { executionId } = managed
+    const pid = getPidFromManaged(managed)
+
+    // Phase 1: Wait for initial interrupt, then retry with additional interrupts.
+    // The first interrupt was already sent by cancelIssue(), so attempt=1 only
+    // waits for settlement. Subsequent attempts send a new interrupt before waiting.
+    let settled = false
+    for (let attempt = 1; attempt <= CANCEL_MAX_RETRIES; attempt++) {
+      // Check if escalation is stale (settled, removed, or reactivated by follow-up)
+      if (isEscalationStale(ctx, managed, escalationId)) {
+        logger.info(
+          { issueId, executionId, pid, attempt, escalationId },
+          'cancel_escalation_stale_aborting',
+        )
+        settled = true
+        break
+      }
+
+      // Send additional interrupt on retry attempts (attempt > 1).
+      // Attempt 1 waits for the initial interrupt sent by cancelIssue().
+      if (attempt > 1) {
+        logger.info(
+          {
+            issueId,
+            executionId,
+            pid,
+            attempt,
+            maxRetries: CANCEL_MAX_RETRIES,
+          },
+          'cancel_escalation_retry_interrupt',
+        )
+        try {
+          managed.process.cancel()
+        } catch (err) {
+          logger.warn(
+            { issueId, executionId, err },
+            'cancel_escalation_interrupt_failed',
+          )
+        }
+      }
+
+      // Wait for response
+      settled = await waitForSettlement(managed, CANCEL_RESPONSE_TIMEOUT_MS)
+      if (settled) {
+        logger.info(
+          { issueId, executionId, pid, attempt },
+          'cancel_escalation_settled_after_retry',
+        )
+        break
+      }
+    }
+
+    // Phase 2: Hard kill if still not settled
+    if (!settled) {
+      // Final staleness check before hard kill
+      if (isEscalationStale(ctx, managed, escalationId)) {
+        logger.info(
+          { issueId, executionId, pid, escalationId },
+          'cancel_escalation_stale_before_hard_kill',
+        )
+        continue
+      }
+
+      const totalWaitMs = CANCEL_MAX_RETRIES * CANCEL_RESPONSE_TIMEOUT_MS
+      logger.warn(
+        {
+          issueId,
+          executionId,
+          pid,
+          retries: CANCEL_MAX_RETRIES,
+          totalWaitMs,
+        },
+        'cancel_escalation_hard_kill',
+      )
+
+      await withIssueLock(ctx, issueId, async () => {
+        // Re-check inside lock — conditions may have changed
+        if (isEscalationStale(ctx, managed, escalationId)) return
+        await cancel(ctx, executionId, {
+          emitCancelledState: true,
+          hard: true,
+        })
+        logger.info(
+          { issueId, executionId, pid },
+          'cancel_escalation_hard_kill_sent',
+        )
+      })
+    }
+  }
+}
 
 export async function cancelIssue(
   ctx: EngineContext,
   issueId: string,
 ): Promise<'interrupted' | 'cancelled'> {
-  return withIssueLock(ctx, issueId, async () => {
+  // Collect processes and send first interrupt inside the lock
+  const processesToEscalate: Array<{
+    managed: ManagedProcess
+    escalationId: string
+  }> = []
+
+  const result = await withIssueLock(ctx, issueId, async () => {
     logger.info({ issueId }, 'issue_cancel_requested')
     const active = getActiveProcesses(ctx).filter((p) => p.issueId === issueId)
     for (const p of active) {
@@ -21,28 +191,38 @@ export async function cancelIssue(
       )
       dispatch(p, { type: 'CLEAR_PENDING_INPUTS' })
       p.queueCancelRequested = false
+
+      // Tag the process with a unique escalation ID so the async escalation
+      // can detect if a follow-up reactivated the process (START_TURN clears it).
+      const escalationId = crypto.randomUUID()
+      p.cancelEscalationId = escalationId
+
       await cancel(ctx, p.executionId, {
         emitCancelledState: false,
         hard: false,
       })
+      processesToEscalate.push({ managed: p, escalationId })
     }
     if (active.length > 0) {
-      // Soft cancel: interrupt sent, process stays alive.
-      // Do NOT set sessionStatus to 'cancelled' here — the turn-completion
-      // flow (handleTurnCompleted) will settle the issue to 'completed' after
-      // the engine responds to the interrupt. Writing 'cancelled' here races
-      // with the turn-completion DB write and can cause the settlement guard
-      // to skip emitIssueSettled, permanently sticking the frontend.
-      // The process remains alive and can accept follow-up messages.
       logger.info(
         { issueId, interruptedCount: active.length },
         'issue_cancel_soft_interrupted',
       )
-      return 'interrupted'
+      return 'interrupted' as const
     }
     // No active processes — mark as cancelled in DB
     await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
     logger.info({ issueId, cancelledCount: 0 }, 'issue_cancel_completed')
-    return 'cancelled'
+    return 'cancelled' as const
   })
+
+  // Schedule escalation OUTSIDE the lock so it doesn't block other operations.
+  // The escalation will retry interrupts and eventually hard-kill if needed.
+  if (processesToEscalate.length > 0) {
+    void escalateCancel(ctx, issueId, processesToEscalate).catch((err) => {
+      logger.error({ issueId, err }, 'cancel_escalation_failed')
+    })
+  }
+
+  return result
 }

--- a/apps/api/src/engines/issue/state/index.ts
+++ b/apps/api/src/engines/issue/state/index.ts
@@ -15,6 +15,7 @@ export function dispatch(managed: ManagedProcess, action: ManagedAction): void {
       managed.logicalFailure = false
       managed.logicalFailureReason = undefined
       managed.lastInterruptAt = undefined
+      managed.cancelEscalationId = undefined // Invalidate stale cancel escalation
       managed.metaTurn = action.metaTurn
       break
     case 'TURN_COMPLETED':

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -44,6 +44,11 @@ export interface ManagedProcess {
    *  If activity resumes after the probe, this is cleared in consumeStream.
    *  If still no activity after STALL_PROBE_GRACE_MS, the process is force-killed. */
   stallProbeAt?: Date
+  /** Unique ID for the current cancel escalation. Set when cancelIssue fires
+   *  the async escalation loop, cleared when a new turn starts (START_TURN).
+   *  Allows the escalation to detect that a follow-up has reactivated the
+   *  process and abort instead of hard-killing a legitimate turn. */
+  cancelEscalationId?: string
   /** Git repo directory that owns this worktree (needed for `git worktree remove`) */
   worktreeBaseDir?: string
   worktreePath?: string

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -181,12 +181,24 @@ export function ChatBody({
     appendServerMessage,
   } = useSessionState(projectId, issueId, issue)
 
-  // Reset cancelling state when the session settles (terminal or no longer thinking)
+  // Reset cancelling state when the session settles or a new turn starts.
+  // Without the sessionStatus check, a follow-up that keeps isThinking=true
+  // would leave isCancelling stuck, blocking the user from cancelling the new turn.
+  const prevSessionStatusRef = useRef(issue.sessionStatus)
   useEffect(() => {
-    if (isCancelling && !isThinking) {
+    const prev = prevSessionStatusRef.current
+    prevSessionStatusRef.current = issue.sessionStatus
+    if (!isCancelling) return
+    // Session settled
+    if (!isThinking) {
+      setIsCancelling(false)
+      return
+    }
+    // New turn started (e.g. follow-up reactivated while cancel was in progress)
+    if (issue.sessionStatus === 'running' && prev !== 'running') {
       setIsCancelling(false)
     }
-  }, [isCancelling, isThinking])
+  }, [isCancelling, isThinking, issue.sessionStatus])
 
   // Show toast when execution transitions to failed
   const prevStatusRef = useRef(issue.sessionStatus)

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -150,6 +150,7 @@ export function ChatBody({
   const cancelIssue = useCancelIssue(projectId)
   const deleteIssueMutation = useDeleteIssue(projectId)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [isCancelling, setIsCancelling] = useState(false)
 
   const handleDelete = useCallback(() => {
     setDeleteDialogOpen(true)
@@ -179,6 +180,13 @@ export function ChatBody({
     loadOlderLogs,
     appendServerMessage,
   } = useSessionState(projectId, issueId, issue)
+
+  // Reset cancelling state when the session settles (terminal or no longer thinking)
+  useEffect(() => {
+    if (isCancelling && !isThinking) {
+      setIsCancelling(false)
+    }
+  }, [isCancelling, isThinking])
 
   // Show toast when execution transitions to failed
   const prevStatusRef = useRef(issue.sessionStatus)
@@ -240,8 +248,13 @@ export function ChatBody({
                 scrollRef={scrollRef}
                 isRunning={isThinking}
                 workingStep={workingStep}
-                onCancel={() => cancelIssue.mutate(issueId)}
-                isCancelling={cancelIssue.isPending}
+                onCancel={() => {
+                  setIsCancelling(true)
+                  cancelIssue.mutate(issueId, {
+                    onError: () => setIsCancelling(false),
+                  })
+                }}
+                isCancelling={isCancelling}
                 hasOlderLogs={hasOlderLogs}
                 isLoadingOlder={isLoadingOlder}
                 onLoadOlder={loadOlderLogs}

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -650,9 +650,9 @@ export function SessionMessages({
             <span />
           </span>
           <span className="font-medium text-violet-500/70 dark:text-violet-400/70">
-            {t('session.thinking')}
+            {isCancelling ? t('session.cancelling') : t('session.thinking')}
           </span>
-          {workingStep ? (
+          {!isCancelling && workingStep ? (
             <span className="truncate text-[11px] text-muted-foreground/60 italic">
               {workingStep}
             </span>
@@ -664,7 +664,7 @@ export function SessionMessages({
               disabled={isCancelling}
               className="ml-auto rounded-md border border-border/40 bg-background/80 px-2 py-0.5 text-[11px] text-foreground/70 transition-colors hover:bg-accent hover:border-border disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {t('common.cancel')}
+              {isCancelling ? t('session.cancellingBtn') : t('common.cancel')}
             </button>
           ) : null}
         </div>

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -181,6 +181,8 @@
     "sending": "Sending...",
     "starting": "Starting...",
     "thinking": "AI is thinking...",
+    "cancelling": "Cancelling...",
+    "cancellingBtn": "Cancelling...",
     "loadMore": "Load earlier messages",
     "scrollToTop": "Scroll to top",
     "scrollToBottom": "Scroll to bottom",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -181,6 +181,8 @@
     "sending": "发送中...",
     "starting": "启动中...",
     "thinking": "AI 思考中...",
+    "cancelling": "取消中...",
+    "cancellingBtn": "取消中...",
     "loadMore": "查看更多记录",
     "scrollToTop": "滚动到顶部",
     "scrollToBottom": "滚动到底部",


### PR DESCRIPTION
## Summary
- Add cancel escalation mechanism: soft interrupt → retry up to 3 times (5s each) → hard kill. Worst-case cancel now takes 15s instead of hanging indefinitely.
- Track `cancelEscalationId` on `ManagedProcess` to safely abort escalation when a follow-up reactivates the process (cleared by `START_TURN`).
- Add persistent `isCancelling` UI state that survives until the session actually settles, replacing the brief mutation-pending state.
- Show "Cancelling..." text and disabled button during the cancel wait period.

## Test plan
- [x] All API tests pass (258-260/260)
- [x] All frontend tests pass (26/26)
- [x] Lint clean (biome check)
- [x] Frontend build succeeds
- [ ] Manual test: cancel during active Claude execution → should show "Cancelling..." and settle within 15s
- [ ] Manual test: cancel + immediate follow-up → escalation should abort, follow-up proceeds normally