### PR TITLE
feat: register Codex slash commands

### DIFF
--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -1,4 +1,3 @@
-import { classifyCommand } from '@/engines/logs'
 import { safeEnv } from '@/engines/safe-env'
 import type {
   EngineAvailability,
@@ -10,10 +9,12 @@ import type {
   NormalizedLogEntry,
   SpawnedProcess,
   SpawnOptions,
-  ToolAction,
 } from '@/engines/types'
+import type { WriteFilterRule } from '@/engines/write-filter'
 import { logger } from '@/logger'
+import { CodexLogNormalizer } from './normalizer'
 import { CodexProtocolHandler } from './protocol'
+import type { ThreadStartParams } from './protocol'
 
 const CODEX_CMD = ['npx', '-y', '@openai/codex']
 const JSONRPC_TIMEOUT = 15000
@@ -47,7 +48,6 @@ class JsonRpcSession {
     const deadline = Date.now() + JSONRPC_TIMEOUT
 
     while (!this.done && Date.now() < deadline) {
-      // First, drain any complete lines already in the buffer
       const parsed = this.parseLine(id)
       if (parsed !== undefined) {
         logger.debug(
@@ -57,7 +57,6 @@ class JsonRpcSession {
         return parsed
       }
 
-      // Read more data from the stream
       const { value, done } = await this.reader.read()
       if (done) {
         logger.debug(
@@ -84,7 +83,6 @@ class JsonRpcSession {
       this.buffer += chunk
     }
 
-    // Final attempt to parse remaining buffer
     const parsed = this.parseLine(id)
     if (parsed !== undefined) {
       logger.debug(
@@ -166,7 +164,6 @@ class JsonRpcSession {
 
 /**
  * Codex app-server model/list response shape.
- * @see https://github.com/openai/codex/tree/main/codex-rs/app-server
  */
 interface CodexModelListResponse {
   data: Array<{
@@ -182,9 +179,6 @@ interface CodexModelListResponse {
 /**
  * Start a short-lived Codex app-server, perform the initialize handshake,
  * then paginate through model/list. Returns flattened EngineModel[].
- *
- * Protocol: JSON-RPC lite over stdio (JSONL, no "jsonrpc":"2.0" header).
- * Lifecycle: initialize -> initialized notification -> model/list (paginated) -> kill.
  */
 async function queryCodexModels(): Promise<EngineModel[]> {
   logger.debug(
@@ -199,7 +193,6 @@ async function queryCodexModels(): Promise<EngineModel[]> {
     env: safeEnv({ NPM_CONFIG_LOGLEVEL: 'error' }),
   })
 
-  // Capture stderr for diagnostics
   const stderrReader = new Response(proc.stderr).text()
 
   const killTimer = setTimeout(() => {
@@ -212,11 +205,13 @@ async function queryCodexModels(): Promise<EngineModel[]> {
   const session = new JsonRpcSession(proc)
 
   try {
-    // 1. Initialize handshake
     logger.debug({ message: 'Sending initialize...' }, 'codex_models_init')
     const initResult = await session.call(
       'initialize',
-      { clientInfo: { name: 'bitk', title: 'BitK', version: '0.1.0' } },
+      {
+        clientInfo: { name: 'bitk', title: 'BitK', version: '0.1.0' },
+        capabilities: { experimental_api: true },
+      },
       0,
     )
     logger.debug(
@@ -224,10 +219,8 @@ async function queryCodexModels(): Promise<EngineModel[]> {
       'codex_models_init_done',
     )
 
-    // 2. Send initialized notification (required before other methods)
     session.notify('initialized', {})
 
-    // 3. Paginate through model/list
     const models: EngineModel[] = []
     let cursor: string | null | undefined = null
     let reqId = 1
@@ -283,35 +276,25 @@ async function queryCodexModels(): Promise<EngineModel[]> {
 }
 
 /**
- * Extract the command string from a Codex item.
- * Codex sends `item.command` as either a string or string[] depending on version.
- * Also checks `item.commandActions[].command` as fallback.
+ * Build the common thread start params used by both spawn and spawnFollowUp.
  */
-function extractCommandString(item: Record<string, unknown>): string {
-  const cmd = item.command
-  if (typeof cmd === 'string') return cmd
-  if (Array.isArray(cmd)) {
-    return cmd
-      .map((a: unknown) => {
-        const s = String(a)
-        return /\s/.test(s) ? `"${s.replace(/"/g, '\\"')}"` : s
-      })
-      .join(' ')
+function buildThreadParams(
+  options: SpawnOptions,
+): ThreadStartParams {
+  const params: ThreadStartParams = {
+    model: options.model,
+    cwd: options.workingDir,
+    approvalPolicy: 'never',
+    sandbox: 'danger-full-access',
   }
-  // Fallback: extract from commandActions array
-  const actions = item.commandActions as
-    | Array<{ command?: unknown }>
-    | undefined
-  const rawCmd = actions?.[0]?.command
-  if (typeof rawCmd === 'string' && rawCmd) return rawCmd
-  return ''
+  return params
 }
 
 /**
  * Codex executor — uses JSON-RPC protocol via `app-server` mode.
  *
- * Launch: `codex app-server`
- * Communication: JSON-RPC over stdio (JSONL)
+ * Protocol: JSON-RPC over stdio (JSONL), with `codex/event/*` notifications
+ * when `experimental_api: true` capability is sent during initialize.
  */
 export class CodexExecutor implements EngineExecutor {
   readonly engineType = 'codex' as const
@@ -347,17 +330,28 @@ export class CodexExecutor implements EngineExecutor {
     // Perform initialize handshake
     await handler.initialize()
 
-    // Create thread — bypass approvals and sandbox since BitK manages
-    // its own execution environment (Docker container / worktree isolation).
-    await handler.startThread({
-      model: options.model,
-      cwd: options.workingDir,
-      approvalPolicy: 'never',
-      sandbox: 'none',
-    })
+    // Auth pre-check: detect missing credentials early
+    try {
+      const account = await handler.getAccount()
+      if (account.requiresOpenaiAuth && !account.account) {
+        throw new Error(
+          'Codex authentication required. Set OPENAI_API_KEY or CODEX_API_KEY, or run `codex auth`.',
+        )
+      }
+    } catch (authErr) {
+      // account/read may not be supported on older versions — log and continue
+      const msg =
+        authErr instanceof Error ? authErr.message : String(authErr)
+      if (msg.includes('authentication required')) throw authErr
+      logger.debug({ error: msg }, 'codex_account_read_skipped')
+    }
+
+    // Create thread with full params
+    const threadParams = buildThreadParams(options)
+    const { threadId } = await handler.startThread(threadParams)
 
     // Start turn with user prompt
-    await handler.startTurn(handler.threadId!, options.prompt)
+    await handler.startTurn(threadId, options.prompt)
 
     logger.info(
       {
@@ -391,8 +385,6 @@ export class CodexExecutor implements EngineExecutor {
           void handler.sendUserMessage(content)
         },
       },
-      // Expose the real Codex thread ID so the issue engine stores it
-      // instead of the pre-generated UUID (needed for follow-up/resume).
       externalSessionId: handler.threadId,
       spawnCommand: cmd.join(' '),
     }
@@ -419,17 +411,39 @@ export class CodexExecutor implements EngineExecutor {
 
     await handler.initialize()
 
-    // Resume the existing thread (options.sessionId contains the Codex thread ID)
-    await handler.resumeThread(options.sessionId)
+    // Use thread/fork instead of thread/resume — creates a new thread
+    // forked from the existing one, which is more reliable and allows
+    // passing updated params (model, sandbox, etc.)
+    const threadParams = buildThreadParams(options)
+    let threadId: string
+
+    try {
+      const forkResult = await handler.forkThread({
+        ...threadParams,
+        threadId: options.sessionId,
+      })
+      threadId = forkResult.threadId
+    } catch (forkErr) {
+      // Fallback to thread/resume if fork fails (older codex versions)
+      const msg =
+        forkErr instanceof Error ? forkErr.message : String(forkErr)
+      logger.warn(
+        { sessionId: options.sessionId, error: msg },
+        'codex_fork_failed_fallback_to_resume',
+      )
+      await handler.resumeThread(options.sessionId)
+      threadId = handler.threadId!
+    }
 
     // Start a new turn with the follow-up prompt
-    await handler.startTurn(handler.threadId!, options.prompt)
+    await handler.startTurn(threadId, options.prompt)
 
     logger.info(
       {
         issueId: env.issueId,
         pid: (proc as { pid?: number }).pid,
         threadId: handler.threadId,
+        forkedFrom: options.sessionId,
         model: options.model,
       },
       'codex_followup_complete',
@@ -513,7 +527,6 @@ export class CodexExecutor implements EngineExecutor {
       const versionMatch = stdout.match(/(\d+\.\d+\.\d[\w.-]*)/)
       const version = versionMatch?.[1]
 
-      // Check auth — OPENAI_API_KEY, CODEX_API_KEY, or ~/.codex/config.toml
       let authStatus: EngineAvailability['authStatus'] = 'unknown'
       if (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY) {
         authStatus = 'authenticated'
@@ -558,343 +571,25 @@ export class CodexExecutor implements EngineExecutor {
     }
   }
 
-  normalizeLog(rawLine: string): NormalizedLogEntry | null {
-    const now = new Date().toISOString()
-
-    try {
-      const data = JSON.parse(rawLine) as {
-        method?: string
-        params?: Record<string, unknown>
-      }
-
-      const method = data.method
-      const params = (data.params ?? {}) as Record<string, unknown>
-
-      // No method field — not a notification we handle
-      if (!method) return null
-
-      switch (method) {
-        // ------------------------------------------------------------------
-        // 1. Streaming assistant text delta — skip
-        // The canonical full text is emitted by item/completed agentMessage,
-        // which is persisted to DB and sent via SSE. Forwarding individual
-        // character deltas causes scattered duplicate messages on the frontend.
-        // ------------------------------------------------------------------
-        case 'item/agentMessage/delta':
-          return null
-
-        // ------------------------------------------------------------------
-        // 2. Item started — dispatch on item type
-        // ------------------------------------------------------------------
-        case 'item/started': {
-          const item = (params.item ?? {}) as Record<string, unknown>
-          const itemType = item.type as string | undefined
-
-          if (itemType === 'commandExecution') {
-            const commandStr = extractCommandString(item)
-            const toolAction: ToolAction = {
-              kind: 'command-run',
-              command: commandStr,
-              category: commandStr ? classifyCommand(commandStr) : 'other',
-            }
-            // item/started is a live indicator only — mark streaming so it's
-            // emitted via SSE but NOT persisted. item/completed is the canonical record.
-            return {
-              entryType: 'tool-use',
-              content: `Tool: Bash`,
-              timestamp: now,
-              metadata: {
-                streaming: true,
-                toolName: 'Bash',
-                toolCallId: item.id as string | undefined,
-                input: commandStr ? { command: commandStr } : undefined,
-              },
-              toolAction,
-            }
-          }
-
-          if (itemType === 'fileChange') {
-            const path = item.path as string | undefined
-            const toolAction: ToolAction = {
-              kind: 'file-edit',
-              path: path ?? '',
-            }
-            // item/started is a live indicator only — see commandExecution above.
-            return {
-              entryType: 'tool-use',
-              content: `Tool: Edit`,
-              timestamp: now,
-              metadata: {
-                streaming: true,
-                toolName: 'Edit',
-                toolCallId: item.id as string | undefined,
-                path,
-                input: path ? { file_path: path } : undefined,
-              },
-              toolAction,
-            }
-          }
-
-          // item/started for agentMessage — always skip.
-          // Streaming text arrives via item/agentMessage/delta and the canonical
-          // record is emitted by item/completed. Emitting text from item/started
-          // would duplicate the message: the full text appears first, then
-          // item/agentMessage/delta replays the same content as character deltas.
-          if (itemType === 'agentMessage') {
-            return null
-          }
-
-          // reasoning items are skipped (like Claude's thinking blocks)
-          if (itemType === 'reasoning') {
-            return null
-          }
-
-          // Unknown item type — skip
-          return null
-        }
-
-        // ------------------------------------------------------------------
-        // 3. Item completed — dispatch on item type, includes results
-        // ------------------------------------------------------------------
-        case 'item/completed': {
-          const item = (params.item ?? {}) as Record<string, unknown>
-          const itemType = item.type as string | undefined
-
-          if (itemType === 'commandExecution') {
-            // Codex uses aggregatedOutput instead of stdout/stderr
-            const stdout = (item.stdout as string) ?? ''
-            const stderr = (item.stderr as string) ?? ''
-            const aggregated = (item.aggregatedOutput as string) ?? ''
-            const combined =
-              aggregated || [stdout, stderr].filter(Boolean).join('\n')
-            const exitCode = item.exitCode as number | undefined
-            const duration = (item.durationMs ?? item.duration) as
-              | number
-              | undefined
-            const commandStr = extractCommandString(item)
-
-            const toolAction: ToolAction = {
-              kind: 'command-run',
-              command: commandStr,
-              result: combined || undefined,
-              category: commandStr ? classifyCommand(commandStr) : 'other',
-            }
-
-            return {
-              entryType: 'tool-use',
-              content: combined,
-              timestamp: now,
-              metadata: {
-                toolName: 'Bash',
-                isResult: true,
-                toolCallId: item.id as string | undefined,
-                exitCode,
-                duration,
-              },
-              toolAction,
-            }
-          }
-
-          if (itemType === 'fileChange') {
-            const patches = item.patches as unknown[] | undefined
-            const path = item.path as string | undefined
-            const patchCount = patches?.length ?? 0
-            const summary = path
-              ? `File changed: ${path} (${patchCount} patch${patchCount !== 1 ? 'es' : ''})`
-              : `File changed (${patchCount} patch${patchCount !== 1 ? 'es' : ''})`
-
-            const toolAction: ToolAction = {
-              kind: 'file-edit',
-              path: path ?? '',
-            }
-
-            return {
-              entryType: 'tool-use',
-              content: summary,
-              timestamp: now,
-              metadata: {
-                toolName: 'Edit',
-                isResult: true,
-                toolCallId: item.id as string | undefined,
-                path,
-              },
-              toolAction,
-            }
-          }
-
-          if (itemType === 'agentMessage') {
-            return {
-              entryType: 'assistant-message',
-              content: (item.text as string) ?? '',
-              timestamp: now,
-            }
-          }
-
-          // Completed reasoning — skip
-          if (itemType === 'reasoning') {
-            return null
-          }
-
-          return null
-        }
-
-        // ------------------------------------------------------------------
-        // 4. Command execution streaming output delta
-        // ------------------------------------------------------------------
-        case 'item/commandExecution/outputDelta': {
-          const delta = params.delta as string | undefined
-          if (!delta) return null
-          return {
-            entryType: 'tool-use',
-            content: delta,
-            timestamp: now,
-            metadata: { isResult: true, streaming: true },
-          }
-        }
-
-        // ------------------------------------------------------------------
-        // 5. File change streaming output delta
-        // ------------------------------------------------------------------
-        case 'item/fileChange/outputDelta': {
-          const delta = params.delta as string | undefined
-          if (!delta) return null
-          return {
-            entryType: 'tool-use',
-            content: delta,
-            timestamp: now,
-            metadata: { isResult: true, streaming: true },
-          }
-        }
-
-        // ------------------------------------------------------------------
-        // 6. Turn started
-        // ------------------------------------------------------------------
-        case 'turn/started': {
-          const turn = (params.turn ?? {}) as Record<string, unknown>
-          return {
-            entryType: 'system-message',
-            content: 'Turn started',
-            timestamp: now,
-            metadata: {
-              subtype: 'turn_started',
-              turnId: turn.id as string | undefined,
-            },
-          }
-        }
-
-        // ------------------------------------------------------------------
-        // 7. Turn completed — emit usage stats
-        // ------------------------------------------------------------------
-        case 'turn/completed': {
-          const turn = (params.turn ?? {}) as Record<string, unknown>
-          const usage = (turn.usage ?? {}) as Record<string, unknown>
-          const inputTokens = usage.inputTokens as number | undefined
-          const outputTokens = usage.outputTokens as number | undefined
-
-          const parts: string[] = []
-          if (inputTokens != null) {
-            // Format large numbers with k suffix for readability
-            parts.push(
-              inputTokens >= 1000
-                ? `${(inputTokens / 1000).toFixed(1)}k input`
-                : `${inputTokens} input`,
-            )
-          }
-          if (outputTokens != null) {
-            parts.push(
-              outputTokens >= 1000
-                ? `${(outputTokens / 1000).toFixed(1)}k output`
-                : `${outputTokens} output`,
-            )
-          }
-
-          return {
-            entryType: 'system-message',
-            content: parts.length ? parts.join(' \u00B7 ') : 'Turn completed',
-            timestamp: now,
-            metadata: {
-              source: 'result',
-              turnCompleted: true,
-              turnId: turn.id as string | undefined,
-              inputTokens,
-              outputTokens,
-            },
-          }
-        }
-
-        // ------------------------------------------------------------------
-        // 8. Thread started
-        // ------------------------------------------------------------------
-        case 'thread/started': {
-          const threadId = params.threadId as string | undefined
-          return {
-            entryType: 'system-message',
-            content: 'Thread started',
-            timestamp: now,
-            metadata: {
-              subtype: 'thread_started',
-              threadId,
-            },
-          }
-        }
-
-        // ------------------------------------------------------------------
-        // 9. Thread status changed — only surface systemError
-        // ------------------------------------------------------------------
-        case 'thread/status/changed': {
-          const status = params.status as string | undefined
-          if (status === 'systemError') {
-            return {
-              entryType: 'error-message',
-              content: `Thread error: ${(params.message as string) ?? 'system error'}`,
-              timestamp: now,
-              metadata: { status },
-            }
-          }
-          // Non-error status changes are noisy — skip
-          return null
-        }
-
-        // ------------------------------------------------------------------
-        // 10. Error notification
-        // ------------------------------------------------------------------
-        case 'error': {
-          const error = (params.error ?? {}) as Record<string, unknown>
-          const willRetry = params.willRetry as boolean | undefined
-          return {
-            entryType: 'error-message',
-            content: (error.message as string) ?? 'Unknown error',
-            timestamp: now,
-            metadata: {
-              code: error.code as number | undefined,
-              willRetry,
-            },
-          }
-        }
-
-        // ------------------------------------------------------------------
-        // 11. Reasoning deltas — skip (internal model reasoning)
-        // ------------------------------------------------------------------
-        case 'item/reasoning/textDelta':
-        case 'item/reasoning/summaryTextDelta':
-          return null
-
-        // ------------------------------------------------------------------
-        // Unknown notification method — skip
-        // ------------------------------------------------------------------
-        default:
-          return null
-      }
-    } catch {
-      // Not valid JSON — treat non-empty lines as plain text system messages
-      if (rawLine.trim()) {
-        return {
-          entryType: 'system-message',
-          content: rawLine,
-          timestamp: now,
-        }
-      }
-      return null
+  /**
+   * Create a stateful normalizer that handles `codex/event/*` notifications.
+   * This replaces the stateless normalizeLog for proper streaming state tracking.
+   */
+  createNormalizer(_filterRules: WriteFilterRule[]) {
+    const normalizer = new CodexLogNormalizer()
+    return {
+      parse: (rawLine: string) => normalizer.parse(rawLine),
     }
+  }
+
+  /**
+   * Stateless normalizer (legacy fallback).
+   * Prefer createNormalizer() which maintains state for streaming events.
+   */
+  normalizeLog(rawLine: string): NormalizedLogEntry | null {
+    const normalizer = new CodexLogNormalizer()
+    const result = normalizer.parse(rawLine)
+    if (Array.isArray(result)) return result[0] ?? null
+    return result
   }
 }

--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -13,8 +13,8 @@ import type {
 import type { WriteFilterRule } from '@/engines/write-filter'
 import { logger } from '@/logger'
 import { CodexLogNormalizer } from './normalizer'
-import { CodexProtocolHandler } from './protocol'
 import type { ThreadStartParams } from './protocol'
+import { CodexProtocolHandler } from './protocol'
 
 const CODEX_CMD = ['npx', '-y', '@openai/codex']
 const JSONRPC_TIMEOUT = 15000
@@ -278,9 +278,7 @@ async function queryCodexModels(): Promise<EngineModel[]> {
 /**
  * Build the common thread start params used by both spawn and spawnFollowUp.
  */
-function buildThreadParams(
-  options: SpawnOptions,
-): ThreadStartParams {
+function buildThreadParams(options: SpawnOptions): ThreadStartParams {
   const params: ThreadStartParams = {
     model: options.model,
     cwd: options.workingDir,
@@ -340,8 +338,7 @@ export class CodexExecutor implements EngineExecutor {
       }
     } catch (authErr) {
       // account/read may not be supported on older versions — log and continue
-      const msg =
-        authErr instanceof Error ? authErr.message : String(authErr)
+      const msg = authErr instanceof Error ? authErr.message : String(authErr)
       if (msg.includes('authentication required')) throw authErr
       logger.debug({ error: msg }, 'codex_account_read_skipped')
     }
@@ -411,29 +408,10 @@ export class CodexExecutor implements EngineExecutor {
 
     await handler.initialize()
 
-    // Use thread/fork instead of thread/resume — creates a new thread
-    // forked from the existing one, which is more reliable and allows
-    // passing updated params (model, sandbox, etc.)
-    const threadParams = buildThreadParams(options)
-    let threadId: string
-
-    try {
-      const forkResult = await handler.forkThread({
-        ...threadParams,
-        threadId: options.sessionId,
-      })
-      threadId = forkResult.threadId
-    } catch (forkErr) {
-      // Fallback to thread/resume if fork fails (older codex versions)
-      const msg =
-        forkErr instanceof Error ? forkErr.message : String(forkErr)
-      logger.warn(
-        { sessionId: options.sessionId, error: msg },
-        'codex_fork_failed_fallback_to_resume',
-      )
-      await handler.resumeThread(options.sessionId)
-      threadId = handler.threadId!
-    }
+    // Resume the existing thread — appends new turns to the same conversation.
+    // This keeps the thread ID stable so follow-up chains work correctly.
+    await handler.resumeThread(options.sessionId)
+    const threadId = options.sessionId
 
     // Start a new turn with the follow-up prompt
     await handler.startTurn(threadId, options.prompt)
@@ -443,7 +421,7 @@ export class CodexExecutor implements EngineExecutor {
         issueId: env.issueId,
         pid: (proc as { pid?: number }).pid,
         threadId: handler.threadId,
-        forkedFrom: options.sessionId,
+        resumedFrom: options.sessionId,
         model: options.model,
       },
       'codex_followup_complete',

--- a/apps/api/src/engines/executors/codex/index.ts
+++ b/apps/api/src/engines/executors/codex/index.ts
@@ -1,2 +1,3 @@
 export { CodexExecutor } from './executor'
+export { CodexLogNormalizer } from './normalizer'
 export { CodexProtocolHandler } from './protocol'

--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -1,8 +1,5 @@
 import { classifyCommand } from '@/engines/logs'
-import type {
-  NormalizedLogEntry,
-  ToolAction,
-} from '@/engines/types'
+import type { NormalizedLogEntry, ToolAction } from '@/engines/types'
 
 // ---------- Types for Codex event protocol ----------
 
@@ -282,7 +279,11 @@ export class CodexLogNormalizer {
             toolAction,
           })
         }
-        return entries.length === 1 ? entries[0] : entries.length > 0 ? entries : null
+        return entries.length === 1
+          ? entries[0]
+          : entries.length > 0
+            ? entries
+            : null
       }
 
       // --- File patch end ---
@@ -291,7 +292,9 @@ export class CodexLogNormalizer {
         const callId = msg.call_id as string | undefined
         return {
           entryType: 'tool-use',
-          content: success ? 'Patch applied successfully' : 'Patch apply failed',
+          content: success
+            ? 'Patch applied successfully'
+            : 'Patch apply failed',
           timestamp: now,
           metadata: {
             toolName: 'Edit',
@@ -347,17 +350,23 @@ export class CodexLogNormalizer {
             toolAction: { kind: 'file-edit', path },
           })
         }
-        return entries.length === 1 ? entries[0] : entries.length > 0 ? entries : null
+        return entries.length === 1
+          ? entries[0]
+          : entries.length > 0
+            ? entries
+            : null
       }
 
       // --- MCP tool call begin ---
       case 'mcp_tool_call_begin': {
         this.resetStreamingState()
-        const invocation = msg.invocation as {
-          server?: string
-          tool?: string
-          arguments?: unknown
-        } | undefined
+        const invocation = msg.invocation as
+          | {
+              server?: string
+              tool?: string
+              arguments?: unknown
+            }
+          | undefined
         if (!invocation) return null
         const toolName = `mcp:${invocation.server ?? 'unknown'}:${invocation.tool ?? 'unknown'}`
         return {
@@ -379,11 +388,15 @@ export class CodexLogNormalizer {
 
       // --- MCP tool call end ---
       case 'mcp_tool_call_end': {
-        const invocation = msg.invocation as {
-          server?: string
-          tool?: string
-        } | undefined
-        const result = msg.result as { content?: unknown[]; is_error?: boolean } | undefined
+        const invocation = msg.invocation as
+          | {
+              server?: string
+              tool?: string
+            }
+          | undefined
+        const result = msg.result as
+          | { content?: unknown[]; is_error?: boolean }
+          | undefined
         const toolName = `mcp:${invocation?.server ?? 'unknown'}:${invocation?.tool ?? 'unknown'}`
         const isError = result?.is_error ?? false
         // Extract text content from MCP result
@@ -394,12 +407,17 @@ export class CodexLogNormalizer {
               const b = block as Record<string, unknown>
               return b?.type === 'text'
             })
-            .map((block: unknown) => (block as Record<string, unknown>).text as string)
+            .map(
+              (block: unknown) =>
+                (block as Record<string, unknown>).text as string,
+            )
             .join('\n')
         }
         return {
           entryType: 'tool-use',
-          content: resultText || (isError ? 'MCP tool call failed' : 'MCP tool call completed'),
+          content:
+            resultText ||
+            (isError ? 'MCP tool call failed' : 'MCP tool call completed'),
           timestamp: now,
           metadata: {
             toolName,
@@ -475,10 +493,14 @@ export class CodexLogNormalizer {
 
       // --- Plan update (todo-like step list) ---
       case 'plan_update': {
-        const plan = msg.plan as Array<{ step: string; status: string }> | undefined
+        this.resetStreamingState()
+        const plan = msg.plan as
+          | Array<{ step: string; status: string }>
+          | undefined
         const explanation = msg.explanation as string | undefined
         if (!plan) return null
-        const content = explanation?.trim() || `Plan updated (${plan.length} steps)`
+        const content =
+          explanation?.trim() || `Plan updated (${plan.length} steps)`
         return {
           entryType: 'system-message',
           content,
@@ -531,10 +553,12 @@ export class CodexLogNormalizer {
 
       // --- Token count / context usage ---
       case 'token_count': {
-        const info = msg.info as {
-          last_token_usage?: { total_tokens?: number }
-          model_context_window?: number
-        } | undefined
+        const info = msg.info as
+          | {
+              last_token_usage?: { total_tokens?: number }
+              model_context_window?: number
+            }
+          | undefined
         if (!info?.last_token_usage) return null
         const totalTokens = info.last_token_usage.total_tokens ?? 0
         const contextWindow = info.model_context_window ?? 0
@@ -593,9 +617,15 @@ export class CodexLogNormalizer {
         }
       }
 
-      // --- Turn complete (within codex/event — new name) ---
+      // --- Turn complete (within codex/event — v2 protocol) ---
       case 'turn_complete': {
-        return null // Handled by the raw turn/completed notification
+        this.resetStreamingState()
+        return {
+          entryType: 'system-message',
+          content: 'Turn completed',
+          timestamp: now,
+          metadata: { turnCompleted: true },
+        }
       }
 
       // --- Item started (plan item) ---
@@ -772,8 +802,7 @@ export class CodexLogNormalizer {
       const stdout = (item.stdout as string) ?? ''
       const stderr = (item.stderr as string) ?? ''
       const aggregated = (item.aggregatedOutput as string) ?? ''
-      const combined =
-        aggregated || [stdout, stderr].filter(Boolean).join('\n')
+      const combined = aggregated || [stdout, stderr].filter(Boolean).join('\n')
       const exitCode = item.exitCode as number | undefined
       const duration = (item.durationMs ?? item.duration) as number | undefined
       const commandStr = extractCommandString(item)

--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -32,8 +32,6 @@ interface CodexEventParams {
 export class CodexLogNormalizer {
   private assistantText = ''
   private thinkingText = ''
-  private hasAssistant = false
-  private hasThinking = false
 
   /**
    * Parse a single stdout line and return normalized log entries.
@@ -131,9 +129,7 @@ export class CodexLogNormalizer {
         const delta = (msg.delta as string) ?? ''
         if (!delta) return null
         this.thinkingText = ''
-        this.hasThinking = false
         this.assistantText += delta
-        this.hasAssistant = true
         return {
           entryType: 'assistant-message',
           content: this.assistantText,
@@ -146,9 +142,7 @@ export class CodexLogNormalizer {
       case 'agent_message': {
         const message = (msg.message as string) ?? ''
         this.thinkingText = ''
-        this.hasThinking = false
         this.assistantText = message
-        this.hasAssistant = true
         const entry: NormalizedLogEntry = {
           entryType: 'assistant-message',
           content: message,
@@ -156,7 +150,6 @@ export class CodexLogNormalizer {
         }
         // Reset for next message
         this.assistantText = ''
-        this.hasAssistant = false
         return entry
       }
 
@@ -165,9 +158,7 @@ export class CodexLogNormalizer {
         const delta = (msg.delta as string) ?? ''
         if (!delta) return null
         this.assistantText = ''
-        this.hasAssistant = false
         this.thinkingText += delta
-        this.hasThinking = true
         return {
           entryType: 'thinking',
           content: this.thinkingText,
@@ -180,25 +171,20 @@ export class CodexLogNormalizer {
       case 'agent_reasoning': {
         const text = (msg.text as string) ?? ''
         this.assistantText = ''
-        this.hasAssistant = false
         this.thinkingText = text
-        this.hasThinking = true
         const entry: NormalizedLogEntry = {
           entryType: 'thinking',
           content: text,
           timestamp: now,
         }
         this.thinkingText = ''
-        this.hasThinking = false
         return entry
       }
 
       // --- Reasoning section break ---
       case 'agent_reasoning_section_break': {
         this.assistantText = ''
-        this.hasAssistant = false
         this.thinkingText = ''
-        this.hasThinking = false
         return null
       }
 
@@ -478,9 +464,7 @@ export class CodexLogNormalizer {
         const delta = (msg.delta as string) ?? ''
         if (!delta) return null
         this.thinkingText = ''
-        this.hasThinking = false
         this.assistantText += delta
-        this.hasAssistant = true
         return {
           entryType: 'assistant-message',
           content: this.assistantText,
@@ -986,9 +970,7 @@ export class CodexLogNormalizer {
 
   private resetStreamingState(): void {
     this.assistantText = ''
-    this.hasAssistant = false
     this.thinkingText = ''
-    this.hasThinking = false
   }
 }
 

--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -1,0 +1,1016 @@
+import { classifyCommand } from '@/engines/logs'
+import type {
+  NormalizedLogEntry,
+  ToolAction,
+} from '@/engines/types'
+
+// ---------- Types for Codex event protocol ----------
+
+/**
+ * Codex wraps events in `codex/event/*` notifications:
+ * { method: "codex/event/xxx", params: { msg: { type: "...", ... }, ... } }
+ *
+ * The `msg` field contains the actual event.
+ */
+
+interface CodexEventParams {
+  msg?: {
+    type?: string
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+// ---------- Stateful normalizer ----------
+
+/**
+ * Stateful Codex log normalizer that handles the `codex/event/*` protocol
+ * and maintains per-item state for proper streaming updates.
+ *
+ * Modeled after the Rust reference implementation in `tmp/exec/src/executors/codex/normalize_logs.rs`.
+ */
+export class CodexLogNormalizer {
+  private assistantText = ''
+  private thinkingText = ''
+  private hasAssistant = false
+  private hasThinking = false
+
+  /**
+   * Parse a single stdout line and return normalized log entries.
+   * Returns null for lines that should be skipped.
+   */
+  parse(rawLine: string): NormalizedLogEntry | NormalizedLogEntry[] | null {
+    const now = new Date().toISOString()
+
+    let data: Record<string, unknown>
+    try {
+      data = JSON.parse(rawLine)
+    } catch {
+      // Non-JSON — treat as plain text system message
+      if (rawLine.trim()) {
+        return {
+          entryType: 'system-message',
+          content: rawLine,
+          timestamp: now,
+        }
+      }
+      return null
+    }
+
+    const method = data.method as string | undefined
+
+    // -- Handle JSON-RPC responses (session ID / model params extraction) --
+    if ('id' in data && 'result' in data && !method) {
+      return this.handleResponse(data, now)
+    }
+
+    // -- No method field — not a notification we handle --
+    if (!method) return null
+
+    // -- codex/event/* notifications (new v2 protocol) --
+    if (method.startsWith('codex/event')) {
+      return this.handleCodexEvent(data, now)
+    }
+
+    // -- Legacy raw notifications --
+    switch (method) {
+      case 'item/agentMessage/delta':
+        return null // Skip individual deltas — use codex/event instead
+
+      case 'item/started':
+        return this.handleItemStarted(data, now)
+
+      case 'item/completed':
+        return this.handleItemCompleted(data, now)
+
+      case 'item/commandExecution/outputDelta':
+        return this.handleCommandOutputDelta(data, now)
+
+      case 'item/fileChange/outputDelta':
+        return this.handleFileChangeOutputDelta(data, now)
+
+      case 'turn/started':
+        return this.handleTurnStarted(data, now)
+
+      case 'turn/completed':
+        return this.handleTurnCompleted(data, now)
+
+      case 'thread/started':
+        return this.handleThreadStarted(data, now)
+
+      case 'thread/status/changed':
+        return this.handleThreadStatusChanged(data, now)
+
+      case 'error':
+        return this.handleError(data, now)
+
+      case 'item/reasoning/textDelta':
+      case 'item/reasoning/summaryTextDelta':
+        return null // Skip reasoning deltas
+
+      default:
+        return null
+    }
+  }
+
+  // ---------- codex/event/* handler ----------
+
+  private handleCodexEvent(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | NormalizedLogEntry[] | null {
+    const params = data.params as CodexEventParams | undefined
+    const msg = params?.msg
+    if (!msg?.type) return null
+
+    const eventType = msg.type as string
+
+    switch (eventType) {
+      // --- Assistant message (streaming delta) ---
+      case 'agent_message_delta': {
+        const delta = (msg.delta as string) ?? ''
+        if (!delta) return null
+        this.thinkingText = ''
+        this.hasThinking = false
+        this.assistantText += delta
+        this.hasAssistant = true
+        return {
+          entryType: 'assistant-message',
+          content: this.assistantText,
+          timestamp: now,
+          metadata: { streaming: true },
+        }
+      }
+
+      // --- Assistant message (complete) ---
+      case 'agent_message': {
+        const message = (msg.message as string) ?? ''
+        this.thinkingText = ''
+        this.hasThinking = false
+        this.assistantText = message
+        this.hasAssistant = true
+        const entry: NormalizedLogEntry = {
+          entryType: 'assistant-message',
+          content: message,
+          timestamp: now,
+        }
+        // Reset for next message
+        this.assistantText = ''
+        this.hasAssistant = false
+        return entry
+      }
+
+      // --- Reasoning (thinking) delta ---
+      case 'agent_reasoning_delta': {
+        const delta = (msg.delta as string) ?? ''
+        if (!delta) return null
+        this.assistantText = ''
+        this.hasAssistant = false
+        this.thinkingText += delta
+        this.hasThinking = true
+        return {
+          entryType: 'thinking',
+          content: this.thinkingText,
+          timestamp: now,
+          metadata: { streaming: true },
+        }
+      }
+
+      // --- Reasoning (thinking) complete ---
+      case 'agent_reasoning': {
+        const text = (msg.text as string) ?? ''
+        this.assistantText = ''
+        this.hasAssistant = false
+        this.thinkingText = text
+        this.hasThinking = true
+        const entry: NormalizedLogEntry = {
+          entryType: 'thinking',
+          content: text,
+          timestamp: now,
+        }
+        this.thinkingText = ''
+        this.hasThinking = false
+        return entry
+      }
+
+      // --- Reasoning section break ---
+      case 'agent_reasoning_section_break': {
+        this.assistantText = ''
+        this.hasAssistant = false
+        this.thinkingText = ''
+        this.hasThinking = false
+        return null
+      }
+
+      // --- Command execution begin ---
+      case 'exec_command_begin': {
+        this.resetStreamingState()
+        const command = msg.command as string[] | undefined
+        const commandStr = command?.join(' ') ?? ''
+        if (!commandStr) return null
+        const callId = msg.call_id as string | undefined
+        const toolAction: ToolAction = {
+          kind: 'command-run',
+          command: commandStr,
+          category: classifyCommand(commandStr),
+        }
+        return {
+          entryType: 'tool-use',
+          content: `Tool: Bash`,
+          timestamp: now,
+          metadata: {
+            toolName: 'Bash',
+            toolCallId: callId,
+            input: { command: commandStr },
+          },
+          toolAction,
+        }
+      }
+
+      // --- Command execution output delta ---
+      case 'exec_command_output_delta': {
+        const chunk = msg.chunk as string | undefined
+        const stream = msg.stream as string | undefined
+        if (!chunk) return null
+        return {
+          entryType: 'tool-use',
+          content: chunk,
+          timestamp: now,
+          metadata: {
+            isResult: true,
+            streaming: true,
+            outputStream: stream,
+          },
+        }
+      }
+
+      // --- Command execution end ---
+      case 'exec_command_end': {
+        const command = msg.command as string[] | undefined
+        const commandStr = command?.join(' ') ?? ''
+        const exitCode = msg.exit_code as number | undefined
+        const formattedOutput = (msg.formatted_output as string) ?? ''
+        const callId = msg.call_id as string | undefined
+        const toolAction: ToolAction = {
+          kind: 'command-run',
+          command: commandStr,
+          result: formattedOutput || undefined,
+          category: commandStr ? classifyCommand(commandStr) : 'other',
+        }
+        return {
+          entryType: 'tool-use',
+          content: formattedOutput,
+          timestamp: now,
+          metadata: {
+            toolName: 'Bash',
+            isResult: true,
+            toolCallId: callId,
+            exitCode,
+          },
+          toolAction,
+        }
+      }
+
+      // --- File patch begin ---
+      case 'patch_apply_begin': {
+        this.resetStreamingState()
+        const changes = msg.changes as Record<string, unknown> | undefined
+        const callId = msg.call_id as string | undefined
+        if (!changes) return null
+        const entries: NormalizedLogEntry[] = []
+        for (const path of Object.keys(changes)) {
+          const toolAction: ToolAction = {
+            kind: 'file-edit',
+            path,
+          }
+          entries.push({
+            entryType: 'tool-use',
+            content: `Tool: Edit`,
+            timestamp: now,
+            metadata: {
+              toolName: 'Edit',
+              toolCallId: callId,
+              path,
+              input: { file_path: path },
+            },
+            toolAction,
+          })
+        }
+        return entries.length === 1 ? entries[0] : entries.length > 0 ? entries : null
+      }
+
+      // --- File patch end ---
+      case 'patch_apply_end': {
+        const success = msg.success as boolean | undefined
+        const callId = msg.call_id as string | undefined
+        return {
+          entryType: 'tool-use',
+          content: success ? 'Patch applied successfully' : 'Patch apply failed',
+          timestamp: now,
+          metadata: {
+            toolName: 'Edit',
+            isResult: true,
+            toolCallId: callId,
+            exitCode: success ? 0 : 1,
+          },
+        }
+      }
+
+      // --- Approval request for exec ---
+      case 'exec_approval_request': {
+        this.resetStreamingState()
+        const command = msg.command as string[] | undefined
+        const commandStr = command?.join(' ') ?? ''
+        const callId = msg.call_id as string | undefined
+        const toolAction: ToolAction = {
+          kind: 'command-run',
+          command: commandStr,
+          category: commandStr ? classifyCommand(commandStr) : 'other',
+        }
+        return {
+          entryType: 'tool-use',
+          content: `Tool: Bash`,
+          timestamp: now,
+          metadata: {
+            toolName: 'Bash',
+            toolCallId: callId,
+            input: { command: commandStr },
+          },
+          toolAction,
+        }
+      }
+
+      // --- Approval request for file patch ---
+      case 'apply_patch_approval_request': {
+        this.resetStreamingState()
+        const changes = msg.changes as Record<string, unknown> | undefined
+        const callId = msg.call_id as string | undefined
+        if (!changes) return null
+        const entries: NormalizedLogEntry[] = []
+        for (const path of Object.keys(changes)) {
+          entries.push({
+            entryType: 'tool-use',
+            content: `Tool: Edit`,
+            timestamp: now,
+            metadata: {
+              toolName: 'Edit',
+              toolCallId: callId,
+              path,
+              input: { file_path: path },
+            },
+            toolAction: { kind: 'file-edit', path },
+          })
+        }
+        return entries.length === 1 ? entries[0] : entries.length > 0 ? entries : null
+      }
+
+      // --- MCP tool call begin ---
+      case 'mcp_tool_call_begin': {
+        this.resetStreamingState()
+        const invocation = msg.invocation as {
+          server?: string
+          tool?: string
+          arguments?: unknown
+        } | undefined
+        if (!invocation) return null
+        const toolName = `mcp:${invocation.server ?? 'unknown'}:${invocation.tool ?? 'unknown'}`
+        return {
+          entryType: 'tool-use',
+          content: `Tool: ${toolName}`,
+          timestamp: now,
+          metadata: {
+            toolName,
+            toolCallId: msg.call_id as string | undefined,
+            input: invocation.arguments,
+          },
+          toolAction: {
+            kind: 'tool',
+            toolName,
+            arguments: invocation.arguments,
+          },
+        }
+      }
+
+      // --- MCP tool call end ---
+      case 'mcp_tool_call_end': {
+        const invocation = msg.invocation as {
+          server?: string
+          tool?: string
+        } | undefined
+        const result = msg.result as { content?: unknown[]; is_error?: boolean } | undefined
+        const toolName = `mcp:${invocation?.server ?? 'unknown'}:${invocation?.tool ?? 'unknown'}`
+        const isError = result?.is_error ?? false
+        // Extract text content from MCP result
+        let resultText = ''
+        if (Array.isArray(result?.content)) {
+          resultText = result.content
+            .filter((block: unknown) => {
+              const b = block as Record<string, unknown>
+              return b?.type === 'text'
+            })
+            .map((block: unknown) => (block as Record<string, unknown>).text as string)
+            .join('\n')
+        }
+        return {
+          entryType: 'tool-use',
+          content: resultText || (isError ? 'MCP tool call failed' : 'MCP tool call completed'),
+          timestamp: now,
+          metadata: {
+            toolName,
+            isResult: true,
+            toolCallId: msg.call_id as string | undefined,
+            exitCode: isError ? 1 : 0,
+          },
+          toolAction: {
+            kind: 'tool',
+            toolName,
+            result: resultText || undefined,
+          },
+        }
+      }
+
+      // --- Web search begin ---
+      case 'web_search_begin': {
+        this.resetStreamingState()
+        return {
+          entryType: 'tool-use',
+          content: 'Tool: WebSearch',
+          timestamp: now,
+          metadata: {
+            toolName: 'WebSearch',
+            toolCallId: msg.call_id as string | undefined,
+          },
+          toolAction: { kind: 'web-fetch', url: '...' },
+        }
+      }
+
+      // --- Web search end ---
+      case 'web_search_end': {
+        const query = (msg.query as string) ?? ''
+        return {
+          entryType: 'tool-use',
+          content: query || 'Web search completed',
+          timestamp: now,
+          metadata: {
+            toolName: 'WebSearch',
+            isResult: true,
+            toolCallId: msg.call_id as string | undefined,
+          },
+          toolAction: { kind: 'web-fetch', url: query },
+        }
+      }
+
+      // --- View image tool call ---
+      case 'view_image_tool_call': {
+        this.resetStreamingState()
+        const path = (msg.path as string) ?? ''
+        return {
+          entryType: 'tool-use',
+          content: `View image: ${path}`,
+          timestamp: now,
+          metadata: { toolName: 'ViewImage', path },
+          toolAction: { kind: 'file-read', path },
+        }
+      }
+
+      // --- Plan delta (streaming plan text) ---
+      case 'plan_delta': {
+        const delta = (msg.delta as string) ?? ''
+        if (!delta) return null
+        this.thinkingText = ''
+        this.hasThinking = false
+        this.assistantText += delta
+        this.hasAssistant = true
+        return {
+          entryType: 'assistant-message',
+          content: this.assistantText,
+          timestamp: now,
+          metadata: { streaming: true, isPlan: true },
+        }
+      }
+
+      // --- Plan update (todo-like step list) ---
+      case 'plan_update': {
+        const plan = msg.plan as Array<{ step: string; status: string }> | undefined
+        const explanation = msg.explanation as string | undefined
+        if (!plan) return null
+        const content = explanation?.trim() || `Plan updated (${plan.length} steps)`
+        return {
+          entryType: 'system-message',
+          content,
+          timestamp: now,
+          metadata: { subtype: 'plan_update', plan },
+        }
+      }
+
+      // --- Stream error ---
+      case 'stream_error': {
+        const message = (msg.message as string) ?? 'Stream error'
+        return {
+          entryType: 'error-message',
+          content: `Stream error: ${message}`,
+          timestamp: now,
+        }
+      }
+
+      // --- Error ---
+      case 'error': {
+        const message = (msg.message as string) ?? 'Unknown error'
+        return {
+          entryType: 'error-message',
+          content: `Error: ${message}`,
+          timestamp: now,
+        }
+      }
+
+      // --- Warning ---
+      case 'warning': {
+        const message = (msg.message as string) ?? ''
+        if (!message) return null
+        return {
+          entryType: 'error-message',
+          content: message,
+          timestamp: now,
+        }
+      }
+
+      // --- Model reroute ---
+      case 'model_reroute': {
+        const fromModel = (msg.from_model as string) ?? ''
+        const toModel = (msg.to_model as string) ?? ''
+        return {
+          entryType: 'system-message',
+          content: `Model rerouted from ${fromModel} to ${toModel}`,
+          timestamp: now,
+        }
+      }
+
+      // --- Token count / context usage ---
+      case 'token_count': {
+        const info = msg.info as {
+          last_token_usage?: { total_tokens?: number }
+          model_context_window?: number
+        } | undefined
+        if (!info?.last_token_usage) return null
+        const totalTokens = info.last_token_usage.total_tokens ?? 0
+        const contextWindow = info.model_context_window ?? 0
+        return {
+          entryType: 'token-usage',
+          content: `Tokens: ${totalTokens} / Context: ${contextWindow}`,
+          timestamp: now,
+          metadata: {
+            totalTokens,
+            contextWindow,
+          },
+        }
+      }
+
+      // --- Context compacted ---
+      case 'context_compacted': {
+        return {
+          entryType: 'system-message',
+          content: 'Context compacted',
+          timestamp: now,
+        }
+      }
+
+      // --- Session configured ---
+      case 'session_configured': {
+        const model = (msg.model as string) ?? ''
+        const sessionId = (msg.session_id as string) ?? ''
+        const parts: string[] = []
+        if (model) parts.push(`model: ${model}`)
+        return {
+          entryType: 'system-message',
+          content: parts.length > 0 ? parts.join('  ') : 'Session configured',
+          timestamp: now,
+          metadata: { subtype: 'session_configured', sessionId, model },
+        }
+      }
+
+      // --- Background event ---
+      case 'background_event': {
+        const message = (msg.message as string) ?? ''
+        if (!message) return null
+        return {
+          entryType: 'system-message',
+          content: `Background event: ${message}`,
+          timestamp: now,
+        }
+      }
+
+      // --- Turn started (within codex/event) ---
+      case 'turn_started': {
+        return {
+          entryType: 'system-message',
+          content: 'Turn started',
+          timestamp: now,
+          metadata: { subtype: 'turn_started' },
+        }
+      }
+
+      // --- Turn complete (within codex/event — new name) ---
+      case 'turn_complete': {
+        return null // Handled by the raw turn/completed notification
+      }
+
+      // --- Item started (plan item) ---
+      case 'item_started': {
+        const item = msg.item as Record<string, unknown> | undefined
+        if (item?.type === 'plan') {
+          this.resetStreamingState()
+          return {
+            entryType: 'system-message',
+            content: 'Plan generation started',
+            timestamp: now,
+            metadata: { subtype: 'plan_started', itemId: item.id },
+          }
+        }
+        return null
+      }
+
+      // --- Item completed (plan item) ---
+      case 'item_completed': {
+        const item = msg.item as Record<string, unknown> | undefined
+        if (item?.type === 'plan') {
+          const text = (item.text as string) ?? ''
+          if (text) {
+            return {
+              entryType: 'assistant-message',
+              content: text,
+              timestamp: now,
+              metadata: { isPlan: true },
+            }
+          }
+        }
+        return null
+      }
+
+      // --- MCP startup events (skip) ---
+      case 'mcp_startup_update':
+      case 'mcp_startup_complete':
+      case 'mcp_list_tools_response':
+      case 'user_message':
+      case 'turn_diff':
+      case 'deprecation_notice':
+      case 'raw_response_item':
+      case 'undo_started':
+      case 'undo_completed':
+      case 'thread_rolled_back':
+      case 'thread_name_updated':
+      case 'shutdown_complete':
+      case 'get_history_entry_response':
+      case 'list_custom_prompts_response':
+      case 'list_skills_response':
+      case 'skills_update_available':
+      case 'turn_aborted':
+      case 'terminal_interaction':
+      case 'elicitation_request':
+      case 'agent_message_content_delta':
+      case 'reasoning_content_delta':
+      case 'reasoning_raw_content_delta':
+      case 'agent_reasoning_raw_content':
+      case 'agent_reasoning_raw_content_delta':
+      case 'collab_agent_spawn_begin':
+      case 'collab_agent_spawn_end':
+      case 'collab_agent_interaction_begin':
+      case 'collab_agent_interaction_end':
+      case 'collab_waiting_begin':
+      case 'collab_waiting_end':
+      case 'collab_close_begin':
+      case 'collab_close_end':
+      case 'collab_resume_begin':
+      case 'collab_resume_end':
+      case 'dynamic_tool_call_request':
+      case 'dynamic_tool_call_response':
+      case 'list_remote_skills_response':
+      case 'remote_skill_downloaded':
+      case 'realtime_conversation_started':
+      case 'realtime_conversation_realtime':
+      case 'realtime_conversation_closed':
+        return null
+
+      default:
+        return null
+    }
+  }
+
+  // ---------- Legacy notification handlers (fallback) ----------
+
+  private handleResponse(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | null {
+    // Extract session ID from thread/start or thread/fork responses
+    const result = data.result as Record<string, unknown> | undefined
+    if (!result) return null
+    const thread = result.thread as Record<string, unknown> | undefined
+    if (thread?.id) {
+      const model = (result.model as string) ?? ''
+      const parts: string[] = []
+      if (model) parts.push(`model: ${model}`)
+      if (parts.length > 0) {
+        return {
+          entryType: 'system-message',
+          content: parts.join('  '),
+          timestamp: now,
+          metadata: { subtype: 'session_configured', model },
+        }
+      }
+    }
+    return null
+  }
+
+  private handleItemStarted(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const item = (params.item ?? {}) as Record<string, unknown>
+    const itemType = item.type as string | undefined
+
+    if (itemType === 'commandExecution') {
+      this.resetStreamingState()
+      const commandStr = extractCommandString(item)
+      const toolAction: ToolAction = {
+        kind: 'command-run',
+        command: commandStr,
+        category: commandStr ? classifyCommand(commandStr) : 'other',
+      }
+      return {
+        entryType: 'tool-use',
+        content: 'Tool: Bash',
+        timestamp: now,
+        metadata: {
+          streaming: true,
+          toolName: 'Bash',
+          toolCallId: item.id as string | undefined,
+          input: commandStr ? { command: commandStr } : undefined,
+        },
+        toolAction,
+      }
+    }
+
+    if (itemType === 'fileChange') {
+      this.resetStreamingState()
+      const path = item.path as string | undefined
+      return {
+        entryType: 'tool-use',
+        content: 'Tool: Edit',
+        timestamp: now,
+        metadata: {
+          streaming: true,
+          toolName: 'Edit',
+          toolCallId: item.id as string | undefined,
+          path,
+          input: path ? { file_path: path } : undefined,
+        },
+        toolAction: { kind: 'file-edit', path: path ?? '' },
+      }
+    }
+
+    if (itemType === 'agentMessage' || itemType === 'reasoning') {
+      return null
+    }
+
+    return null
+  }
+
+  private handleItemCompleted(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const item = (params.item ?? {}) as Record<string, unknown>
+    const itemType = item.type as string | undefined
+
+    if (itemType === 'commandExecution') {
+      const stdout = (item.stdout as string) ?? ''
+      const stderr = (item.stderr as string) ?? ''
+      const aggregated = (item.aggregatedOutput as string) ?? ''
+      const combined =
+        aggregated || [stdout, stderr].filter(Boolean).join('\n')
+      const exitCode = item.exitCode as number | undefined
+      const duration = (item.durationMs ?? item.duration) as number | undefined
+      const commandStr = extractCommandString(item)
+      return {
+        entryType: 'tool-use',
+        content: combined,
+        timestamp: now,
+        metadata: {
+          toolName: 'Bash',
+          isResult: true,
+          toolCallId: item.id as string | undefined,
+          exitCode,
+          duration,
+        },
+        toolAction: {
+          kind: 'command-run',
+          command: commandStr,
+          result: combined || undefined,
+          category: commandStr ? classifyCommand(commandStr) : 'other',
+        },
+      }
+    }
+
+    if (itemType === 'fileChange') {
+      const patches = item.patches as unknown[] | undefined
+      const path = item.path as string | undefined
+      const patchCount = patches?.length ?? 0
+      const summary = path
+        ? `File changed: ${path} (${patchCount} patch${patchCount !== 1 ? 'es' : ''})`
+        : `File changed (${patchCount} patch${patchCount !== 1 ? 'es' : ''})`
+      return {
+        entryType: 'tool-use',
+        content: summary,
+        timestamp: now,
+        metadata: {
+          toolName: 'Edit',
+          isResult: true,
+          toolCallId: item.id as string | undefined,
+          path,
+        },
+        toolAction: { kind: 'file-edit', path: path ?? '' },
+      }
+    }
+
+    if (itemType === 'agentMessage') {
+      return {
+        entryType: 'assistant-message',
+        content: (item.text as string) ?? '',
+        timestamp: now,
+      }
+    }
+
+    if (itemType === 'reasoning') return null
+    return null
+  }
+
+  private handleCommandOutputDelta(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const delta = params.delta as string | undefined
+    if (!delta) return null
+    return {
+      entryType: 'tool-use',
+      content: delta,
+      timestamp: now,
+      metadata: { isResult: true, streaming: true },
+    }
+  }
+
+  private handleFileChangeOutputDelta(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const delta = params.delta as string | undefined
+    if (!delta) return null
+    return {
+      entryType: 'tool-use',
+      content: delta,
+      timestamp: now,
+      metadata: { isResult: true, streaming: true },
+    }
+  }
+
+  private handleTurnStarted(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const turn = (params.turn ?? {}) as Record<string, unknown>
+    return {
+      entryType: 'system-message',
+      content: 'Turn started',
+      timestamp: now,
+      metadata: {
+        subtype: 'turn_started',
+        turnId: turn.id as string | undefined,
+      },
+    }
+  }
+
+  private handleTurnCompleted(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const turn = (params.turn ?? {}) as Record<string, unknown>
+    const usage = (turn.usage ?? {}) as Record<string, unknown>
+    const inputTokens = usage.inputTokens as number | undefined
+    const outputTokens = usage.outputTokens as number | undefined
+
+    const parts: string[] = []
+    if (inputTokens != null) {
+      parts.push(
+        inputTokens >= 1000
+          ? `${(inputTokens / 1000).toFixed(1)}k input`
+          : `${inputTokens} input`,
+      )
+    }
+    if (outputTokens != null) {
+      parts.push(
+        outputTokens >= 1000
+          ? `${(outputTokens / 1000).toFixed(1)}k output`
+          : `${outputTokens} output`,
+      )
+    }
+
+    return {
+      entryType: 'system-message',
+      content: parts.length ? parts.join(' \u00B7 ') : 'Turn completed',
+      timestamp: now,
+      metadata: {
+        source: 'result',
+        turnCompleted: true,
+        turnId: turn.id as string | undefined,
+        inputTokens,
+        outputTokens,
+      },
+    }
+  }
+
+  private handleThreadStarted(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const threadId = params.threadId as string | undefined
+    return {
+      entryType: 'system-message',
+      content: 'Thread started',
+      timestamp: now,
+      metadata: { subtype: 'thread_started', threadId },
+    }
+  }
+
+  private handleThreadStatusChanged(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const status = params.status as string | undefined
+    if (status === 'systemError') {
+      return {
+        entryType: 'error-message',
+        content: `Thread error: ${(params.message as string) ?? 'system error'}`,
+        timestamp: now,
+        metadata: { status },
+      }
+    }
+    return null
+  }
+
+  private handleError(
+    data: Record<string, unknown>,
+    now: string,
+  ): NormalizedLogEntry {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const error = (params.error ?? {}) as Record<string, unknown>
+    const willRetry = params.willRetry as boolean | undefined
+    return {
+      entryType: 'error-message',
+      content: (error.message as string) ?? 'Unknown error',
+      timestamp: now,
+      metadata: {
+        code: error.code as number | undefined,
+        willRetry,
+      },
+    }
+  }
+
+  // ---------- Helpers ----------
+
+  private resetStreamingState(): void {
+    this.assistantText = ''
+    this.hasAssistant = false
+    this.thinkingText = ''
+    this.hasThinking = false
+  }
+}
+
+/**
+ * Extract the command string from a Codex item.
+ * Codex sends `item.command` as either a string or string[] depending on version.
+ */
+function extractCommandString(item: Record<string, unknown>): string {
+  const cmd = item.command
+  if (typeof cmd === 'string') return cmd
+  if (Array.isArray(cmd)) {
+    return cmd
+      .map((a: unknown) => {
+        const s = String(a)
+        return /\s/.test(s) ? `"${s.replace(/"/g, '\\"')}"` : s
+      })
+      .join(' ')
+  }
+  const actions = item.commandActions as
+    | Array<{ command?: unknown }>
+    | undefined
+  const rawCmd = actions?.[0]?.command
+  if (typeof rawCmd === 'string' && rawCmd) return rawCmd
+  return ''
+}

--- a/apps/api/src/engines/executors/codex/protocol.ts
+++ b/apps/api/src/engines/executors/codex/protocol.ts
@@ -82,6 +82,21 @@ export interface ThreadForkParams extends ThreadStartParams {
   threadId: string
 }
 
+/** Convert ThreadStartParams to a plain RPC params object, omitting undefined values. */
+function threadParamsToRpc(params: ThreadStartParams): Record<string, unknown> {
+  const rpc: Record<string, unknown> = {}
+  if (params.model) rpc.model = params.model
+  if (params.cwd) rpc.cwd = params.cwd
+  if (params.approvalPolicy) rpc.approvalPolicy = params.approvalPolicy
+  if (params.sandbox) rpc.sandbox = params.sandbox
+  if (params.config) rpc.config = params.config
+  if (params.baseInstructions) rpc.baseInstructions = params.baseInstructions
+  if (params.developerInstructions)
+    rpc.developerInstructions = params.developerInstructions
+  if (params.modelProvider) rpc.modelProvider = params.modelProvider
+  return rpc
+}
+
 /**
  * Manages the Codex app-server JSON-RPC protocol over stdio (JSONL, no
  * `"jsonrpc":"2.0"`). Uses a push-based approach: a background reader
@@ -96,6 +111,7 @@ export class CodexProtocolHandler {
   private readonly stdin: FileSink
   private readonly pending = new Map<number | string, PendingRequest>()
   private readonly requestTimeout: number
+  private readonly encoder = new TextEncoder()
   private notificationController:
     | ReadableStreamDefaultController<Uint8Array>
     | undefined
@@ -172,19 +188,7 @@ export class CodexProtocolHandler {
     threadId: string
     model?: string
   }> {
-    const rpcParams: Record<string, unknown> = {}
-    if (params.model) rpcParams.model = params.model
-    if (params.cwd) rpcParams.cwd = params.cwd
-    if (params.approvalPolicy) rpcParams.approvalPolicy = params.approvalPolicy
-    if (params.sandbox) rpcParams.sandbox = params.sandbox
-    if (params.config) rpcParams.config = params.config
-    if (params.baseInstructions)
-      rpcParams.baseInstructions = params.baseInstructions
-    if (params.developerInstructions)
-      rpcParams.developerInstructions = params.developerInstructions
-    if (params.modelProvider) rpcParams.modelProvider = params.modelProvider
-
-    const result = (await this.sendRequest('thread/start', rpcParams)) as {
+    const result = (await this.sendRequest('thread/start', threadParamsToRpc(params))) as {
       thread?: { id?: string }
       model?: string
     }
@@ -210,19 +214,10 @@ export class CodexProtocolHandler {
     threadId: string
     model?: string
   }> {
-    const rpcParams: Record<string, unknown> = {
+    const rpcParams = {
+      ...threadParamsToRpc(params),
       threadId: params.threadId,
     }
-    if (params.model) rpcParams.model = params.model
-    if (params.cwd) rpcParams.cwd = params.cwd
-    if (params.approvalPolicy) rpcParams.approvalPolicy = params.approvalPolicy
-    if (params.sandbox) rpcParams.sandbox = params.sandbox
-    if (params.config) rpcParams.config = params.config
-    if (params.baseInstructions)
-      rpcParams.baseInstructions = params.baseInstructions
-    if (params.developerInstructions)
-      rpcParams.developerInstructions = params.developerInstructions
-    if (params.modelProvider) rpcParams.modelProvider = params.modelProvider
 
     const result = (await this.sendRequest('thread/fork', rpcParams)) as {
       thread?: { id?: string }
@@ -351,14 +346,13 @@ export class CodexProtocolHandler {
       )
     }
 
-    const encoder = new TextEncoder()
     let msg: Record<string, unknown>
     try {
       msg = JSON.parse(line)
     } catch {
       // Non-JSON line — push through as-is
       try {
-        this.notificationController?.enqueue(encoder.encode(`${line}\n`))
+        this.notificationController?.enqueue(this.encoder.encode(`${line}\n`))
       } catch {
         /* controller closed */
       }
@@ -379,7 +373,7 @@ export class CodexProtocolHandler {
       case 'notification':
         this.trackNotification(msg as unknown as JsonRpcNotification)
         try {
-          this.notificationController?.enqueue(encoder.encode(`${line}\n`))
+          this.notificationController?.enqueue(this.encoder.encode(`${line}\n`))
         } catch {
           /* controller closed */
         }
@@ -387,7 +381,7 @@ export class CodexProtocolHandler {
 
       default:
         try {
-          this.notificationController?.enqueue(encoder.encode(`${line}\n`))
+          this.notificationController?.enqueue(this.encoder.encode(`${line}\n`))
         } catch {
           /* controller closed */
         }
@@ -435,10 +429,9 @@ export class CodexProtocolHandler {
     if (!pending) {
       logger.warn({ id: response.id }, 'codex_protocol_orphan_response')
       // Push orphan response through for downstream processing
-      const encoder = new TextEncoder()
       try {
         this.notificationController?.enqueue(
-          encoder.encode(`${JSON.stringify(response)}\n`),
+          this.encoder.encode(`${JSON.stringify(response)}\n`),
         )
       } catch {
         /* controller closed */
@@ -461,14 +454,13 @@ export class CodexProtocolHandler {
       pending.resolve(response.result)
 
       // Push matched responses through for downstream session ID / model extraction
-      const encoder = new TextEncoder()
       try {
         const responseJson = JSON.stringify({
           id: response.id,
           result: response.result,
         })
         this.notificationController?.enqueue(
-          encoder.encode(`${responseJson}\n`),
+          this.encoder.encode(`${responseJson}\n`),
         )
       } catch {
         /* controller closed */

--- a/apps/api/src/engines/executors/codex/protocol.ts
+++ b/apps/api/src/engines/executors/codex/protocol.ts
@@ -14,6 +14,7 @@ function clipForLog(input: string): string {
 const APPROVAL_METHODS = new Set([
   'item/commandExecution/requestApproval',
   'item/fileChange/requestApproval',
+  'toolRequestUserInput',
 ])
 
 interface PendingRequest {
@@ -58,6 +59,27 @@ function classifyMessage(
   if (hasId && hasMethod) return 'server-request'
   if (hasMethod && !hasId) return 'notification'
   return 'unknown'
+}
+
+/**
+ * Thread start parameters matching the Codex app-server protocol.
+ */
+export interface ThreadStartParams {
+  model?: string
+  cwd?: string
+  approvalPolicy?: string
+  sandbox?: string
+  config?: Record<string, unknown>
+  baseInstructions?: string
+  developerInstructions?: string
+  modelProvider?: string
+}
+
+/**
+ * Thread fork parameters — creates a new thread forked from an existing one.
+ */
+export interface ThreadForkParams extends ThreadStartParams {
+  threadId: string
 }
 
 /**
@@ -113,7 +135,7 @@ export class CodexProtocolHandler {
   async initialize(): Promise<{ userAgent: string }> {
     const result = (await this.sendRequest('initialize', {
       clientInfo: { name: 'bitk', version: '0.1.0', title: 'BitK' },
-      capabilities: {},
+      capabilities: { experimental_api: true },
     })) as { userAgent?: string }
 
     this.sendNotification('initialized')
@@ -123,22 +145,48 @@ export class CodexProtocolHandler {
   }
 
   /**
+   * Read account info to check auth status before starting a thread.
+   */
+  async getAccount(): Promise<{
+    requiresOpenaiAuth: boolean
+    account: unknown | null
+  }> {
+    const result = (await this.sendRequest('account/read', {
+      refreshToken: false,
+    })) as {
+      requiresOpenaiAuth?: boolean
+      requires_openai_auth?: boolean
+      account?: unknown
+    }
+    return {
+      requiresOpenaiAuth:
+        result?.requiresOpenaiAuth ?? result?.requires_openai_auth ?? false,
+      account: result?.account ?? null,
+    }
+  }
+
+  /**
    * Create a new thread, returns the thread ID.
    */
-  async startThread(options: {
+  async startThread(params: ThreadStartParams): Promise<{
+    threadId: string
     model?: string
-    cwd?: string
-    approvalPolicy?: string
-    sandbox?: string
-  }): Promise<string> {
-    const params: Record<string, unknown> = {}
-    if (options.model) params.model = options.model
-    if (options.cwd) params.cwd = options.cwd
-    if (options.approvalPolicy) params.approvalPolicy = options.approvalPolicy
-    if (options.sandbox) params.sandbox = options.sandbox
+  }> {
+    const rpcParams: Record<string, unknown> = {}
+    if (params.model) rpcParams.model = params.model
+    if (params.cwd) rpcParams.cwd = params.cwd
+    if (params.approvalPolicy) rpcParams.approvalPolicy = params.approvalPolicy
+    if (params.sandbox) rpcParams.sandbox = params.sandbox
+    if (params.config) rpcParams.config = params.config
+    if (params.baseInstructions)
+      rpcParams.baseInstructions = params.baseInstructions
+    if (params.developerInstructions)
+      rpcParams.developerInstructions = params.developerInstructions
+    if (params.modelProvider) rpcParams.modelProvider = params.modelProvider
 
-    const result = (await this.sendRequest('thread/start', params)) as {
+    const result = (await this.sendRequest('thread/start', rpcParams)) as {
       thread?: { id?: string }
+      model?: string
     }
 
     const threadId = result?.thread?.id
@@ -147,12 +195,55 @@ export class CodexProtocolHandler {
     }
 
     this._threadId = threadId
-    logger.info({ threadId }, 'codex_protocol_thread_started')
-    return threadId
+    logger.info(
+      { threadId, model: result?.model },
+      'codex_protocol_thread_started',
+    )
+    return { threadId, model: result?.model }
   }
 
   /**
-   * Resume an existing thread.
+   * Fork an existing thread — creates a new thread with the same history.
+   * Used for follow-ups instead of thread/resume (more reliable).
+   */
+  async forkThread(params: ThreadForkParams): Promise<{
+    threadId: string
+    model?: string
+  }> {
+    const rpcParams: Record<string, unknown> = {
+      threadId: params.threadId,
+    }
+    if (params.model) rpcParams.model = params.model
+    if (params.cwd) rpcParams.cwd = params.cwd
+    if (params.approvalPolicy) rpcParams.approvalPolicy = params.approvalPolicy
+    if (params.sandbox) rpcParams.sandbox = params.sandbox
+    if (params.config) rpcParams.config = params.config
+    if (params.baseInstructions)
+      rpcParams.baseInstructions = params.baseInstructions
+    if (params.developerInstructions)
+      rpcParams.developerInstructions = params.developerInstructions
+    if (params.modelProvider) rpcParams.modelProvider = params.modelProvider
+
+    const result = (await this.sendRequest('thread/fork', rpcParams)) as {
+      thread?: { id?: string }
+      model?: string
+    }
+
+    const threadId = result?.thread?.id
+    if (!threadId) {
+      throw new Error('thread/fork response missing thread.id')
+    }
+
+    this._threadId = threadId
+    logger.info(
+      { threadId, forkedFrom: params.threadId, model: result?.model },
+      'codex_protocol_thread_forked',
+    )
+    return { threadId, model: result?.model }
+  }
+
+  /**
+   * Resume an existing thread (legacy fallback if fork fails).
    */
   async resumeThread(threadId: string): Promise<void> {
     await this.sendRequest('thread/resume', { threadId })
@@ -169,7 +260,6 @@ export class CodexProtocolHandler {
       input: [{ type: 'text', text: prompt }],
     })) as { turn?: { id?: string }; turnId?: string }
 
-    // The response structure may vary — try both shapes
     const turnId = result?.turn?.id ?? result?.turnId
     if (turnId) {
       this._turnId = turnId
@@ -203,7 +293,6 @@ export class CodexProtocolHandler {
     if (this.closed) return
     this.closed = true
 
-    // Reject all pending requests
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer)
       pending.reject(
@@ -236,7 +325,6 @@ export class CodexProtocolHandler {
           const { done, value } = await reader.read()
           if (done) break
           buffer += decoder.decode(value, { stream: true })
-          // Split on newlines, process each complete line
           const lines = buffer.split('\n')
           buffer = lines.pop() ?? ''
           for (const line of lines) {
@@ -244,13 +332,11 @@ export class CodexProtocolHandler {
             this.processLine(line)
           }
         }
-        // Flush remaining buffer
         if (buffer.trim()) this.processLine(buffer)
       } catch (error) {
         logger.warn({ error }, 'codex_protocol_reader_error')
       } finally {
         reader.releaseLock()
-        // Close pending request timers and notification stream on reader exit
         this.close()
       }
     })()
@@ -292,7 +378,6 @@ export class CodexProtocolHandler {
 
       case 'notification':
         this.trackNotification(msg as unknown as JsonRpcNotification)
-        // Push through for downstream normalizeLog
         try {
           this.notificationController?.enqueue(encoder.encode(`${line}\n`))
         } catch {
@@ -301,7 +386,6 @@ export class CodexProtocolHandler {
         break
 
       default:
-        // Unknown structure — push through
         try {
           this.notificationController?.enqueue(encoder.encode(`${line}\n`))
         } catch {
@@ -350,6 +434,15 @@ export class CodexProtocolHandler {
     const pending = this.pending.get(response.id)
     if (!pending) {
       logger.warn({ id: response.id }, 'codex_protocol_orphan_response')
+      // Push orphan response through for downstream processing
+      const encoder = new TextEncoder()
+      try {
+        this.notificationController?.enqueue(
+          encoder.encode(`${JSON.stringify(response)}\n`),
+        )
+      } catch {
+        /* controller closed */
+      }
       return
     }
 
@@ -366,6 +459,20 @@ export class CodexProtocolHandler {
     } else {
       logger.debug({ id: response.id }, 'codex_protocol_rpc_response')
       pending.resolve(response.result)
+
+      // Push matched responses through for downstream session ID / model extraction
+      const encoder = new TextEncoder()
+      try {
+        const responseJson = JSON.stringify({
+          id: response.id,
+          result: response.result,
+        })
+        this.notificationController?.enqueue(
+          encoder.encode(`${responseJson}\n`),
+        )
+      } catch {
+        /* controller closed */
+      }
     }
   }
 
@@ -395,13 +502,22 @@ export class CodexProtocolHandler {
       this._turnId = undefined
     }
 
-    // Extract turn ID if provided in turn/started
     if (method === 'turn/started' && params) {
       const turnId = (params as Record<string, unknown>).turnId as
         | string
         | undefined
       if (turnId) {
         this._turnId = turnId
+      }
+    }
+
+    if (method === 'thread/started' && params) {
+      const thread = (params as Record<string, unknown>).thread as
+        | Record<string, unknown>
+        | undefined
+      const threadId = thread?.id as string | undefined
+      if (threadId && !this._threadId) {
+        this._threadId = threadId
       }
     }
   }

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -168,13 +168,25 @@ async function runLiveProbe(): Promise<EngineDiscovery> {
 
 const DISCOVERY_TIMEOUT_MS = 130_000
 
+/** Static slash commands for Codex (no discovery needed). */
+const CODEX_SLASH_COMMANDS = ['/compact', '/status', '/mcp']
+
 /**
  * Discover slash commands and agents for installed engines.
- * Currently only Claude Code supports this. Saves results to DB + memory cache.
+ * Claude Code: discovered dynamically. Codex: registered statically.
  */
 async function discoverSlashCommands(
   installed: EngineAvailability[],
 ): Promise<void> {
+  // Register static Codex slash commands if installed
+  if (installed.some((e) => e.engineType === 'codex')) {
+    await setAppSetting(
+      slashCommandsKey('codex'),
+      JSON.stringify(CODEX_SLASH_COMMANDS),
+    )
+    await refreshSlashCommandsCacheForEngine('codex')
+  }
+
   for (const engine of installed) {
     if (engine.engineType !== 'claude-code') continue
 

--- a/apps/api/test/codex-normalize-log.test.ts
+++ b/apps/api/test/codex-normalize-log.test.ts
@@ -386,7 +386,9 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
 
     test('empty delta returns null', () => {
       const n = new CodexLogNormalizer()
-      expect(n.parse(codexEvent('agent_message_delta', { delta: '' }))).toBeNull()
+      expect(
+        n.parse(codexEvent('agent_message_delta', { delta: '' })),
+      ).toBeNull()
     })
 
     test('resets thinking state when assistant delta arrives', () => {
@@ -403,7 +405,9 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
       const n = new CodexLogNormalizer()
       // Accumulate some deltas first
       n.parse(codexEvent('agent_message_delta', { delta: 'partial' }))
-      const r = n.parse(codexEvent('agent_message', { message: 'Full message' }))
+      const r = n.parse(
+        codexEvent('agent_message', { message: 'Full message' }),
+      )
       expect(r!.entryType).toBe('assistant-message')
       expect(r!.content).toBe('Full message')
       expect(r!.metadata?.streaming).toBeUndefined()
@@ -420,12 +424,16 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('agent_reasoning_delta', () => {
     test('accumulates thinking text', () => {
       const n = new CodexLogNormalizer()
-      const r1 = n.parse(codexEvent('agent_reasoning_delta', { delta: 'Let me ' }))
+      const r1 = n.parse(
+        codexEvent('agent_reasoning_delta', { delta: 'Let me ' }),
+      )
       expect(r1!.entryType).toBe('thinking')
       expect(r1!.content).toBe('Let me ')
       expect(r1!.metadata?.streaming).toBe(true)
 
-      const r2 = n.parse(codexEvent('agent_reasoning_delta', { delta: 'think...' }))
+      const r2 = n.parse(
+        codexEvent('agent_reasoning_delta', { delta: 'think...' }),
+      )
       expect(r2!.content).toBe('Let me think...')
     })
   })
@@ -433,7 +441,9 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('agent_reasoning (complete)', () => {
     test('returns complete thinking entry', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('agent_reasoning', { text: 'Full reasoning' }))
+      const r = n.parse(
+        codexEvent('agent_reasoning', { text: 'Full reasoning' }),
+      )
       expect(r!.entryType).toBe('thinking')
       expect(r!.content).toBe('Full reasoning')
       expect(r!.metadata?.streaming).toBeUndefined()
@@ -446,10 +456,12 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('exec_command_begin', () => {
     test('returns tool-use with command', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('exec_command_begin', {
-        command: ['git', 'status'],
-        call_id: 'call-1',
-      }))
+      const r = n.parse(
+        codexEvent('exec_command_begin', {
+          command: ['git', 'status'],
+          call_id: 'call-1',
+        }),
+      )
       expect(r!.entryType).toBe('tool-use')
       expect(r!.content).toBe('Tool: Bash')
       expect(r!.metadata?.toolName).toBe('Bash')
@@ -460,17 +472,21 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
 
     test('returns null for empty command', () => {
       const n = new CodexLogNormalizer()
-      expect(n.parse(codexEvent('exec_command_begin', { command: [] }))).toBeNull()
+      expect(
+        n.parse(codexEvent('exec_command_begin', { command: [] })),
+      ).toBeNull()
     })
   })
 
   describe('exec_command_output_delta', () => {
     test('returns streaming tool output', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('exec_command_output_delta', {
-        chunk: 'output text',
-        stream: 'stdout',
-      }))
+      const r = n.parse(
+        codexEvent('exec_command_output_delta', {
+          chunk: 'output text',
+          stream: 'stdout',
+        }),
+      )
       expect(r!.entryType).toBe('tool-use')
       expect(r!.content).toBe('output text')
       expect(r!.metadata?.streaming).toBe(true)
@@ -481,12 +497,14 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('exec_command_end', () => {
     test('returns tool result with exit code', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('exec_command_end', {
-        command: ['ls', '-la'],
-        exit_code: 0,
-        formatted_output: 'file1.ts\nfile2.ts',
-        call_id: 'call-2',
-      }))
+      const r = n.parse(
+        codexEvent('exec_command_end', {
+          command: ['ls', '-la'],
+          exit_code: 0,
+          formatted_output: 'file1.ts\nfile2.ts',
+          call_id: 'call-2',
+        }),
+      )
       expect(r!.entryType).toBe('tool-use')
       expect(r!.content).toBe('file1.ts\nfile2.ts')
       expect(r!.metadata?.isResult).toBe(true)
@@ -501,10 +519,12 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('patch_apply_begin', () => {
     test('returns tool-use entries for each changed file', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('patch_apply_begin', {
-        changes: { '/app/a.ts': '+line', '/app/b.ts': '-line' },
-        call_id: 'patch-1',
-      }))
+      const r = n.parse(
+        codexEvent('patch_apply_begin', {
+          changes: { '/app/a.ts': '+line', '/app/b.ts': '-line' },
+          call_id: 'patch-1',
+        }),
+      )
       expect(Array.isArray(r)).toBe(true)
       const entries = r as any[]
       expect(entries.length).toBe(2)
@@ -514,9 +534,11 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
 
     test('single file returns single entry (not array)', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('patch_apply_begin', {
-        changes: { '/app/x.ts': '+line' },
-      }))
+      const r = n.parse(
+        codexEvent('patch_apply_begin', {
+          changes: { '/app/x.ts': '+line' },
+        }),
+      )
       expect(Array.isArray(r)).toBe(false)
       expect((r as any).metadata?.path).toBe('/app/x.ts')
     })
@@ -544,9 +566,15 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('mcp_tool_call_begin', () => {
     test('returns tool-use with server:tool name', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('mcp_tool_call_begin', {
-        invocation: { server: 'fs', tool: 'readFile', arguments: { path: '/tmp' } },
-      }))
+      const r = n.parse(
+        codexEvent('mcp_tool_call_begin', {
+          invocation: {
+            server: 'fs',
+            tool: 'readFile',
+            arguments: { path: '/tmp' },
+          },
+        }),
+      )
       expect(r!.metadata?.toolName).toBe('mcp:fs:readFile')
       expect(r!.toolAction?.kind).toBe('tool')
     })
@@ -555,23 +583,27 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('mcp_tool_call_end', () => {
     test('extracts text content from result', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'readFile' },
-        result: {
-          content: [{ type: 'text', text: 'file contents' }],
-          is_error: false,
-        },
-      }))
+      const r = n.parse(
+        codexEvent('mcp_tool_call_end', {
+          invocation: { server: 'fs', tool: 'readFile' },
+          result: {
+            content: [{ type: 'text', text: 'file contents' }],
+            is_error: false,
+          },
+        }),
+      )
       expect(r!.content).toBe('file contents')
       expect(r!.metadata?.exitCode).toBe(0)
     })
 
     test('handles error result', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'readFile' },
-        result: { is_error: true },
-      }))
+      const r = n.parse(
+        codexEvent('mcp_tool_call_end', {
+          invocation: { server: 'fs', tool: 'readFile' },
+          result: { is_error: true },
+        }),
+      )
       expect(r!.content).toBe('MCP tool call failed')
       expect(r!.metadata?.exitCode).toBe(1)
     })
@@ -590,7 +622,9 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
 
     test('stream_error returns error-message', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('stream_error', { message: 'connection lost' }))
+      const r = n.parse(
+        codexEvent('stream_error', { message: 'connection lost' }),
+      )
       expect(r!.entryType).toBe('error-message')
       expect(r!.content).toBe('Stream error: connection lost')
     })
@@ -611,22 +645,26 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('system events', () => {
     test('model_reroute', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('model_reroute', {
-        from_model: 'gpt-4o',
-        to_model: 'gpt-5.3-codex',
-      }))
+      const r = n.parse(
+        codexEvent('model_reroute', {
+          from_model: 'gpt-4o',
+          to_model: 'gpt-5.3-codex',
+        }),
+      )
       expect(r!.entryType).toBe('system-message')
       expect(r!.content).toBe('Model rerouted from gpt-4o to gpt-5.3-codex')
     })
 
     test('token_count', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('token_count', {
-        info: {
-          last_token_usage: { total_tokens: 5000 },
-          model_context_window: 128000,
-        },
-      }))
+      const r = n.parse(
+        codexEvent('token_count', {
+          info: {
+            last_token_usage: { total_tokens: 5000 },
+            model_context_window: 128000,
+          },
+        }),
+      )
       expect(r!.entryType).toBe('token-usage')
       expect(r!.metadata?.totalTokens).toBe(5000)
       expect(r!.metadata?.contextWindow).toBe(128000)
@@ -640,10 +678,12 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
 
     test('session_configured', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('session_configured', {
-        model: 'gpt-5.3-codex',
-        session_id: 'sess-123',
-      }))
+      const r = n.parse(
+        codexEvent('session_configured', {
+          model: 'gpt-5.3-codex',
+          session_id: 'sess-123',
+        }),
+      )
       expect(r!.content).toBe('model: gpt-5.3-codex')
       expect(r!.metadata?.sessionId).toBe('sess-123')
     })
@@ -698,10 +738,12 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
   describe('JSON-RPC response handling', () => {
     test('thread/start response with model emits session_configured', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(JSON.stringify({
-        id: 1,
-        result: { thread: { id: 'thr-1' }, model: 'gpt-5.3-codex' },
-      }))
+      const r = n.parse(
+        JSON.stringify({
+          id: 1,
+          result: { thread: { id: 'thr-1' }, model: 'gpt-5.3-codex' },
+        }),
+      )
       expect(r!.entryType).toBe('system-message')
       expect(r!.content).toBe('model: gpt-5.3-codex')
     })
@@ -728,13 +770,15 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
 
     test('plan_update with steps', () => {
       const n = new CodexLogNormalizer()
-      const r = n.parse(codexEvent('plan_update', {
-        plan: [
-          { step: 'Read file', status: 'done' },
-          { step: 'Edit file', status: 'pending' },
-        ],
-        explanation: 'Updated plan',
-      }))
+      const r = n.parse(
+        codexEvent('plan_update', {
+          plan: [
+            { step: 'Read file', status: 'done' },
+            { step: 'Edit file', status: 'pending' },
+          ],
+          explanation: 'Updated plan',
+        }),
+      )
       expect(r!.entryType).toBe('system-message')
       expect(r!.content).toBe('Updated plan')
     })

--- a/apps/api/test/codex-normalize-log.test.ts
+++ b/apps/api/test/codex-normalize-log.test.ts
@@ -698,7 +698,6 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
       'mcp_startup_complete',
       'user_message',
       'turn_diff',
-      'turn_complete',
       'shutdown_complete',
       'turn_aborted',
     ]
@@ -730,6 +729,30 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
       const r = n.parse(codexEvent('agent_reasoning_delta', { delta: 'fresh' }))
       expect(r!.content).toBe('fresh')
     })
+
+    test('plan_update resets assistant buffer so next delta starts fresh', () => {
+      const n = new CodexLogNormalizer()
+      n.parse(codexEvent('plan_delta', { delta: 'Step 1: do X' }))
+      n.parse(
+        codexEvent('plan_update', {
+          plan: [{ step: 'Step 1', status: 'done' }],
+        }),
+      )
+      // Next agent_message_delta should NOT include stale plan text
+      const r = n.parse(codexEvent('agent_message_delta', { delta: 'Answer' }))
+      expect(r!.content).toBe('Answer')
+    })
+
+    test('turn_complete resets streaming state', () => {
+      const n = new CodexLogNormalizer()
+      n.parse(codexEvent('agent_message_delta', { delta: 'partial' }))
+      n.parse(codexEvent('turn_complete'))
+      // Next delta should start fresh
+      const r = n.parse(
+        codexEvent('agent_message_delta', { delta: 'New turn' }),
+      )
+      expect(r!.content).toBe('New turn')
+    })
   })
 
   // ------------------------------------------------------------------
@@ -751,6 +774,20 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
     test('response without thread returns null', () => {
       const n = new CodexLogNormalizer()
       expect(n.parse(JSON.stringify({ id: 1, result: {} }))).toBeNull()
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Turn complete (v2 codex/event)
+  // ------------------------------------------------------------------
+  describe('turn_complete event', () => {
+    test('emits completion entry with turnCompleted metadata', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('turn_complete'))
+      expect(r).not.toBeNull()
+      expect(r!.entryType).toBe('system-message')
+      expect(r!.content).toBe('Turn completed')
+      expect(r!.metadata?.turnCompleted).toBe(true)
     })
   })
 

--- a/apps/api/test/codex-normalize-log.test.ts
+++ b/apps/api/test/codex-normalize-log.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, test } from 'bun:test'
-import { CodexExecutor } from '@/engines/executors/codex'
+import { CodexExecutor, CodexLogNormalizer } from '@/engines/executors/codex'
 
 const executor = new CodexExecutor()
 
 function normalize(method: string, params?: Record<string, unknown>) {
   return executor.normalizeLog(JSON.stringify({ method, params }))
+}
+
+/** Helper: build a codex/event/* notification line */
+function codexEvent(eventType: string, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    method: 'codex/event/xxx',
+    params: { msg: { type: eventType, ...extra } },
+  })
 }
 
 describe('CodexExecutor.normalizeLog', () => {
@@ -352,6 +360,383 @@ describe('CodexExecutor.normalizeLog', () => {
       expect(entry!.timestamp).toBeTruthy()
       // Verify ISO 8601 format
       expect(() => new Date(entry!.timestamp!)).not.toThrow()
+    })
+  })
+})
+
+// ==================================================================
+// Stateful CodexLogNormalizer — codex/event/* protocol tests
+// ==================================================================
+describe('CodexLogNormalizer (codex/event/*)', () => {
+  // ------------------------------------------------------------------
+  // Streaming assistant message accumulation
+  // ------------------------------------------------------------------
+  describe('agent_message_delta (streaming)', () => {
+    test('accumulates deltas into full assistant-message', () => {
+      const n = new CodexLogNormalizer()
+      const r1 = n.parse(codexEvent('agent_message_delta', { delta: 'Hello ' }))
+      expect(r1).not.toBeNull()
+      expect(r1!.entryType).toBe('assistant-message')
+      expect(r1!.content).toBe('Hello ')
+      expect(r1!.metadata?.streaming).toBe(true)
+
+      const r2 = n.parse(codexEvent('agent_message_delta', { delta: 'world!' }))
+      expect(r2!.content).toBe('Hello world!')
+    })
+
+    test('empty delta returns null', () => {
+      const n = new CodexLogNormalizer()
+      expect(n.parse(codexEvent('agent_message_delta', { delta: '' }))).toBeNull()
+    })
+
+    test('resets thinking state when assistant delta arrives', () => {
+      const n = new CodexLogNormalizer()
+      n.parse(codexEvent('agent_reasoning_delta', { delta: 'thinking...' }))
+      const r = n.parse(codexEvent('agent_message_delta', { delta: 'Hi' }))
+      expect(r!.entryType).toBe('assistant-message')
+      expect(r!.content).toBe('Hi')
+    })
+  })
+
+  describe('agent_message (complete)', () => {
+    test('returns complete assistant-message and resets state', () => {
+      const n = new CodexLogNormalizer()
+      // Accumulate some deltas first
+      n.parse(codexEvent('agent_message_delta', { delta: 'partial' }))
+      const r = n.parse(codexEvent('agent_message', { message: 'Full message' }))
+      expect(r!.entryType).toBe('assistant-message')
+      expect(r!.content).toBe('Full message')
+      expect(r!.metadata?.streaming).toBeUndefined()
+
+      // Next delta should start fresh
+      const r2 = n.parse(codexEvent('agent_message_delta', { delta: 'New' }))
+      expect(r2!.content).toBe('New')
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Reasoning (thinking) events
+  // ------------------------------------------------------------------
+  describe('agent_reasoning_delta', () => {
+    test('accumulates thinking text', () => {
+      const n = new CodexLogNormalizer()
+      const r1 = n.parse(codexEvent('agent_reasoning_delta', { delta: 'Let me ' }))
+      expect(r1!.entryType).toBe('thinking')
+      expect(r1!.content).toBe('Let me ')
+      expect(r1!.metadata?.streaming).toBe(true)
+
+      const r2 = n.parse(codexEvent('agent_reasoning_delta', { delta: 'think...' }))
+      expect(r2!.content).toBe('Let me think...')
+    })
+  })
+
+  describe('agent_reasoning (complete)', () => {
+    test('returns complete thinking entry', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('agent_reasoning', { text: 'Full reasoning' }))
+      expect(r!.entryType).toBe('thinking')
+      expect(r!.content).toBe('Full reasoning')
+      expect(r!.metadata?.streaming).toBeUndefined()
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Command execution events
+  // ------------------------------------------------------------------
+  describe('exec_command_begin', () => {
+    test('returns tool-use with command', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('exec_command_begin', {
+        command: ['git', 'status'],
+        call_id: 'call-1',
+      }))
+      expect(r!.entryType).toBe('tool-use')
+      expect(r!.content).toBe('Tool: Bash')
+      expect(r!.metadata?.toolName).toBe('Bash')
+      expect(r!.metadata?.toolCallId).toBe('call-1')
+      expect(r!.metadata?.input).toEqual({ command: 'git status' })
+      expect(r!.toolAction?.kind).toBe('command-run')
+    })
+
+    test('returns null for empty command', () => {
+      const n = new CodexLogNormalizer()
+      expect(n.parse(codexEvent('exec_command_begin', { command: [] }))).toBeNull()
+    })
+  })
+
+  describe('exec_command_output_delta', () => {
+    test('returns streaming tool output', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('exec_command_output_delta', {
+        chunk: 'output text',
+        stream: 'stdout',
+      }))
+      expect(r!.entryType).toBe('tool-use')
+      expect(r!.content).toBe('output text')
+      expect(r!.metadata?.streaming).toBe(true)
+      expect(r!.metadata?.outputStream).toBe('stdout')
+    })
+  })
+
+  describe('exec_command_end', () => {
+    test('returns tool result with exit code', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('exec_command_end', {
+        command: ['ls', '-la'],
+        exit_code: 0,
+        formatted_output: 'file1.ts\nfile2.ts',
+        call_id: 'call-2',
+      }))
+      expect(r!.entryType).toBe('tool-use')
+      expect(r!.content).toBe('file1.ts\nfile2.ts')
+      expect(r!.metadata?.isResult).toBe(true)
+      expect(r!.metadata?.exitCode).toBe(0)
+      expect(r!.toolAction?.kind).toBe('command-run')
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // File patch events
+  // ------------------------------------------------------------------
+  describe('patch_apply_begin', () => {
+    test('returns tool-use entries for each changed file', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('patch_apply_begin', {
+        changes: { '/app/a.ts': '+line', '/app/b.ts': '-line' },
+        call_id: 'patch-1',
+      }))
+      expect(Array.isArray(r)).toBe(true)
+      const entries = r as any[]
+      expect(entries.length).toBe(2)
+      expect(entries[0].metadata?.path).toBe('/app/a.ts')
+      expect(entries[1].metadata?.path).toBe('/app/b.ts')
+    })
+
+    test('single file returns single entry (not array)', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('patch_apply_begin', {
+        changes: { '/app/x.ts': '+line' },
+      }))
+      expect(Array.isArray(r)).toBe(false)
+      expect((r as any).metadata?.path).toBe('/app/x.ts')
+    })
+  })
+
+  describe('patch_apply_end', () => {
+    test('returns success result', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('patch_apply_end', { success: true }))
+      expect(r!.content).toBe('Patch applied successfully')
+      expect(r!.metadata?.exitCode).toBe(0)
+    })
+
+    test('returns failure result', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('patch_apply_end', { success: false }))
+      expect(r!.content).toBe('Patch apply failed')
+      expect(r!.metadata?.exitCode).toBe(1)
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // MCP tool call events
+  // ------------------------------------------------------------------
+  describe('mcp_tool_call_begin', () => {
+    test('returns tool-use with server:tool name', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('mcp_tool_call_begin', {
+        invocation: { server: 'fs', tool: 'readFile', arguments: { path: '/tmp' } },
+      }))
+      expect(r!.metadata?.toolName).toBe('mcp:fs:readFile')
+      expect(r!.toolAction?.kind).toBe('tool')
+    })
+  })
+
+  describe('mcp_tool_call_end', () => {
+    test('extracts text content from result', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('mcp_tool_call_end', {
+        invocation: { server: 'fs', tool: 'readFile' },
+        result: {
+          content: [{ type: 'text', text: 'file contents' }],
+          is_error: false,
+        },
+      }))
+      expect(r!.content).toBe('file contents')
+      expect(r!.metadata?.exitCode).toBe(0)
+    })
+
+    test('handles error result', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('mcp_tool_call_end', {
+        invocation: { server: 'fs', tool: 'readFile' },
+        result: { is_error: true },
+      }))
+      expect(r!.content).toBe('MCP tool call failed')
+      expect(r!.metadata?.exitCode).toBe(1)
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Error / warning / system events
+  // ------------------------------------------------------------------
+  describe('error and warning events', () => {
+    test('error returns error-message', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('error', { message: 'API error' }))
+      expect(r!.entryType).toBe('error-message')
+      expect(r!.content).toBe('Error: API error')
+    })
+
+    test('stream_error returns error-message', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('stream_error', { message: 'connection lost' }))
+      expect(r!.entryType).toBe('error-message')
+      expect(r!.content).toBe('Stream error: connection lost')
+    })
+
+    test('warning returns error-message', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('warning', { message: 'Deprecated API' }))
+      expect(r!.entryType).toBe('error-message')
+      expect(r!.content).toBe('Deprecated API')
+    })
+
+    test('warning with empty message returns null', () => {
+      const n = new CodexLogNormalizer()
+      expect(n.parse(codexEvent('warning', { message: '' }))).toBeNull()
+    })
+  })
+
+  describe('system events', () => {
+    test('model_reroute', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('model_reroute', {
+        from_model: 'gpt-4o',
+        to_model: 'gpt-5.3-codex',
+      }))
+      expect(r!.entryType).toBe('system-message')
+      expect(r!.content).toBe('Model rerouted from gpt-4o to gpt-5.3-codex')
+    })
+
+    test('token_count', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('token_count', {
+        info: {
+          last_token_usage: { total_tokens: 5000 },
+          model_context_window: 128000,
+        },
+      }))
+      expect(r!.entryType).toBe('token-usage')
+      expect(r!.metadata?.totalTokens).toBe(5000)
+      expect(r!.metadata?.contextWindow).toBe(128000)
+    })
+
+    test('context_compacted', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('context_compacted'))
+      expect(r!.content).toBe('Context compacted')
+    })
+
+    test('session_configured', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('session_configured', {
+        model: 'gpt-5.3-codex',
+        session_id: 'sess-123',
+      }))
+      expect(r!.content).toBe('model: gpt-5.3-codex')
+      expect(r!.metadata?.sessionId).toBe('sess-123')
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Skipped events
+  // ------------------------------------------------------------------
+  describe('skipped events', () => {
+    const skipTypes = [
+      'mcp_startup_update',
+      'mcp_startup_complete',
+      'user_message',
+      'turn_diff',
+      'turn_complete',
+      'shutdown_complete',
+      'turn_aborted',
+    ]
+    for (const type of skipTypes) {
+      test(`${type} returns null`, () => {
+        const n = new CodexLogNormalizer()
+        expect(n.parse(codexEvent(type))).toBeNull()
+      })
+    }
+  })
+
+  // ------------------------------------------------------------------
+  // Streaming state reset on tool use
+  // ------------------------------------------------------------------
+  describe('streaming state management', () => {
+    test('exec_command_begin resets accumulated assistant text', () => {
+      const n = new CodexLogNormalizer()
+      n.parse(codexEvent('agent_message_delta', { delta: 'partial text' }))
+      n.parse(codexEvent('exec_command_begin', { command: ['ls'] }))
+      // Next delta should start fresh
+      const r = n.parse(codexEvent('agent_message_delta', { delta: 'New' }))
+      expect(r!.content).toBe('New')
+    })
+
+    test('agent_reasoning_section_break resets all state', () => {
+      const n = new CodexLogNormalizer()
+      n.parse(codexEvent('agent_reasoning_delta', { delta: 'thinking' }))
+      n.parse(codexEvent('agent_reasoning_section_break'))
+      const r = n.parse(codexEvent('agent_reasoning_delta', { delta: 'fresh' }))
+      expect(r!.content).toBe('fresh')
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // JSON-RPC response handling (session configured)
+  // ------------------------------------------------------------------
+  describe('JSON-RPC response handling', () => {
+    test('thread/start response with model emits session_configured', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(JSON.stringify({
+        id: 1,
+        result: { thread: { id: 'thr-1' }, model: 'gpt-5.3-codex' },
+      }))
+      expect(r!.entryType).toBe('system-message')
+      expect(r!.content).toBe('model: gpt-5.3-codex')
+    })
+
+    test('response without thread returns null', () => {
+      const n = new CodexLogNormalizer()
+      expect(n.parse(JSON.stringify({ id: 1, result: {} }))).toBeNull()
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Plan events
+  // ------------------------------------------------------------------
+  describe('plan events', () => {
+    test('plan_delta accumulates plan text', () => {
+      const n = new CodexLogNormalizer()
+      const r1 = n.parse(codexEvent('plan_delta', { delta: 'Step 1: ' }))
+      expect(r1!.content).toBe('Step 1: ')
+      expect(r1!.metadata?.isPlan).toBe(true)
+
+      const r2 = n.parse(codexEvent('plan_delta', { delta: 'do something' }))
+      expect(r2!.content).toBe('Step 1: do something')
+    })
+
+    test('plan_update with steps', () => {
+      const n = new CodexLogNormalizer()
+      const r = n.parse(codexEvent('plan_update', {
+        plan: [
+          { step: 'Read file', status: 'done' },
+          { step: 'Edit file', status: 'pending' },
+        ],
+        explanation: 'Updated plan',
+      }))
+      expect(r!.entryType).toBe('system-message')
+      expect(r!.content).toBe('Updated plan')
     })
   })
 })

--- a/apps/api/test/codex-protocol.test.ts
+++ b/apps/api/test/codex-protocol.test.ts
@@ -95,8 +95,8 @@ describe('CodexProtocolHandler', () => {
       JSON.stringify({ id: req.id, result: { thread: { id: 'thread-abc' } } }),
     )
 
-    const threadId = await threadPromise
-    expect(threadId).toBe('thread-abc')
+    const result = await threadPromise
+    expect(result.threadId).toBe('thread-abc')
     expect(handler.threadId).toBe('thread-abc')
 
     handler.close()
@@ -436,6 +436,244 @@ describe('CodexProtocolHandler', () => {
       }),
     )
     await tick()
+
+    handler.close()
+    stdout.close()
+  })
+
+  // ------------------------------------------------------------------
+  // New protocol features: forkThread, getAccount, toolRequestUserInput
+  // ------------------------------------------------------------------
+
+  test('forkThread sends thread/fork with threadId and returns new threadId', async () => {
+    const { sink, written } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const forkPromise = handler.forkThread({
+      threadId: 'original-thread',
+      model: 'gpt-5.3',
+      sandbox: 'danger-full-access',
+    })
+    await tick()
+
+    const req = JSON.parse(written[0]!)
+    expect(req.method).toBe('thread/fork')
+    expect(req.params.threadId).toBe('original-thread')
+    expect(req.params.model).toBe('gpt-5.3')
+    expect(req.params.sandbox).toBe('danger-full-access')
+
+    stdout.push(
+      JSON.stringify({
+        id: req.id,
+        result: { thread: { id: 'forked-thread' }, model: 'gpt-5.3' },
+      }),
+    )
+
+    const result = await forkPromise
+    expect(result.threadId).toBe('forked-thread')
+    expect(result.model).toBe('gpt-5.3')
+    expect(handler.threadId).toBe('forked-thread')
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('forkThread throws when thread.id is missing', async () => {
+    const { sink } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const forkPromise = handler.forkThread({ threadId: 'orig' })
+    await tick()
+
+    stdout.push(JSON.stringify({ id: 1, result: {} }))
+
+    await expect(forkPromise).rejects.toThrow(
+      'thread/fork response missing thread.id',
+    )
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('getAccount sends account/read and returns auth status', async () => {
+    const { sink, written } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const accountPromise = handler.getAccount()
+    await tick()
+
+    const req = JSON.parse(written[0]!)
+    expect(req.method).toBe('account/read')
+    expect(req.params.refreshToken).toBe(false)
+
+    stdout.push(
+      JSON.stringify({
+        id: req.id,
+        result: { requiresOpenaiAuth: false, account: { name: 'test' } },
+      }),
+    )
+
+    const account = await accountPromise
+    expect(account.requiresOpenaiAuth).toBe(false)
+    expect(account.account).toEqual({ name: 'test' })
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('getAccount handles snake_case response', async () => {
+    const { sink } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const accountPromise = handler.getAccount()
+    await tick()
+
+    stdout.push(
+      JSON.stringify({
+        id: 1,
+        result: { requires_openai_auth: true, account: null },
+      }),
+    )
+
+    const account = await accountPromise
+    expect(account.requiresOpenaiAuth).toBe(true)
+    expect(account.account).toBeNull()
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('auto-approves toolRequestUserInput', async () => {
+    const { sink, written } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+    await tick()
+
+    stdout.push(
+      JSON.stringify({
+        id: 300,
+        method: 'toolRequestUserInput',
+        params: { prompt: 'Enter value' },
+      }),
+    )
+    await tick()
+
+    const approvalResp = written.find((w) => {
+      try {
+        const p = JSON.parse(w)
+        return p.id === 300 && p.result?.decision === 'accept'
+      } catch {
+        return false
+      }
+    })
+    expect(approvalResp).toBeTruthy()
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('startThread returns model from response', async () => {
+    const { sink, written } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const threadPromise = handler.startThread({
+      model: 'gpt-5.3-codex',
+      sandbox: 'danger-full-access',
+      approvalPolicy: 'never',
+    })
+    await tick()
+
+    const req = JSON.parse(written[0]!)
+    expect(req.params.sandbox).toBe('danger-full-access')
+    expect(req.params.approvalPolicy).toBe('never')
+
+    stdout.push(
+      JSON.stringify({
+        id: req.id,
+        result: { thread: { id: 'thr-new' }, model: 'gpt-5.3-codex' },
+      }),
+    )
+
+    const result = await threadPromise
+    expect(result.threadId).toBe('thr-new')
+    expect(result.model).toBe('gpt-5.3-codex')
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('thread/started notification sets threadId if not already set', async () => {
+    const { sink } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+    const reader = handler.notifications.getReader()
+
+    await tick()
+    expect(handler.threadId).toBeUndefined()
+
+    stdout.push(
+      JSON.stringify({
+        method: 'thread/started',
+        params: { thread: { id: 'notif-thread' } },
+      }),
+    )
+    await tick()
+    await reader.read()
+
+    expect(handler.threadId).toBe('notif-thread')
+
+    reader.releaseLock()
+    handler.close()
+    stdout.close()
+  })
+
+  test('interrupt sends turn/interrupt request', async () => {
+    const { sink, written } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const interruptPromise = handler.interrupt('thr-1', 'turn-1')
+    await tick()
+
+    const req = JSON.parse(written[0]!)
+    expect(req.method).toBe('turn/interrupt')
+    expect(req.params.threadId).toBe('thr-1')
+    expect(req.params.turnId).toBe('turn-1')
+
+    stdout.push(JSON.stringify({ id: req.id, result: {} }))
+    await interruptPromise
+
+    handler.close()
+    stdout.close()
+  })
+
+  test('initialize sends experimental_api capability', async () => {
+    const { sink, written } = createMockStdin()
+    const stdout = createMockStdout()
+
+    const handler = new CodexProtocolHandler(sink, stdout.stream, 5000)
+
+    const initPromise = handler.initialize()
+    await tick()
+
+    const req = JSON.parse(written[0]!)
+    expect(req.params.capabilities.experimental_api).toBe(true)
+
+    stdout.push(JSON.stringify({ id: 1, result: { userAgent: 'codex/2.0' } }))
+    await initPromise
 
     handler.close()
     stdout.close()


### PR DESCRIPTION
## Summary

- Register `/compact`, `/status`, `/mcp` as discoverable slash commands for the Codex engine
- Commands are stored in DB during startup probe and served to the frontend via the `/slash-commands` API
- Commands are passed through as regular prompts — the Codex agent handles `/compact` natively

## Test plan

- [ ] Verify Codex slash commands appear in the frontend command menu
- [ ] Test `/compact` on an active Codex session
- [ ] Verify existing Claude Code slash commands are unaffected