### PR TITLE
feat: inline slash command menu in chat input

### DIFF
--- a/apps/api/src/engines/executors/claude/normalizer.ts
+++ b/apps/api/src/engines/executors/claude/normalizer.ts
@@ -103,6 +103,8 @@ export class ClaudeLogNormalizer {
             slashCommands: Array.isArray(data.slash_commands)
               ? data.slash_commands
               : [],
+            agents: Array.isArray(data.agents) ? data.agents : [],
+            plugins: Array.isArray(data.plugins) ? data.plugins : [],
           },
         }
       case 'compact_boundary':

--- a/apps/api/src/engines/issue/engine.ts
+++ b/apps/api/src/engines/issue/engine.ts
@@ -24,6 +24,7 @@ import { terminateProcess } from './process/cancel'
 import {
   cancelAll,
   getActiveProcessesList,
+  getCategorizedCommands,
   getLogs,
   getProcess,
   getSlashCommands,
@@ -187,6 +188,13 @@ export class IssueEngine {
 
   getSlashCommands(issueId: string, engineType?: EngineType): string[] {
     return getSlashCommands(this.ctx, issueId, engineType)
+  }
+
+  getCategorizedCommands(
+    issueId: string,
+    engineType?: EngineType,
+  ): import('@bitk/shared').CategorizedCommands {
+    return getCategorizedCommands(this.ctx, issueId, engineType)
   }
 
   getActiveProcesses(): ManagedProcess[] {

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -49,6 +49,8 @@ export function register(
     metaTurn,
     lastActivityAt: new Date(),
     slashCommands: [],
+    agents: [],
+    plugins: [],
     spawnCommand: process.spawnCommand,
     worktreeBaseDir,
     worktreePath,

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -1,3 +1,4 @@
+import type { CategorizedCommands } from '@bitk/shared'
 import { cacheDel } from '@/cache'
 import { getAppSetting, setAppSetting } from '@/db/helpers'
 import type { EngineType, NormalizedLogEntry } from '@/engines/types'
@@ -10,6 +11,12 @@ import { isVisibleForMode, setIssueDevMode } from './utils/visibility'
 
 const SLASH_COMMANDS_PREFIX = 'engine:slashCommands'
 
+const EMPTY_CATEGORIZED: CategorizedCommands = {
+  commands: [],
+  agents: [],
+  plugins: [],
+}
+
 /** All known engine types for cache loading. */
 const ALL_ENGINE_TYPES: EngineType[] = [
   'claude-code',
@@ -18,28 +25,56 @@ const ALL_ENGINE_TYPES: EngineType[] = [
   'echo',
 ]
 
-/** Per-engine in-memory cache for slash commands from DB. */
-const cachedSlashCommands = new Map<EngineType, string[]>()
+/** Per-engine in-memory cache for categorized commands from DB. */
+const cachedCommands = new Map<EngineType, CategorizedCommands>()
 
 /** DB key for engine-specific slash commands. */
 export function slashCommandsKey(engineType: EngineType): string {
   return `${SLASH_COMMANDS_PREFIX}:${engineType}`
 }
 
-/** Load slash commands from DB into memory cache for all engines. Called on startup and after probe. */
+/**
+ * Parse raw DB value into CategorizedCommands.
+ * Handles both legacy format (string[]) and new format (CategorizedCommands).
+ */
+function parseCategorized(raw: string): CategorizedCommands | null {
+  try {
+    const parsed = JSON.parse(raw)
+    // Legacy format: plain string[]
+    if (Array.isArray(parsed)) {
+      return parsed.length > 0
+        ? { commands: parsed as string[], agents: [], plugins: [] }
+        : null
+    }
+    // New format: { commands, agents, plugins }
+    const cat = parsed as CategorizedCommands
+    if (
+      cat.commands?.length > 0 ||
+      cat.agents?.length > 0 ||
+      cat.plugins?.length > 0
+    ) {
+      return {
+        commands: cat.commands ?? [],
+        agents: cat.agents ?? [],
+        plugins: cat.plugins ?? [],
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/** Load categorized commands from DB into memory cache for all engines. */
 export async function refreshSlashCommandsCache(): Promise<void> {
   await Promise.all(
     ALL_ENGINE_TYPES.map(async (et) => {
       const raw = await getAppSetting(slashCommandsKey(et))
-      try {
-        const commands = raw ? (JSON.parse(raw) as string[]) : null
-        if (commands && commands.length > 0) {
-          cachedSlashCommands.set(et, commands)
-        } else {
-          cachedSlashCommands.delete(et)
-        }
-      } catch {
-        cachedSlashCommands.delete(et)
+      const cat = raw ? parseCategorized(raw) : null
+      if (cat) {
+        cachedCommands.set(et, cat)
+      } else {
+        cachedCommands.delete(et)
       }
     }),
   )
@@ -50,26 +85,31 @@ export async function refreshSlashCommandsCacheForEngine(
   engineType: EngineType,
 ): Promise<void> {
   const raw = await getAppSetting(slashCommandsKey(engineType))
-  try {
-    const commands = raw ? (JSON.parse(raw) as string[]) : null
-    if (commands && commands.length > 0) {
-      cachedSlashCommands.set(engineType, commands)
-    } else {
-      cachedSlashCommands.delete(engineType)
-    }
-  } catch {
-    cachedSlashCommands.delete(engineType)
+  const cat = raw ? parseCategorized(raw) : null
+  if (cat) {
+    cachedCommands.set(engineType, cat)
+  } else {
+    cachedCommands.delete(engineType)
   }
 }
 
-export function getCachedSlashCommands(engineType?: EngineType): string[] {
-  if (engineType) return cachedSlashCommands.get(engineType) ?? []
-  // Fallback: merge all engines (for backwards compat with global endpoint without engine param)
-  const all: string[] = []
-  for (const cmds of cachedSlashCommands.values()) {
-    all.push(...cmds)
+export function getCachedCategorizedCommands(
+  engineType?: EngineType,
+): CategorizedCommands {
+  if (engineType) return cachedCommands.get(engineType) ?? EMPTY_CATEGORIZED
+  // Fallback: merge all engines
+  const merged: CategorizedCommands = { commands: [], agents: [], plugins: [] }
+  for (const cat of cachedCommands.values()) {
+    merged.commands.push(...cat.commands)
+    merged.agents.push(...cat.agents)
+    merged.plugins.push(...cat.plugins)
   }
-  return all
+  return merged
+}
+
+/** @deprecated Use getCachedCategorizedCommands instead. Kept for callers that only need command names. */
+export function getCachedSlashCommands(engineType?: EngineType): string[] {
+  return getCachedCategorizedCommands(engineType).commands
 }
 
 /**
@@ -191,16 +231,35 @@ export function isTurnInFlight(ctx: EngineContext, issueId: string): boolean {
   return !!active && active.turnInFlight
 }
 
+export function getCategorizedCommands(
+  ctx: EngineContext,
+  issueId: string,
+  engineType?: EngineType,
+): CategorizedCommands {
+  const active = getActiveProcessForIssue(ctx, issueId)
+  if (
+    active &&
+    (active.slashCommands.length > 0 ||
+      active.agents.length > 0 ||
+      active.plugins.length > 0)
+  ) {
+    return {
+      commands: active.slashCommands,
+      agents: active.agents,
+      plugins: active.plugins,
+    }
+  }
+  const et = active?.engineType ?? engineType
+  return getCachedCategorizedCommands(et)
+}
+
+/** @deprecated Use getCategorizedCommands instead. */
 export function getSlashCommands(
   ctx: EngineContext,
   issueId: string,
   engineType?: EngineType,
 ): string[] {
-  const active = getActiveProcessForIssue(ctx, issueId)
-  if (active && active.slashCommands.length > 0) return active.slashCommands
-  // Use the active process's engine type, or the caller-supplied one, for cache lookup
-  const et = active?.engineType ?? engineType
-  return getCachedSlashCommands(et)
+  return getCategorizedCommands(ctx, issueId, engineType).commands
 }
 
 export async function cancelAll(ctx: EngineContext): Promise<void> {

--- a/apps/api/src/engines/issue/streams/consumer.ts
+++ b/apps/api/src/engines/issue/streams/consumer.ts
@@ -1,3 +1,4 @@
+import type { CategorizedCommands } from '@bitk/shared'
 import { setAppSetting } from '@/db/helpers'
 import {
   refreshSlashCommandsCacheForEngine,
@@ -17,12 +18,17 @@ function clipForLog(input: string): string {
   return `${input.slice(0, MAX_IO_LOG_CHARS)}...<truncated:${input.length - MAX_IO_LOG_CHARS}>`
 }
 
-async function saveSlashCommandsToSettings(
+async function saveCategorizedCommandsToSettings(
   engineType: EngineType,
-  commands: string[],
+  categorized: CategorizedCommands,
 ): Promise<void> {
-  if (commands.length === 0) return
-  await setAppSetting(slashCommandsKey(engineType), JSON.stringify(commands))
+  if (
+    categorized.commands.length === 0 &&
+    categorized.agents.length === 0 &&
+    categorized.plugins.length === 0
+  )
+    return
+  await setAppSetting(slashCommandsKey(engineType), JSON.stringify(categorized))
   await refreshSlashCommandsCacheForEngine(engineType)
 }
 
@@ -75,17 +81,26 @@ export async function consumeStream(
           timestamp: rawEntry.timestamp ?? new Date().toISOString(),
         }
 
-        // Extract slash commands from SDK init message
+        // Extract categorized commands from SDK init message
         if (
           entry.entryType === 'system-message' &&
-          entry.metadata?.subtype === 'init' &&
-          Array.isArray(entry.metadata.slashCommands)
+          entry.metadata?.subtype === 'init'
         ) {
-          managed.slashCommands = entry.metadata.slashCommands as string[]
-          void saveSlashCommandsToSettings(
-            managed.engineType,
-            managed.slashCommands,
-          )
+          const meta = entry.metadata
+          managed.slashCommands = Array.isArray(meta.slashCommands)
+            ? (meta.slashCommands as string[])
+            : []
+          managed.agents = Array.isArray(meta.agents)
+            ? (meta.agents as string[])
+            : []
+          managed.plugins = Array.isArray(meta.plugins)
+            ? (meta.plugins as Array<{ name: string; path: string }>)
+            : []
+          void saveCategorizedCommandsToSettings(managed.engineType, {
+            commands: managed.slashCommands,
+            agents: managed.agents,
+            plugins: managed.plugins,
+          })
         }
 
         // Tag all entries in a meta turn so they are hidden from the frontend

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -34,6 +34,8 @@ export interface ManagedProcess {
    *  All log entries in this turn will be tagged with `type: 'system'` and hidden by isVisibleForMode(). */
   metaTurn: boolean
   slashCommands: string[]
+  agents: string[]
+  plugins: Array<{ name: string; path: string }>
   /** The full command used to spawn this process (e.g. "claude -p --output-format=stream-json ...") */
   spawnCommand?: string
   /** Timestamp when the last turn completed and the process became idle */

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -213,7 +213,11 @@ async function discoverSlashCommands(
 
       await setAppSetting(
         slashCommandsKey('claude-code'),
-        JSON.stringify(result.slashCommands),
+        JSON.stringify({
+          commands: result.slashCommands,
+          agents: result.agents,
+          plugins: result.plugins,
+        }),
       )
       await refreshSlashCommandsCacheForEngine('claude-code')
 

--- a/apps/api/src/routes/issues/command.ts
+++ b/apps/api/src/routes/issues/command.ts
@@ -266,8 +266,8 @@ command.get('/:id/slash-commands', async (c) => {
 
   const engineType =
     (issue.engineType as import('@/engines/types').EngineType) ?? undefined
-  const commands = issueEngine.getSlashCommands(issueId, engineType)
-  return c.json({ success: true, data: { commands } })
+  const categorized = issueEngine.getCategorizedCommands(issueId, engineType)
+  return c.json({ success: true, data: categorized })
 })
 
 export default command

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -285,12 +285,15 @@ message.post('/:id/follow-up', async (c) => {
     const { prompt: effectivePrompt, pendingIds } =
       await collectPendingMessages(issueId, fullPrompt)
     const firstWord = prompt.split(/\s/)[0] ?? ''
-    const knownCommands = issueEngine
-      .getSlashCommands(
-        issueId,
-        (issue.engineType as import('@/engines/types').EngineType) ?? undefined,
-      )
-      .map((cmd) => (cmd.startsWith('/') ? cmd : `/${cmd}`))
+    const categorized = issueEngine.getCategorizedCommands(
+      issueId,
+      (issue.engineType as import('@/engines/types').EngineType) ?? undefined,
+    )
+    const knownCommands = [
+      ...categorized.commands,
+      ...categorized.agents,
+      ...categorized.plugins.map((p) => p.name),
+    ].map((cmd) => (cmd.startsWith('/') ? cmd : `/${cmd}`))
     const isCommand =
       firstWord.startsWith('/') &&
       knownCommands.some((cmd) => cmd === firstWord)

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -5,6 +5,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import * as z from 'zod'
 import { getAppSetting, setAppSetting } from '@/db/helpers'
+import { getCachedCategorizedCommands } from '@/engines/issue/queries'
 import type { WriteFilterRule } from '@/engines/write-filter'
 import {
   DEFAULT_FILTER_RULES,
@@ -197,20 +198,20 @@ general.get('/slash-commands', async (c) => {
     )
   }
   const engine = rawEngine as import('@/engines/types').EngineType | undefined
-  const key = engine ? `engine:slashCommands:${engine}` : undefined
-
-  let commands: string[] = []
-  if (key) {
-    const raw = await getAppSetting(key)
-    if (raw) {
-      try {
-        commands = JSON.parse(raw) as string[]
-      } catch {
-        commands = []
-      }
-    }
+  let categorized = getCachedCategorizedCommands(engine)
+  // If cache is cold (empty result), try refreshing from DB before responding
+  if (
+    categorized.commands.length === 0 &&
+    categorized.agents.length === 0 &&
+    categorized.plugins.length === 0
+  ) {
+    const { refreshSlashCommandsCache } = await import(
+      '@/engines/issue/queries'
+    )
+    await refreshSlashCommandsCache()
+    categorized = getCachedCategorizedCommands(engine)
   }
-  return c.json({ success: true, data: { commands } })
+  return c.json({ success: true, data: categorized })
 })
 
 export default general

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -168,8 +168,14 @@ export function ChatBody({
   const hasSession = !!issue.sessionStatus
   const { data: globalCmds } = useGlobalSlashCommands(issue.engineType)
   const { data: liveCmds } = useSlashCommands(projectId, issueId, hasSession)
-  const slashCommands =
-    (liveCmds?.commands.length ? liveCmds.commands : globalCmds?.commands) ?? []
+  const hasLive =
+    (liveCmds?.commands?.length ?? 0) > 0 ||
+    (liveCmds?.agents?.length ?? 0) > 0 ||
+    (liveCmds?.plugins?.length ?? 0) > 0
+  const activeCmds = hasLive ? liveCmds : globalCmds
+  const slashCommands = activeCmds?.commands ?? []
+  const agentCommands = activeCmds?.agents ?? []
+  const pluginCommands = activeCmds?.plugins ?? []
 
   const {
     logs,
@@ -323,6 +329,8 @@ export function ChatBody({
         statusId={issue.statusId}
         isThinking={isThinking}
         slashCommands={slashCommands}
+        agentCommands={agentCommands}
+        pluginCommands={pluginCommands}
         onMessageSent={(messageId, prompt, metadata) => {
           appendServerMessage(messageId, prompt, metadata)
         }}

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -1,8 +1,10 @@
 import {
+  Bot,
   FileText,
   Image as ImageIcon,
   Loader2,
   Paperclip,
+  Plug,
   SlashSquare,
   X,
 } from 'lucide-react'
@@ -690,6 +692,22 @@ export function ChatInput({
                 onSelect={(cmd) => selectSlashCommand(cmd)}
               />
             ) : null}
+            {agentCommands.length > 0 ? (
+              <AgentPicker
+                agents={agentCommands}
+                onSelect={(a) =>
+                  selectSlashCommand(a.startsWith('/') ? a : `/${a}`)
+                }
+              />
+            ) : null}
+            {pluginCommands.length > 0 ? (
+              <PluginPicker
+                plugins={pluginCommands}
+                onSelect={(p) =>
+                  selectSlashCommand(p.startsWith('/') ? p : `/${p}`)
+                }
+              />
+            ) : null}
           </div>
 
           <Button
@@ -955,6 +973,113 @@ function CommandPicker({
                 className="text-xs px-3 py-1.5"
               >
                 <code className="font-mono text-foreground/80">{cmd}</code>
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+// ─── AgentPicker ─────────────────────────────────────────────────────────────
+
+function AgentPicker({
+  agents,
+  onSelect,
+}: {
+  agents: string[]
+  onSelect: (agent: string) => void
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={<Button variant="ghost" size="icon" title={t('chat.agents')} />}
+      >
+        <Bot className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent side="top" align="start" className="w-[260px] p-0">
+        <Command>
+          <CommandInput
+            placeholder={t('chat.agentSearch')}
+            className="text-xs h-8"
+          />
+          <CommandList className="max-h-[240px]">
+            <CommandEmpty className="text-xs text-muted-foreground/50 px-3 py-2">
+              {t('chat.noAgents')}
+            </CommandEmpty>
+            {agents.map((agent) => (
+              <CommandItem
+                key={agent}
+                value={agent}
+                onSelect={() => {
+                  onSelect(agent)
+                  setOpen(false)
+                }}
+                className="text-xs px-3 py-1.5"
+              >
+                <code className="font-mono text-foreground/80">{agent}</code>
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+// ─── PluginPicker ────────────────────────────────────────────────────────────
+
+function PluginPicker({
+  plugins,
+  onSelect,
+}: {
+  plugins: Array<{ name: string; path: string }>
+  onSelect: (name: string) => void
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button variant="ghost" size="icon" title={t('chat.plugins')} />
+        }
+      >
+        <Plug className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent side="top" align="start" className="w-[280px] p-0">
+        <Command>
+          <CommandInput
+            placeholder={t('chat.pluginSearch')}
+            className="text-xs h-8"
+          />
+          <CommandList className="max-h-[240px]">
+            <CommandEmpty className="text-xs text-muted-foreground/50 px-3 py-2">
+              {t('chat.noPlugins')}
+            </CommandEmpty>
+            {plugins.map((plugin) => (
+              <CommandItem
+                key={plugin.name}
+                value={plugin.name}
+                onSelect={() => {
+                  onSelect(plugin.name)
+                  setOpen(false)
+                }}
+                className="text-xs px-3 py-1.5"
+              >
+                <div className="flex flex-col gap-0.5">
+                  <code className="font-mono text-foreground/80">
+                    {plugin.name}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground/50 truncate">
+                    {plugin.path}
+                  </span>
+                </div>
               </CommandItem>
             ))}
           </CommandList>

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -184,7 +184,13 @@ export function ChatInput({
       : busyAction
     : undefined
 
-  // Build tagged command list with category labels
+  // Normalized slash commands only (for CommandPicker button + command detection)
+  const normalizedSlashCommands = useMemo(
+    () => slashCommands.map((cmd) => (cmd.startsWith('/') ? cmd : `/${cmd}`)),
+    [slashCommands],
+  )
+
+  // Build tagged command list with category labels (for inline menu)
   type TaggedCommand = {
     value: string
     category: 'command' | 'agent' | 'plugin'
@@ -201,7 +207,7 @@ export function ChatInput({
     return items
   }, [slashCommands, agentCommands, pluginCommands])
 
-  // Keep normalizedCommands for command detection in handleSend
+  // All command values for command detection in handleSend
   const normalizedCommands = useMemo(
     () => allCommands.map((c) => c.value),
     [allCommands],
@@ -686,9 +692,9 @@ export function ChatInput({
             >
               <Paperclip className="size-4" />
             </Button>
-            {normalizedCommands.length > 0 ? (
+            {normalizedSlashCommands.length > 0 ? (
               <CommandPicker
-                commands={normalizedCommands}
+                commands={normalizedSlashCommands}
                 onSelect={(cmd) => selectSlashCommand(cmd)}
               />
             ) : null}

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -68,6 +68,8 @@ export function ChatInput({
   isThinking = false,
   onMessageSent,
   slashCommands = [],
+  agentCommands = [],
+  pluginCommands = [],
 }: {
   projectId?: string
   issueId?: string
@@ -85,6 +87,8 @@ export function ChatInput({
     metadata?: Record<string, unknown>,
   ) => void
   slashCommands?: string[]
+  agentCommands?: string[]
+  pluginCommands?: Array<{ name: string; path: string }>
 }) {
   const { t } = useTranslation()
   const draftKey = issueId ? `bitk:draft:${issueId}` : null
@@ -178,10 +182,27 @@ export function ChatInput({
       : busyAction
     : undefined
 
-  // Commands from SDK may or may not have "/" prefix — normalize
+  // Build tagged command list with category labels
+  type TaggedCommand = {
+    value: string
+    category: 'command' | 'agent' | 'plugin'
+  }
+  const allCommands: TaggedCommand[] = useMemo(() => {
+    const norm = (cmd: string) => (cmd.startsWith('/') ? cmd : `/${cmd}`)
+    const items: TaggedCommand[] = []
+    for (const cmd of slashCommands)
+      items.push({ value: norm(cmd), category: 'command' })
+    for (const a of agentCommands)
+      items.push({ value: norm(a), category: 'agent' })
+    for (const p of pluginCommands)
+      items.push({ value: norm(p.name), category: 'plugin' })
+    return items
+  }, [slashCommands, agentCommands, pluginCommands])
+
+  // Keep normalizedCommands for command detection in handleSend
   const normalizedCommands = useMemo(
-    () => slashCommands.map((cmd) => (cmd.startsWith('/') ? cmd : `/${cmd}`)),
-    [slashCommands],
+    () => allCommands.map((c) => c.value),
+    [allCommands],
   )
 
   // Inline command menu: show when input starts with "/" and has no spaces yet
@@ -193,10 +214,11 @@ export function ChatInput({
   }, [input])
 
   const filteredCommands = useMemo(() => {
-    if (commandQuery === null || normalizedCommands.length === 0) return []
-    if (commandQuery === '') return normalizedCommands
-    return normalizedCommands.filter((cmd) => {
-      const target = cmd.toLowerCase()
+    if (commandQuery === null || allCommands.length === 0)
+      return [] as TaggedCommand[]
+    if (commandQuery === '') return allCommands
+    return allCommands.filter((item) => {
+      const target = item.value.toLowerCase()
       let ti = 0
       for (let qi = 0; qi < commandQuery.length; qi++) {
         ti = target.indexOf(commandQuery[qi], ti)
@@ -205,7 +227,7 @@ export function ChatInput({
       }
       return true
     })
-  }, [commandQuery, normalizedCommands])
+  }, [commandQuery, allCommands])
 
   const showCommandMenu = filteredCommands.length > 0
   const [commandIndex, setCommandIndex] = useState(0)
@@ -368,9 +390,9 @@ export function ChatInput({
       }
       if (e.key === 'Enter' || e.key === 'Tab') {
         e.preventDefault()
-        const cmd = filteredCommands[commandIndex]
-        if (cmd) {
-          setInput(`${cmd} `)
+        const item = filteredCommands[commandIndex]
+        if (item) {
+          setInput(`${item.value} `)
           textareaRef.current?.focus()
         }
         return
@@ -554,22 +576,27 @@ export function ChatInput({
         {showCommandMenu ? (
           <div className="mx-2 mt-1 rounded-lg border border-border/40 bg-popover shadow-md overflow-hidden">
             <div className="max-h-[200px] overflow-y-auto py-1">
-              {filteredCommands.map((cmd, i) => (
+              {filteredCommands.map((item, i) => (
                 <button
-                  key={cmd}
+                  key={`${item.category}:${item.value}`}
                   type="button"
                   onMouseDown={(e) => {
                     e.preventDefault()
-                    setInput(`${cmd} `)
+                    setInput(`${item.value} `)
                     textareaRef.current?.focus()
                   }}
-                  className={`w-full text-left px-3 py-1.5 text-xs font-mono transition-colors ${
+                  className={`w-full flex items-center gap-2 text-left px-3 py-1.5 text-xs transition-colors ${
                     i === commandIndex
                       ? 'bg-primary/10 text-primary'
                       : 'text-foreground/80 hover:bg-muted/50'
                   }`}
                 >
-                  {cmd}
+                  <code className="font-mono">{item.value}</code>
+                  {item.category !== 'command' ? (
+                    <span className="ml-auto text-[10px] text-muted-foreground/60 uppercase tracking-wider">
+                      {item.category}
+                    </span>
+                  ) : null}
                 </button>
               ))}
             </div>

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -396,7 +396,7 @@ export function ChatInput({
         setCommandIndex((i) => (i > 0 ? i - 1 : filteredCommands.length - 1))
         return
       }
-      if (e.key === 'Enter' || e.key === 'Tab') {
+      if ((e.key === 'Enter' && !e.metaKey && !e.ctrlKey) || e.key === 'Tab') {
         e.preventDefault()
         const item = filteredCommands[commandIndex]
         if (item) {
@@ -602,7 +602,9 @@ export function ChatInput({
                   <code className="font-mono">{item.value}</code>
                   {item.category !== 'command' ? (
                     <span className="ml-auto text-[10px] text-muted-foreground/60 uppercase tracking-wider">
-                      {item.category}
+                      {t(
+                        `chat.${item.category === 'agent' ? 'agents' : 'plugins'}`,
+                      )}
                     </span>
                   ) : null}
                 </button>

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -184,6 +184,38 @@ export function ChatInput({
     [slashCommands],
   )
 
+  // Inline command menu: show when input starts with "/" and has no spaces yet
+  const commandQuery = useMemo(() => {
+    const trimmed = input.trimStart()
+    if (!trimmed.startsWith('/')) return null
+    if (trimmed.includes(' ')) return null
+    return trimmed.slice(1).toLowerCase()
+  }, [input])
+
+  const filteredCommands = useMemo(() => {
+    if (commandQuery === null || normalizedCommands.length === 0) return []
+    if (commandQuery === '') return normalizedCommands
+    return normalizedCommands.filter((cmd) => {
+      const target = cmd.toLowerCase()
+      let ti = 0
+      for (let qi = 0; qi < commandQuery.length; qi++) {
+        ti = target.indexOf(commandQuery[qi], ti)
+        if (ti === -1) return false
+        ti++
+      }
+      return true
+    })
+  }, [commandQuery, normalizedCommands])
+
+  const showCommandMenu = filteredCommands.length > 0
+  const [commandIndex, setCommandIndex] = useState(0)
+  // Reset selection when filtered list changes
+  const prevFilteredRef = useRef(filteredCommands)
+  if (prevFilteredRef.current !== filteredCommands) {
+    prevFilteredRef.current = filteredCommands
+    if (commandIndex !== 0) setCommandIndex(0)
+  }
+
   const normalizedPrompt = normalizePrompt(input)
   const canSend =
     (normalizedPrompt.length > 0 || attachedFiles.length > 0) &&
@@ -323,6 +355,33 @@ export function ChatInput({
   }, [])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (showCommandMenu) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setCommandIndex((i) => (i < filteredCommands.length - 1 ? i + 1 : 0))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setCommandIndex((i) => (i > 0 ? i - 1 : filteredCommands.length - 1))
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        const cmd = filteredCommands[commandIndex]
+        if (cmd) {
+          setInput(`${cmd} `)
+          textareaRef.current?.focus()
+        }
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        // Add a space to dismiss the menu while keeping the text
+        setInput((prev) => `${prev} `)
+        return
+      }
+    }
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
       e.preventDefault()
       void handleSend()
@@ -488,6 +547,32 @@ export function ChatInput({
         {sendError ? (
           <div className="mx-2 mt-2 rounded-lg bg-destructive/10 border border-destructive/20 px-2 py-2 text-xs text-destructive">
             {sendError}
+          </div>
+        ) : null}
+
+        {/* Inline command menu */}
+        {showCommandMenu ? (
+          <div className="mx-2 mt-1 rounded-lg border border-border/40 bg-popover shadow-md overflow-hidden">
+            <div className="max-h-[200px] overflow-y-auto py-1">
+              {filteredCommands.map((cmd, i) => (
+                <button
+                  key={cmd}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    setInput(`${cmd} `)
+                    textareaRef.current?.focus()
+                  }}
+                  className={`w-full text-left px-3 py-1.5 text-xs font-mono transition-colors ${
+                    i === commandIndex
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-foreground/80 hover:bg-muted/50'
+                  }`}
+                >
+                  {cmd}
+                </button>
+              ))}
+            </div>
           </div>
         ) : null}
 

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -164,6 +164,12 @@
     "commands": "Commands",
     "commandSearch": "Search commands...",
     "noCommands": "No matching commands",
+    "agents": "Agents",
+    "agentSearch": "Search agents...",
+    "noAgents": "No matching agents",
+    "plugins": "Plugins",
+    "pluginSearch": "Search plugins...",
+    "noPlugins": "No matching plugins",
     "worktree": "Worktree",
     "worktreeBranch": "Branch",
     "worktreePath": "Path"

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -164,6 +164,12 @@
     "commands": "命令",
     "commandSearch": "搜索命令...",
     "noCommands": "没有匹配的命令",
+    "agents": "Agents",
+    "agentSearch": "搜索 Agent...",
+    "noAgents": "没有匹配的 Agent",
+    "plugins": "Plugins",
+    "pluginSearch": "搜索插件...",
+    "noPlugins": "没有匹配的插件",
     "worktree": "工作树",
     "worktreeBranch": "分支",
     "worktreePath": "路径"

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -1,6 +1,7 @@
 import type {
   ApiResponse,
   BusyAction,
+  CategorizedCommands,
   EngineDiscoveryResult,
   EngineProfile,
   EngineSettings,
@@ -224,7 +225,7 @@ export const kanbanApi = {
     )
   },
   getSlashCommands: (projectId: string, issueId: string) =>
-    get<{ commands: string[] }>(
+    get<CategorizedCommands>(
       `/api/projects/${projectId}/issues/${issueId}/slash-commands`,
     ),
   getIssueChanges: (projectId: string, issueId: string) =>
@@ -257,7 +258,7 @@ export const kanbanApi = {
 
   // App Settings
   getSlashCommandSettings: (engine?: string) =>
-    get<{ commands: string[] }>(
+    get<CategorizedCommands>(
       `/api/settings/slash-commands${engine ? `?engine=${encodeURIComponent(engine)}` : ''}`,
     ),
   getWorkspacePath: () => get<{ path: string }>('/api/settings/workspace-path'),

--- a/apps/frontend/src/types/kanban.ts
+++ b/apps/frontend/src/types/kanban.ts
@@ -4,6 +4,7 @@
 export type {
   ApiResponse,
   BusyAction,
+  CategorizedCommands,
   CommandCategory,
   DirectoryListing,
   EngineAvailability,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,14 @@ export type Project = {
 }
 
 export type EngineType = 'claude-code' | 'codex' | 'gemini' | 'echo'
+
+export type PluginInfo = { name: string; path: string }
+
+export type CategorizedCommands = {
+  commands: string[]
+  agents: string[]
+  plugins: PluginInfo[]
+}
 export type PermissionMode = 'auto' | 'supervised' | 'plan'
 export type BusyAction = 'queue' | 'cancel'
 export type SessionStatus =


### PR DESCRIPTION
## Summary
- Typing `/` as the first character in the chat textarea triggers an inline command menu
- Fuzzy subsequence matching filters commands as user types (e.g. `/lp` matches `/help`)
- Keyboard navigation: ↑/↓ to select, Enter/Tab to confirm, Escape to dismiss
- Mouse click also selects commands
- Existing CommandPicker toolbar button preserved as fallback

## Test plan
- [ ] Type `/` in chat input → full command list appears
- [ ] Continue typing to filter (e.g. `/he` → `/help`)
- [ ] Arrow keys navigate, Enter/Tab selects and appends space
- [ ] Escape dismisses menu
- [ ] Clicking a command selects it
- [ ] Space after `/command` dismisses menu
- [ ] CommandPicker button still works independently