### PR TITLE
refactor: redesign settings UI with sidebar navigation layout

### DIFF
--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -1,12 +1,15 @@
 import {
   ArrowDownToLine,
+  Box,
   Check,
   ChevronDown,
   CircleAlert,
   CircleCheck,
   FolderOpen,
+  Info,
   Loader2,
   RefreshCw,
+  Settings,
 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,12 +17,6 @@ import { DirectoryPicker } from '@/components/DirectoryPicker'
 import { EngineIcon } from '@/components/EngineIcons'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { Field } from '@/components/ui/field'
 import { Label } from '@/components/ui/label'
 import {
@@ -29,8 +26,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import type { SettingsNavItem } from '@/components/ui/settings-layout'
+import { SettingsLayout } from '@/components/ui/settings-layout'
 import { Switch } from '@/components/ui/switch'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   useCheckForUpdates,
   useDownloadStatus,
@@ -73,8 +71,138 @@ export function AppSettingsDialog({
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
+  const { t } = useTranslation()
+
+  const navItems: SettingsNavItem[] = useMemo(
+    () => [
+      { id: 'general', label: t('settings.tabGeneral'), icon: Settings },
+      { id: 'models', label: t('settings.tabModels'), icon: Box },
+      { id: 'about', label: t('settings.tabAbout'), icon: Info },
+    ],
+    [t],
+  )
+
+  return (
+    <SettingsLayout
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('settings.title')}
+      items={navItems}
+      defaultItem="general"
+    >
+      {(active) => (
+        <>
+          {active === 'general' && <GeneralSection open={open} />}
+          {active === 'models' && <ModelsSection open={open} />}
+          {active === 'about' && <AboutSection open={open} />}
+        </>
+      )}
+    </SettingsLayout>
+  )
+}
+
+function GeneralSection({ open }: { open: boolean }) {
   const { t, i18n } = useTranslation()
   const { theme, setTheme } = useTheme()
+  const { data: wsData } = useWorkspacePath(open)
+  const updateWsPath = useUpdateWorkspacePath()
+  const [dirPickerOpen, setDirPickerOpen] = useState(false)
+  const { data: worktreeCleanupData } = useWorktreeAutoCleanup(open)
+  const setWorktreeAutoCleanup = useSetWorktreeAutoCleanup()
+
+  const handleSelectWorkspace = (path: string) => {
+    updateWsPath.mutate(path)
+  }
+
+  return (
+    <div className="space-y-4">
+      <Field>
+        <Label>{t('settings.workspacePath')}</Label>
+        <div className="mt-1.5 flex items-center gap-1.5">
+          <div className="flex-1 rounded-md border bg-muted/50 px-2 py-1.5 text-sm font-mono text-muted-foreground truncate">
+            {wsData?.path ?? '/'}
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setDirPickerOpen(true)}
+          >
+            <FolderOpen className="size-4 text-muted-foreground" />
+          </Button>
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          {t('settings.workspacePathHint')}
+        </p>
+        <DirectoryPicker
+          open={dirPickerOpen}
+          onOpenChange={setDirPickerOpen}
+          initialPath={wsData?.path ?? '/'}
+          onSelect={handleSelectWorkspace}
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field>
+          <Label>{t('settings.language')}</Label>
+          <Select
+            value={i18n.language}
+            onValueChange={(value) => i18n.changeLanguage(value ?? undefined)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {LANGUAGES.map((lang) => (
+                <SelectItem key={lang.id} value={lang.id}>
+                  {lang.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field>
+          <Label>{t('settings.appearance')}</Label>
+          <Select
+            value={theme}
+            onValueChange={(value) =>
+              setTheme(value as 'system' | 'light' | 'dark')
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {THEME_OPTIONS.map((option) => (
+                <SelectItem key={option.id} value={option.id}>
+                  {t(option.labelKey)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <span className="text-sm font-medium">
+            {t('settings.worktreeAutoCleanup')}
+          </span>
+          <p className="text-[11px] text-muted-foreground">
+            {t('settings.worktreeAutoCleanupHint')}
+          </p>
+        </div>
+        <Switch
+          size="sm"
+          checked={worktreeCleanupData?.enabled ?? false}
+          onCheckedChange={(checked) => setWorktreeAutoCleanup.mutate(checked)}
+        />
+      </div>
+    </div>
+  )
+}
+
+function ModelsSection({ open }: { open: boolean }) {
+  const { t } = useTranslation()
   const { data: discovery, isLoading: enginesLoading } =
     useEngineAvailability(open)
   const engines = discovery?.engines
@@ -94,237 +222,99 @@ export function AppSettingsDialog({
   const showNoAvailableEngines =
     !enginesLoading && availableEngines.length === 0
 
-  const { data: wsData } = useWorkspacePath(open)
-  const updateWsPath = useUpdateWorkspacePath()
-  const [dirPickerOpen, setDirPickerOpen] = useState(false)
-
-  const { data: worktreeCleanupData } = useWorktreeAutoCleanup(open)
-  const setWorktreeAutoCleanup = useSetWorktreeAutoCleanup()
-
-  const handleSelectWorkspace = (path: string) => {
-    updateWsPath.mutate(path)
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent aria-describedby={undefined} className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{t('settings.title')}</DialogTitle>
-        </DialogHeader>
-
-        <Tabs defaultValue="general">
-          <TabsList>
-            <TabsTrigger value="general">
-              {t('settings.tabGeneral')}
-            </TabsTrigger>
-            <TabsTrigger value="models">{t('settings.tabModels')}</TabsTrigger>
-            <TabsTrigger value="about">{t('settings.tabAbout')}</TabsTrigger>
-          </TabsList>
-
-          {/* General tab */}
-          <TabsContent value="general">
-            <div className="max-h-[60dvh] overflow-y-auto overflow-x-hidden space-y-4 pt-2">
-              <Field>
-                <Label>{t('settings.workspacePath')}</Label>
-                <div className="mt-1.5 flex items-center gap-1.5">
-                  <div className="flex-1 rounded-md border bg-muted/50 px-2 py-1.5 text-sm font-mono text-muted-foreground truncate">
-                    {wsData?.path ?? '/'}
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setDirPickerOpen(true)}
-                  >
-                    <FolderOpen className="size-4 text-muted-foreground" />
-                  </Button>
-                </div>
-                <p className="text-[11px] text-muted-foreground">
-                  {t('settings.workspacePathHint')}
-                </p>
-                <DirectoryPicker
-                  open={dirPickerOpen}
-                  onOpenChange={setDirPickerOpen}
-                  initialPath={wsData?.path ?? '/'}
-                  onSelect={handleSelectWorkspace}
-                />
-              </Field>
-
-              {/* Language & Theme */}
-              <div className="grid grid-cols-2 gap-4">
-                <Field>
-                  <Label>{t('settings.language')}</Label>
-                  <Select
-                    value={i18n.language}
-                    onValueChange={(value) =>
-                      i18n.changeLanguage(value ?? undefined)
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {LANGUAGES.map((lang) => (
-                        <SelectItem key={lang.id} value={lang.id}>
-                          {lang.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-                <Field>
-                  <Label>{t('settings.appearance')}</Label>
-                  <Select
-                    value={theme}
-                    onValueChange={(value) =>
-                      setTheme(value as 'system' | 'light' | 'dark')
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {THEME_OPTIONS.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {t(option.labelKey)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </div>
-
-              {/* Worktree Auto-Cleanup */}
-              <div className="flex items-center justify-between">
-                <div>
-                  <span className="text-sm font-medium">
-                    {t('settings.worktreeAutoCleanup')}
-                  </span>
-                  <p className="text-[11px] text-muted-foreground">
-                    {t('settings.worktreeAutoCleanupHint')}
-                  </p>
-                </div>
-                <Switch
-                  size="sm"
-                  checked={worktreeCleanupData?.enabled ?? false}
-                  onCheckedChange={(checked) =>
-                    setWorktreeAutoCleanup.mutate(checked)
-                  }
-                />
-              </div>
-            </div>
-          </TabsContent>
-
-          {/* Models tab */}
-          <TabsContent value="models">
-            <div className="max-h-[60dvh] overflow-y-auto overflow-x-hidden space-y-4 pt-2">
-              {/* Default Engine */}
-              {!enginesLoading && availableEngines.length > 0 ? (
-                <Field>
-                  <Label>{t('settings.defaultEngine')}</Label>
-                  <div className="mt-1.5 flex flex-wrap gap-1.5">
-                    {availableEngines.map((eng) => {
-                      const profile = profiles?.find(
-                        (p) => p.engineType === eng.engineType,
-                      )
-                      const isSelected =
-                        eng.engineType === engineSettings?.defaultEngine ||
-                        (!engineSettings?.defaultEngine &&
-                          eng.engineType === availableEngines[0]?.engineType)
-                      return (
-                        <button
-                          key={eng.engineType}
-                          type="button"
-                          onClick={() =>
-                            updateDefaultEngine.mutate(eng.engineType)
-                          }
-                          className={cn(
-                            'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
-                            isSelected
-                              ? 'border-primary bg-primary/10 text-primary'
-                              : 'text-muted-foreground hover:bg-accent/50',
-                          )}
-                        >
-                          <EngineIcon
-                            engineType={eng.engineType}
-                            className="h-3.5 w-3.5 shrink-0"
-                          />
-                          {profile?.name ?? eng.engineType}
-                        </button>
-                      )
-                    })}
-                  </div>
-                  <p className="text-[11px] text-muted-foreground">
-                    {t('settings.defaultEngineHint')}
-                  </p>
-                </Field>
-              ) : null}
-
-              {/* Engines section */}
-              <div className="flex items-center justify-between">
-                <Label>{t('settings.engines')}</Label>
-                <Button
-                  onClick={() => probe.mutate()}
-                  variant="ghost"
-                  size="sm"
-                  disabled={probe.isPending}
+    <div className="space-y-4">
+      {!enginesLoading && availableEngines.length > 0 ? (
+        <Field>
+          <Label>{t('settings.defaultEngine')}</Label>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {availableEngines.map((eng) => {
+              const profile = profiles?.find(
+                (p) => p.engineType === eng.engineType,
+              )
+              const isSelected =
+                eng.engineType === engineSettings?.defaultEngine ||
+                (!engineSettings?.defaultEngine &&
+                  eng.engineType === availableEngines[0]?.engineType)
+              return (
+                <button
+                  key={eng.engineType}
+                  type="button"
+                  onClick={() => updateDefaultEngine.mutate(eng.engineType)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
+                    isSelected
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'text-muted-foreground hover:bg-accent/50',
+                  )}
                 >
-                  <RefreshCw
-                    className={cn('size-3', probe.isPending && 'animate-spin')}
+                  <EngineIcon
+                    engineType={eng.engineType}
+                    className="h-3.5 w-3.5 shrink-0"
                   />
-                  {probe.isPending
-                    ? t('settings.probing')
-                    : t('settings.probe')}
-                </Button>
-              </div>
+                  {profile?.name ?? eng.engineType}
+                </button>
+              )
+            })}
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            {t('settings.defaultEngineHint')}
+          </p>
+        </Field>
+      ) : null}
 
-              <div className="flex flex-col gap-2">
-                {enginesLoading ? (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    {t('settings.detecting')}
-                  </div>
-                ) : showNoAvailableEngines ? (
-                  <div className="text-sm text-muted-foreground py-2">
-                    {t('settings.noAvailableEngines')}
-                  </div>
-                ) : (
-                  availableEngines.map((engine) => {
-                    const profile = profiles?.find(
-                      (p) => p.engineType === engine.engineType,
-                    )
-                    const engineModels = models?.[engine.engineType] ?? []
-                    const savedDefault =
-                      engineSettings?.engines[engine.engineType]?.defaultModel
-                    return (
-                      <EngineCard
-                        key={engine.engineType}
-                        engine={engine}
-                        profile={profile}
-                        models={engineModels}
-                        savedDefault={savedDefault}
-                        onChangeDefault={(modelId) =>
-                          updateModelSetting.mutate({
-                            engineType: engine.engineType,
-                            defaultModel: modelId,
-                          })
-                        }
-                      />
-                    )
+      <div className="flex items-center justify-between">
+        <Label>{t('settings.engines')}</Label>
+        <Button
+          onClick={() => probe.mutate()}
+          variant="ghost"
+          size="sm"
+          disabled={probe.isPending}
+        >
+          <RefreshCw
+            className={cn('size-3', probe.isPending && 'animate-spin')}
+          />
+          {probe.isPending ? t('settings.probing') : t('settings.probe')}
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {enginesLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            {t('settings.detecting')}
+          </div>
+        ) : showNoAvailableEngines ? (
+          <div className="text-sm text-muted-foreground py-2">
+            {t('settings.noAvailableEngines')}
+          </div>
+        ) : (
+          availableEngines.map((engine) => {
+            const profile = profiles?.find(
+              (p) => p.engineType === engine.engineType,
+            )
+            const engineModels = models?.[engine.engineType] ?? []
+            const savedDefault =
+              engineSettings?.engines[engine.engineType]?.defaultModel
+            return (
+              <EngineCard
+                key={engine.engineType}
+                engine={engine}
+                profile={profile}
+                models={engineModels}
+                savedDefault={savedDefault}
+                onChangeDefault={(modelId) =>
+                  updateModelSetting.mutate({
+                    engineType: engine.engineType,
+                    defaultModel: modelId,
                   })
-                )}
-              </div>
-            </div>
-          </TabsContent>
-
-          {/* About tab */}
-          <TabsContent value="about">
-            <div className="max-h-[60dvh] overflow-y-auto overflow-x-hidden pt-2">
-              <AboutSection open={open} />
-            </div>
-          </TabsContent>
-        </Tabs>
-      </DialogContent>
-    </Dialog>
+                }
+              />
+            )
+          })
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -604,7 +594,6 @@ function EngineCard({
 
   return (
     <div className="rounded-lg border overflow-hidden">
-      {/* Header */}
       <button
         type="button"
         onClick={() => hasModels && setExpanded((v) => !v)}
@@ -670,7 +659,6 @@ function EngineCard({
         </div>
       </button>
 
-      {/* Expanded model list */}
       {expanded && hasModels ? (
         <div className="border-t px-3 py-2 flex flex-col gap-1">
           <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-0.5">

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -1,5 +1,14 @@
-import { FolderOpen, GitBranch, Loader2, Trash2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import {
+  FileText,
+  FolderOpen,
+  GitBranch,
+  GitFork,
+  Loader2,
+  Settings,
+  Terminal,
+  Trash2,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { DirectoryPicker } from '@/components/DirectoryPicker'
@@ -15,7 +24,8 @@ import {
 import { Field, FieldGroup } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import type { SettingsNavItem } from '@/components/ui/settings-layout'
+import { SettingsLayout } from '@/components/ui/settings-layout'
 import { Textarea } from '@/components/ui/textarea'
 import {
   useDeleteProject,
@@ -101,7 +111,7 @@ function DeleteProjectDialog({
   )
 }
 
-function WorktreeTab({ project }: { project: Project }) {
+function WorktreeSection({ project }: { project: Project }) {
   const { t } = useTranslation()
   const { data: worktrees, isLoading } = useProjectWorktrees(project.id)
   const deleteWorktree = useDeleteWorktree()
@@ -271,229 +281,93 @@ export function ProjectSettingsDialog({
     )
   }
 
+  const navItems: SettingsNavItem[] = useMemo(
+    () => [
+      { id: 'general', label: t('project.tabGeneral'), icon: Settings },
+      { id: 'prompt', label: t('project.tabPrompt'), icon: FileText },
+      { id: 'envvars', label: t('project.tabEnvVars'), icon: Terminal },
+      { id: 'worktrees', label: t('project.tabWorktrees'), icon: GitFork },
+    ],
+    [t],
+  )
+
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="md:max-w-lg">
-          <DialogHeader>
-            <div>
-              <DialogTitle>{t('project.settings')}</DialogTitle>
-              <DialogDescription>
-                {t('project.settingsDescription')}
-              </DialogDescription>
+      <SettingsLayout
+        open={open}
+        onOpenChange={onOpenChange}
+        title={t('project.settings')}
+        items={navItems}
+        defaultItem="general"
+        footer={(active) =>
+          active !== 'worktrees' ? (
+            <div className="flex items-center justify-between border-t px-5 py-3">
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setDeleteDialogOpen(true)}
+              >
+                {t('project.delete')}
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onOpenChange(false)}
+                >
+                  {t('common.cancel')}
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={
+                    updateProject.isPending || !name.trim() || !hasChanges
+                  }
+                >
+                  {updateProject.isPending
+                    ? t('project.saving')
+                    : t('project.saveChanges')}
+                </Button>
+              </div>
             </div>
-          </DialogHeader>
-
-          <Tabs defaultValue="general">
-            <TabsList>
-              <TabsTrigger value="general">
-                {t('project.tabGeneral')}
-              </TabsTrigger>
-              <TabsTrigger value="prompt">{t('project.tabPrompt')}</TabsTrigger>
-              <TabsTrigger value="envvars">
-                {t('project.tabEnvVars')}
-              </TabsTrigger>
-              <TabsTrigger value="worktrees">
-                {t('project.tabWorktrees')}
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="general">
-              <FieldGroup>
-                <Field>
-                  <Label>
-                    {t('project.name')}{' '}
-                    <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    type="text"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder={t('project.namePlaceholder')}
-                    autoFocus
-                    className="w-full"
-                  />
-                </Field>
-
-                <Field>
-                  <Label>{t('project.description')}</Label>
-                  <Textarea
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder={t('project.descriptionPlaceholder')}
-                    rows={3}
-                    className="w-full resize-none"
-                  />
-                </Field>
-
-                <Field>
-                  <Label>{t('project.directory')}</Label>
-                  <div className="flex gap-1.5">
-                    <Input
-                      type="text"
-                      value={directory}
-                      onChange={(e) => setDirectory(e.target.value)}
-                      placeholder={t('project.directoryPlaceholder')}
-                      className="w-full"
-                    />
-                    <Button
-                      onClick={() => setDirPickerOpen(true)}
-                      variant="outline"
-                      size="icon"
-                      title={t('project.browseDirectories')}
-                    >
-                      <FolderOpen className="size-4 text-muted-foreground" />
-                    </Button>
-                  </div>
-                  <DirectoryPicker
-                    open={dirPickerOpen}
-                    onOpenChange={setDirPickerOpen}
-                    initialPath={directory || undefined}
-                    onSelect={setDirectory}
-                  />
-                </Field>
-
-                <Field className="space-y-1.5">
-                  <Label>{t('project.repositoryUrl')}</Label>
-                  <div className="flex gap-1.5">
-                    <Input
-                      type="text"
-                      value={repositoryUrl}
-                      onChange={(e) => setRepositoryUrl(e.target.value)}
-                      placeholder={t('project.repositoryUrlPlaceholder')}
-                      className="w-full"
-                    />
-                    <Button
-                      onClick={async () => {
-                        const dir = directory.trim()
-                        if (!dir) return
-                        setDetectingRemote(true)
-                        try {
-                          const result = await kanbanApi.detectGitRemote(dir)
-                          setRepositoryUrl(result.url)
-                        } catch {
-                          // silently ignore — directory may not be a git repo
-                        } finally {
-                          setDetectingRemote(false)
-                        }
-                      }}
-                      variant="outline"
-                      type="button"
-                      disabled={!directory.trim() || detectingRemote}
-                      title={t('project.detectGitRemote')}
-                      className="shrink-0"
-                    >
-                      {detectingRemote ? (
-                        <Loader2 className="size-4 animate-spin" />
-                      ) : (
-                        'Auto'
-                      )}
-                    </Button>
-                  </div>
-                </Field>
-
-                {error ? (
-                  <p className="text-sm text-destructive">{error}</p>
-                ) : null}
-              </FieldGroup>
-
-              <DialogFooter className="mt-4">
-                <Button
-                  variant="destructive"
-                  onClick={() => setDeleteDialogOpen(true)}
-                >
-                  {t('project.delete')}
-                </Button>
-                <Button variant="outline" onClick={() => onOpenChange(false)}>
-                  {t('common.cancel')}
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={
-                    updateProject.isPending || !name.trim() || !hasChanges
-                  }
-                >
-                  {updateProject.isPending
-                    ? t('project.saving')
-                    : t('project.saveChanges')}
-                </Button>
-              </DialogFooter>
-            </TabsContent>
-
-            <TabsContent value="prompt">
-              <FieldGroup>
-                <Field>
-                  <Label>{t('project.systemPrompt')}</Label>
-                  <Textarea
-                    value={systemPrompt}
-                    onChange={(e) => setSystemPrompt(e.target.value)}
-                    placeholder={t('project.systemPromptPlaceholder')}
-                    rows={8}
-                    className="w-full resize-y font-mono text-xs"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {t('project.systemPromptHint')}
-                  </p>
-                </Field>
-              </FieldGroup>
-
-              <DialogFooter className="mt-4">
-                <Button variant="outline" onClick={() => onOpenChange(false)}>
-                  {t('common.cancel')}
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={
-                    updateProject.isPending || !name.trim() || !hasChanges
-                  }
-                >
-                  {updateProject.isPending
-                    ? t('project.saving')
-                    : t('project.saveChanges')}
-                </Button>
-              </DialogFooter>
-            </TabsContent>
-
-            <TabsContent value="envvars">
-              <FieldGroup>
-                <Field>
-                  <Label>{t('project.envVars')}</Label>
-                  <p className="text-xs text-muted-foreground mb-2">
-                    {t('project.envVarsHint')}
-                  </p>
-                  <Textarea
-                    value={envVarsText}
-                    onChange={(e) => setEnvVarsText(e.target.value)}
-                    placeholder={t('project.envVarsPlaceholder')}
-                    rows={8}
-                    className="w-full resize-y font-mono text-xs"
-                  />
-                </Field>
-              </FieldGroup>
-
-              <DialogFooter className="mt-4">
-                <Button variant="outline" onClick={() => onOpenChange(false)}>
-                  {t('common.cancel')}
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={
-                    updateProject.isPending || !name.trim() || !hasChanges
-                  }
-                >
-                  {updateProject.isPending
-                    ? t('project.saving')
-                    : t('project.saveChanges')}
-                </Button>
-              </DialogFooter>
-            </TabsContent>
-
-            <TabsContent value="worktrees">
-              <WorktreeTab project={project} />
-            </TabsContent>
-          </Tabs>
-        </DialogContent>
-      </Dialog>
+          ) : null
+        }
+      >
+        {(active) => (
+          <>
+            {active === 'general' && (
+              <GeneralSection
+                name={name}
+                setName={setName}
+                description={description}
+                setDescription={setDescription}
+                directory={directory}
+                setDirectory={setDirectory}
+                repositoryUrl={repositoryUrl}
+                setRepositoryUrl={setRepositoryUrl}
+                dirPickerOpen={dirPickerOpen}
+                setDirPickerOpen={setDirPickerOpen}
+                detectingRemote={detectingRemote}
+                setDetectingRemote={setDetectingRemote}
+                error={error}
+              />
+            )}
+            {active === 'prompt' && (
+              <PromptSection
+                systemPrompt={systemPrompt}
+                setSystemPrompt={setSystemPrompt}
+              />
+            )}
+            {active === 'envvars' && (
+              <EnvVarsSection
+                envVarsText={envVarsText}
+                setEnvVarsText={setEnvVarsText}
+              />
+            )}
+            {active === 'worktrees' && <WorktreeSection project={project} />}
+          </>
+        )}
+      </SettingsLayout>
 
       <DeleteProjectDialog
         open={deleteDialogOpen}
@@ -506,5 +380,188 @@ export function ProjectSettingsDialog({
         }}
       />
     </>
+  )
+}
+
+function GeneralSection({
+  name,
+  setName,
+  description,
+  setDescription,
+  directory,
+  setDirectory,
+  repositoryUrl,
+  setRepositoryUrl,
+  dirPickerOpen,
+  setDirPickerOpen,
+  detectingRemote,
+  setDetectingRemote,
+  error,
+}: {
+  name: string
+  setName: (v: string) => void
+  description: string
+  setDescription: (v: string) => void
+  directory: string
+  setDirectory: (v: string) => void
+  repositoryUrl: string
+  setRepositoryUrl: (v: string) => void
+  dirPickerOpen: boolean
+  setDirPickerOpen: (v: boolean) => void
+  detectingRemote: boolean
+  setDetectingRemote: (v: boolean) => void
+  error: string
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <FieldGroup>
+      <Field>
+        <Label>
+          {t('project.name')} <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t('project.namePlaceholder')}
+          autoFocus
+          className="w-full"
+        />
+      </Field>
+
+      <Field>
+        <Label>{t('project.description')}</Label>
+        <Textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={t('project.descriptionPlaceholder')}
+          rows={3}
+          className="w-full resize-none"
+        />
+      </Field>
+
+      <Field>
+        <Label>{t('project.directory')}</Label>
+        <div className="flex gap-1.5">
+          <Input
+            type="text"
+            value={directory}
+            onChange={(e) => setDirectory(e.target.value)}
+            placeholder={t('project.directoryPlaceholder')}
+            className="w-full"
+          />
+          <Button
+            onClick={() => setDirPickerOpen(true)}
+            variant="outline"
+            size="icon"
+            title={t('project.browseDirectories')}
+          >
+            <FolderOpen className="size-4 text-muted-foreground" />
+          </Button>
+        </div>
+        <DirectoryPicker
+          open={dirPickerOpen}
+          onOpenChange={setDirPickerOpen}
+          initialPath={directory || undefined}
+          onSelect={setDirectory}
+        />
+      </Field>
+
+      <Field className="space-y-1.5">
+        <Label>{t('project.repositoryUrl')}</Label>
+        <div className="flex gap-1.5">
+          <Input
+            type="text"
+            value={repositoryUrl}
+            onChange={(e) => setRepositoryUrl(e.target.value)}
+            placeholder={t('project.repositoryUrlPlaceholder')}
+            className="w-full"
+          />
+          <Button
+            onClick={async () => {
+              const dir = directory.trim()
+              if (!dir) return
+              setDetectingRemote(true)
+              try {
+                const result = await kanbanApi.detectGitRemote(dir)
+                setRepositoryUrl(result.url)
+              } catch {
+                // silently ignore — directory may not be a git repo
+              } finally {
+                setDetectingRemote(false)
+              }
+            }}
+            variant="outline"
+            type="button"
+            disabled={!directory.trim() || detectingRemote}
+            title={t('project.detectGitRemote')}
+            className="shrink-0"
+          >
+            {detectingRemote ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              'Auto'
+            )}
+          </Button>
+        </div>
+      </Field>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </FieldGroup>
+  )
+}
+
+function PromptSection({
+  systemPrompt,
+  setSystemPrompt,
+}: {
+  systemPrompt: string
+  setSystemPrompt: (v: string) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <FieldGroup className="h-full">
+      <Field className="flex-1">
+        <Label>{t('project.systemPrompt')}</Label>
+        <Textarea
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          placeholder={t('project.systemPromptPlaceholder')}
+          className="w-full flex-1 resize-none font-mono text-xs"
+        />
+        <p className="text-xs text-muted-foreground">
+          {t('project.systemPromptHint')}
+        </p>
+      </Field>
+    </FieldGroup>
+  )
+}
+
+function EnvVarsSection({
+  envVarsText,
+  setEnvVarsText,
+}: {
+  envVarsText: string
+  setEnvVarsText: (v: string) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <FieldGroup className="h-full">
+      <Field className="flex-1">
+        <Label>{t('project.envVars')}</Label>
+        <p className="text-xs text-muted-foreground mb-2">
+          {t('project.envVarsHint')}
+        </p>
+        <Textarea
+          value={envVarsText}
+          onChange={(e) => setEnvVarsText(e.target.value)}
+          placeholder={t('project.envVarsPlaceholder')}
+          className="w-full flex-1 resize-none font-mono text-xs"
+        />
+      </Field>
+    </FieldGroup>
   )
 }

--- a/apps/frontend/src/components/ui/settings-layout.tsx
+++ b/apps/frontend/src/components/ui/settings-layout.tsx
@@ -1,0 +1,146 @@
+import type { LucideIcon } from 'lucide-react'
+import { Menu, X } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+export interface SettingsNavItem {
+  id: string
+  label: string
+  icon: LucideIcon
+}
+
+export function SettingsLayout({
+  open,
+  onOpenChange,
+  title,
+  items,
+  defaultItem,
+  children,
+  footer,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  items: SettingsNavItem[]
+  defaultItem?: string
+  children: (activeItem: string) => React.ReactNode
+  footer?: (activeItem: string) => React.ReactNode
+}) {
+  const [active, setActive] = useState(defaultItem ?? items[0]?.id ?? '')
+  const [mobileNavOpen, setMobileNavOpen] = useState(false)
+
+  const handleNavClick = (id: string) => {
+    setActive(id)
+    setMobileNavOpen(false)
+  }
+
+  const activeLabel = items.find((i) => i.id === active)?.label
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        aria-describedby={undefined}
+        showCloseButton={false}
+        className={cn(
+          // Mobile: full-screen
+          'inset-0 top-0 left-0 h-dvh w-full max-w-none translate-x-0 translate-y-0 rounded-none',
+          // Desktop (md+): centered dialog
+          'md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2',
+          'md:h-[min(460px,65dvh)] md:w-full md:max-w-2xl md:rounded-xl',
+          // Shared
+          'flex flex-col overflow-hidden p-0 gap-0',
+        )}
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <div className="relative flex min-h-0 flex-1">
+          {/* Sidebar — always visible on desktop, overlay on mobile */}
+          <nav
+            className={cn(
+              // Desktop: static sidebar
+              'hidden md:flex w-40 shrink-0 flex-col border-r bg-muted/30 p-3',
+              // Mobile: overlay drawer from left
+              mobileNavOpen &&
+                'fixed inset-y-0 left-0 z-50 flex w-64 bg-background p-3 shadow-lg md:relative md:w-40 md:bg-muted/30 md:shadow-none md:z-auto',
+            )}
+          >
+            <div className="mb-3 flex items-center justify-between px-2">
+              <h2 className="text-sm font-semibold">{title}</h2>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="md:hidden"
+                onClick={() => setMobileNavOpen(false)}
+              >
+                <X className="size-4" />
+              </Button>
+            </div>
+            <div className="flex flex-col gap-0.5">
+              {items.map((item) => {
+                const Icon = item.icon
+                const isActive = item.id === active
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => handleNavClick(item.id)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors text-left',
+                      isActive
+                        ? 'bg-primary/10 text-primary font-medium'
+                        : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
+                    )}
+                  >
+                    <Icon className="size-4 shrink-0" />
+                    {item.label}
+                  </button>
+                )
+              })}
+            </div>
+          </nav>
+
+          {/* Mobile nav backdrop */}
+          {mobileNavOpen && (
+            <div
+              className="fixed inset-0 z-40 bg-black/20 md:hidden"
+              onClick={() => setMobileNavOpen(false)}
+              onKeyDown={() => {}}
+              role="presentation"
+            />
+          )}
+
+          {/* Content — always visible */}
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <div className="flex items-center justify-between border-b px-5 py-3">
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  className="md:hidden"
+                  onClick={() => setMobileNavOpen(true)}
+                >
+                  <Menu className="size-4" />
+                </Button>
+                <h3 className="text-sm font-semibold">{activeLabel}</h3>
+              </div>
+              <DialogClose render={<Button variant="ghost" size="icon-sm" />}>
+                <X className="size-4" />
+                <span className="sr-only">Close</span>
+              </DialogClose>
+            </div>
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-5">
+              {children(active)}
+            </div>
+            {footer?.(active)}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -75,6 +75,8 @@ export function useUpdateProject() {
       description?: string
       directory?: string
       repositoryUrl?: string
+      systemPrompt?: string
+      envVars?: Record<string, string>
     }) => {
       const { id, ...rest } = data
       return kanbanApi.updateProject(id, rest)


### PR DESCRIPTION
## Summary

- Create shared `SettingsLayout` component (`settings-layout.tsx`) with left sidebar navigation + right content panel
- Refactor `AppSettingsDialog` and `ProjectSettingsDialog` to use the new layout, replacing tab-based navigation
- **Desktop (md+)**: centered dialog with fixed height (`min(460px, 65dvh)`), sidebar always visible
- **Mobile (<md)**: full-screen with hamburger menu button that opens a left overlay drawer for navigation
- Prompt and env vars textareas use flex layout to fill available space
- Fix `useUpdateProject` hook missing `systemPrompt` and `envVars` type definitions

## Test plan

- [ ] Open App Settings from sidebar — verify sidebar nav works, all 3 sections (General, Models, About) render correctly
- [ ] Open Project Settings — verify all 4 sections (General, Prompt, Env Vars, Worktrees) render correctly
- [ ] Switch between sections — dialog size stays consistent
- [ ] Save changes in Project Settings — verify footer buttons work on all tabs except Worktrees
- [ ] Test on mobile viewport — verify full-screen layout with hamburger menu overlay
- [ ] Verify Prompt and Env Vars textareas fill available height