### PR TITLE
fix: sync promoted pending messages to frontend

### DIFF
--- a/apps/api/src/db/pending-messages.ts
+++ b/apps/api/src/db/pending-messages.ts
@@ -1,3 +1,4 @@
+import type { NormalizedLogEntry } from '@bitk/shared'
 import { resolve } from 'node:path'
 import { and, asc, eq, inArray, isNotNull } from 'drizzle-orm'
 import { UPLOAD_DIR } from '@/uploads'
@@ -51,14 +52,26 @@ export async function markPendingMessagesDispatched(ids: string[]) {
  * persist a new user-message entry for the same content (skipPersistMessage),
  * avoiding duplicate messages in the frontend.
  */
-export async function promotePendingMessages(ids: string[]) {
-  if (ids.length === 0) return
+export async function promotePendingMessages(
+  ids: string[],
+): Promise<NormalizedLogEntry[]> {
+  if (ids.length === 0) return []
   // Batch update in a single transaction to avoid N+1
-  await db.transaction(async (tx) => {
+  return db.transaction(async (tx) => {
     const rows = await tx
-      .select({ id: issueLogs.id, metadata: issueLogs.metadata })
+      .select({
+        id: issueLogs.id,
+        turnIndex: issueLogs.turnIndex,
+        entryIndex: issueLogs.entryIndex,
+        content: issueLogs.content,
+        metadata: issueLogs.metadata,
+        replyToMessageId: issueLogs.replyToMessageId,
+        timestamp: issueLogs.timestamp,
+      })
       .from(issueLogs)
       .where(inArray(issueLogs.id, ids))
+      .orderBy(asc(issueLogs.turnIndex), asc(issueLogs.entryIndex))
+    const updatedEntries: NormalizedLogEntry[] = []
     for (const row of rows) {
       let meta: Record<string, unknown> = {}
       try {
@@ -73,7 +86,19 @@ export async function promotePendingMessages(ids: string[]) {
           metadata: Object.keys(rest).length > 0 ? JSON.stringify(rest) : null,
         })
         .where(eq(issueLogs.id, row.id))
+      updatedEntries.push({
+        messageId: row.id,
+        entryType: 'user-message',
+        content: row.content,
+        turnIndex: row.turnIndex,
+        timestamp: row.timestamp ?? undefined,
+        ...(row.replyToMessageId
+          ? { replyToMessageId: row.replyToMessageId }
+          : {}),
+        ...(Object.keys(rest).length > 0 ? { metadata: rest } : {}),
+      })
     }
+    return updatedEntries
   })
 }
 

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -9,6 +9,7 @@ import {
 } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled, emitStateChange } from '@/engines/issue/events'
+import { emitIssueLogUpdated } from '@/events/issue-events'
 import { dispatch } from '@/engines/issue/state'
 import type { ManagedProcess } from '@/engines/issue/types'
 import { sendInputToRunningProcess } from '@/engines/issue/user-message'
@@ -106,12 +107,18 @@ export function handleTurnCompleted(
           // (caught below), rows stay pending so the next retry consumes them.
           // Promote itself is best-effort: the follow-up is already running,
           // so a failure here must NOT cause a duplicate dispatch on next turn.
-          await promotePendingMessages(pendingIds).catch((promoteErr) => {
-            logger.error(
-              { issueId, err: promoteErr },
-              'promote_pending_after_followup_failed',
-            )
-          })
+          await promotePendingMessages(pendingIds)
+            .then((entries) => {
+              for (const entry of entries) {
+                emitIssueLogUpdated(issueId, entry)
+              }
+            })
+            .catch((promoteErr) => {
+              logger.error(
+                { issueId, err: promoteErr },
+                'promote_pending_after_followup_failed',
+              )
+            })
           return
         } catch (flushErr) {
           logger.error({ issueId, err: flushErr }, 'auto_flush_pending_failed')

--- a/apps/api/src/events/issue-events.ts
+++ b/apps/api/src/events/issue-events.ts
@@ -1,3 +1,4 @@
+import type { NormalizedLogEntry } from '@bitk/shared'
 import { appEvents } from './index'
 
 export function emitIssueUpdated(
@@ -5,4 +6,11 @@ export function emitIssueUpdated(
   changes: Record<string, unknown>,
 ): void {
   appEvents.emit('issue-updated', { issueId, changes })
+}
+
+export function emitIssueLogUpdated(
+  issueId: string,
+  entry: NormalizedLogEntry,
+): void {
+  appEvents.emit('log-updated', { issueId, entry })
 }

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -52,6 +52,11 @@ events.get('/', async (c) => {
         { order: 100 },
       )
 
+      const unsubLogUpdated = appEvents.on('log-updated', (data) => {
+        if (!isVisibleForMode(data.entry, getIssueDevMode(data.issueId))) return
+        writeEvent('log-updated', data)
+      })
+
       // Non-terminal state changes
       const unsubState = appEvents.on('state', (data) => {
         if (TERMINAL.has(data.state)) return // handled by 'done' below
@@ -97,6 +102,7 @@ events.get('/', async (c) => {
       } finally {
         clearInterval(heartbeat)
         unsubLog()
+        unsubLogUpdated()
         unsubState()
         unsubDone()
         unsubIssueUpdated()

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -14,7 +14,7 @@ import {
 import { issues as issuesTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
 import type { EngineType } from '@/engines/types'
-import { emitIssueUpdated } from '@/events/issue-events'
+import { emitIssueLogUpdated, emitIssueUpdated } from '@/events/issue-events'
 import { logger } from '@/logger'
 import { toISO } from '@/utils/date'
 
@@ -199,12 +199,18 @@ export function flushPendingAsFollowUp(
       // by outer catch), rows stay pending for retry. Promote itself is
       // best-effort: the follow-up is already running, so a failure here
       // must NOT cause a duplicate dispatch.
-      await promotePendingMessages(pendingIds).catch((promoteErr) => {
-        logger.error(
-          { issueId, err: promoteErr },
-          'promote_pending_after_followup_failed',
-        )
-      })
+      await promotePendingMessages(pendingIds)
+        .then((entries) => {
+          for (const entry of entries) {
+            emitIssueLogUpdated(issueId, entry)
+          }
+        })
+        .catch((promoteErr) => {
+          logger.error(
+            { issueId, err: promoteErr },
+            'promote_pending_after_followup_failed',
+          )
+        })
       logger.debug(
         { issueId, pendingCount: pendingIds.length },
         'pending_flushed_as_followup',

--- a/apps/api/test/pending-messages-unit.test.ts
+++ b/apps/api/test/pending-messages-unit.test.ts
@@ -1,10 +1,12 @@
 import { beforeAll, describe, expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
 import { db } from '@/db'
 import {
   issueLogs,
   issues as issuesTable,
   projects as projectsTable,
 } from '@/db/schema'
+import { promotePendingMessages } from '@/db/pending-messages'
 // We import the shared helpers directly
 import {
   getPendingMessages,
@@ -309,5 +311,46 @@ describe('Pending message lifecycle', () => {
             .filter(Boolean)
             .join('\n\n')
     expect(merged).toBe('just the base')
+  })
+})
+
+describe('promotePendingMessages', () => {
+  test('returns updated entries and removes pending metadata while preserving other fields', async () => {
+    const issue = await createTestIssue()
+    await db.insert(issueLogs).values({
+      issueId: issue.id,
+      turnIndex: 2,
+      entryIndex: Date.now(),
+      entryType: 'user-message',
+      content: 'promote me',
+      metadata: JSON.stringify({
+        type: 'pending',
+        attachments: [{ id: 'att-1', name: 'spec.txt', size: 12 }],
+      }),
+      timestamp: new Date().toISOString(),
+    })
+
+    const pending = await getPendingMessages(issue.id)
+    expect(pending.length).toBe(1)
+
+    const updated = await promotePendingMessages([pending[0]!.id])
+    expect(updated).toHaveLength(1)
+    expect(updated[0]!.messageId).toBe(pending[0]!.id)
+    expect(updated[0]!.metadata?.type).toBeUndefined()
+    expect(updated[0]!.metadata?.attachments).toEqual([
+      { id: 'att-1', name: 'spec.txt', size: 12 },
+    ])
+
+    const pendingAfter = await getPendingMessages(issue.id)
+    expect(pendingAfter).toHaveLength(0)
+
+    const [row] = await db
+      .select({ metadata: issueLogs.metadata })
+      .from(issueLogs)
+      .where(eq(issueLogs.id, pending[0]!.id))
+    expect(row).toBeTruthy()
+    expect(JSON.parse(row!.metadata!)).toEqual({
+      attachments: [{ id: 'att-1', name: 'spec.txt', size: 12 }],
+    })
   })
 })

--- a/apps/frontend/src/__tests__/hooks/use-issue-stream.test.tsx
+++ b/apps/frontend/src/__tests__/hooks/use-issue-stream.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IssueEventHandler } from '@/lib/event-bus'
+import type { NormalizedLogEntry } from '@/types/kanban'
+import { useIssueStream } from '@/hooks/use-issue-stream'
+
+const subscribeMock = vi.fn()
+const getIssueLogsMock = vi.fn()
+
+vi.mock('@/lib/event-bus', () => ({
+  eventBus: {
+    subscribe: (...args: unknown[]) => subscribeMock(...args),
+  },
+}))
+
+vi.mock('@/lib/kanban-api', () => ({
+  kanbanApi: {
+    getIssueLogs: (...args: unknown[]) => getIssueLogsMock(...args),
+  },
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useIssueStream', () => {
+  beforeEach(() => {
+    subscribeMock.mockReset()
+    getIssueLogsMock.mockReset()
+  })
+
+  it('replaces an existing pending message when log-updated arrives', async () => {
+    let handler: IssueEventHandler | null = null
+    subscribeMock.mockImplementation(
+      (_issueId: string, nextHandler: IssueEventHandler) => {
+        handler = nextHandler
+        return () => {}
+      },
+    )
+
+    const pendingEntry: NormalizedLogEntry = {
+      messageId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      entryType: 'user-message',
+      content: 'queued follow-up',
+      timestamp: new Date().toISOString(),
+      metadata: { type: 'pending' },
+    }
+
+    getIssueLogsMock.mockResolvedValue({
+      issue: null,
+      logs: [pendingEntry],
+      nextCursor: null,
+      hasMore: false,
+    })
+
+    const { result } = renderHook(
+      () =>
+        useIssueStream({
+          projectId: 'proj-1',
+          issueId: 'issue-1',
+          sessionStatus: 'running',
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1)
+    })
+    expect(result.current.logs[0]?.metadata?.type).toBe('pending')
+
+    act(() => {
+      handler?.onLogUpdated({
+        ...pendingEntry,
+        metadata: undefined,
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.logs[0]?.metadata?.type).toBeUndefined()
+    })
+  })
+})

--- a/apps/frontend/src/__tests__/hooks/use-issue-stream.test.tsx
+++ b/apps/frontend/src/__tests__/hooks/use-issue-stream.test.tsx
@@ -37,6 +37,16 @@ function createWrapper() {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 describe('useIssueStream', () => {
   beforeEach(() => {
     subscribeMock.mockReset()
@@ -92,6 +102,69 @@ describe('useIssueStream', () => {
     })
 
     await waitFor(() => {
+      expect(result.current.logs[0]?.metadata?.type).toBeUndefined()
+    })
+  })
+
+  it('prefers the SSE-updated entry over a stale initial snapshot with the same messageId', async () => {
+    let handler: IssueEventHandler | null = null
+    subscribeMock.mockImplementation(
+      (_issueId: string, nextHandler: IssueEventHandler) => {
+        handler = nextHandler
+        return () => {}
+      },
+    )
+
+    const initialFetch = deferred<{
+      issue: null
+      logs: NormalizedLogEntry[]
+      nextCursor: null
+      hasMore: boolean
+    }>()
+
+    getIssueLogsMock.mockReturnValue(initialFetch.promise)
+
+    const pendingEntry: NormalizedLogEntry = {
+      messageId: '01ARZ3NDEKTSV4RRFFQ69G5FAA',
+      entryType: 'user-message',
+      content: 'queued follow-up',
+      timestamp: new Date().toISOString(),
+      metadata: { type: 'pending' },
+    }
+
+    const { result } = renderHook(
+      () =>
+        useIssueStream({
+          projectId: 'proj-1',
+          issueId: 'issue-1',
+          sessionStatus: 'running',
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    )
+
+    act(() => {
+      handler?.onLogUpdated({
+        ...pendingEntry,
+        metadata: undefined,
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1)
+      expect(result.current.logs[0]?.metadata?.type).toBeUndefined()
+    })
+
+    initialFetch.resolve({
+      issue: null,
+      logs: [pendingEntry],
+      nextCursor: null,
+      hasMore: false,
+    })
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1)
       expect(result.current.logs[0]?.metadata?.type).toBeUndefined()
     })
   })

--- a/apps/frontend/src/hooks/use-issue-stream.ts
+++ b/apps/frontend/src/hooks/use-issue-stream.ts
@@ -60,6 +60,33 @@ function compareByMessageId(
   return 0
 }
 
+function mergeLogsPreferLive(
+  snapshotLogs: NormalizedLogEntry[],
+  liveLogs: NormalizedLogEntry[],
+): NormalizedLogEntry[] {
+  if (liveLogs.length === 0) return snapshotLogs
+
+  const liveById = new Map(
+    liveLogs
+      .filter((entry) => entry.messageId)
+      .map((entry) => [entry.messageId!, entry]),
+  )
+
+  const mergedSnapshot = snapshotLogs.map((entry) => {
+    if (!entry.messageId) return entry
+    return liveById.get(entry.messageId) ?? entry
+  })
+
+  const snapshotIds = new Set(
+    snapshotLogs.map((entry) => entry.messageId).filter(Boolean),
+  )
+  const liveOnly = liveLogs.filter(
+    (entry) => entry.messageId && !snapshotIds.has(entry.messageId),
+  )
+
+  return [...mergedSnapshot, ...liveOnly].sort(compareByMessageId)
+}
+
 export function useIssueStream({
   projectId,
   issueId,
@@ -318,22 +345,10 @@ export function useIssueStream({
             return data.logs
           }
 
-          // Collect SSE-only entries (arrived before HTTP response, not in DB snapshot)
-          const dbIds = new Set(
-            data.logs.map((e) => e.messageId).filter(Boolean),
-          )
-          const sseOnly = prev.filter(
-            (e) => e.messageId && !dbIds.has(e.messageId),
-          )
-
-          if (sseOnly.length === 0) {
-            // All SSE entries are already in the DB snapshot
-            liveLogsRef.current = data.logs
-            return data.logs
-          }
-
-          // Merge + sort by ULID to ensure correct chronological order
-          const next = [...data.logs, ...sseOnly].sort(compareByMessageId)
+          // Prefer any in-memory SSE-updated entry when the same messageId is
+          // also present in the DB snapshot. This prevents a stale initial
+          // fetch from overwriting a newer log-updated event that arrived first.
+          const next = mergeLogsPreferLive(data.logs, prev)
           liveLogsRef.current = next
           return next
         })

--- a/apps/frontend/src/hooks/use-issue-stream.ts
+++ b/apps/frontend/src/hooks/use-issue-stream.ts
@@ -82,6 +82,8 @@ export function useIssueStream({
   const activeExecutionRef = useRef<string | null>(null)
   const streamScopeRef = useRef<string | null>(null)
   const olderCursorRef = useRef<string | null>(null)
+  const liveLogsRef = useRef<NormalizedLogEntry[]>([])
+  const olderLogsRef = useRef<NormalizedLogEntry[]>([])
 
   // ---- MessageId-based dedup tracking ----
   // O(1) lookup instead of scanning the entire array on every append.
@@ -113,6 +115,8 @@ export function useIssueStream({
   }, [olderLogs, liveLogs])
 
   const clearLogs = useCallback(() => {
+    liveLogsRef.current = []
+    olderLogsRef.current = []
     setLiveLogs([])
     setOlderLogs([])
     setHasOlderLogs(false)
@@ -149,13 +153,54 @@ export function useIssueStream({
         const next = [...prev, incoming]
         if (next.length > MAX_LIVE_LOGS) {
           const trimmed = next.slice(next.length - MAX_LIVE_LOGS)
+          liveLogsRef.current = trimmed
           setHasOlderLogs(true)
           return trimmed
         }
+        liveLogsRef.current = next
         return next
       })
     },
     [isSeen, markSeen],
+  )
+
+  /** Replace an existing entry by messageId; append if the entry is not present yet. */
+  const upsertEntry = useCallback(
+    (incoming: NormalizedLogEntry) => {
+      if (!incoming.messageId) {
+        appendEntry(incoming)
+        return
+      }
+
+      if (
+        olderLogsRef.current.some((entry) => entry.messageId === incoming.messageId)
+      ) {
+        setOlderLogs((prev) => {
+          const next = prev.map((entry) =>
+            entry.messageId === incoming.messageId ? incoming : entry,
+          )
+          olderLogsRef.current = next
+          return next
+        })
+        return
+      }
+
+      if (
+        liveLogsRef.current.some((entry) => entry.messageId === incoming.messageId)
+      ) {
+        setLiveLogs((prev) => {
+          const next = prev.map((entry) =>
+            entry.messageId === incoming.messageId ? incoming : entry,
+          )
+          liveLogsRef.current = next
+          return next
+        })
+        return
+      }
+
+      appendEntry(incoming)
+    },
+    [appendEntry],
   )
 
   /** Append a user message with a server-assigned messageId */
@@ -206,7 +251,9 @@ export function useIssueStream({
             if (e.messageId) seenIdsRef.current.add(e.messageId)
             return true
           })
-          return [...newEntries, ...prev].sort(compareByMessageId)
+          const next = [...newEntries, ...prev].sort(compareByMessageId)
+          olderLogsRef.current = next
+          return next
         })
       })
       .catch((err) => {
@@ -267,6 +314,7 @@ export function useIssueStream({
 
           if (prev.length === 0) {
             // Fast path: no SSE entries arrived yet, just use the DB snapshot
+            liveLogsRef.current = data.logs
             return data.logs
           }
 
@@ -280,13 +328,17 @@ export function useIssueStream({
 
           if (sseOnly.length === 0) {
             // All SSE entries are already in the DB snapshot
+            liveLogsRef.current = data.logs
             return data.logs
           }
 
           // Merge + sort by ULID to ensure correct chronological order
-          return [...data.logs, ...sseOnly].sort(compareByMessageId)
+          const next = [...data.logs, ...sseOnly].sort(compareByMessageId)
+          liveLogsRef.current = next
+          return next
         })
 
+        olderLogsRef.current = []
         setOlderLogs([])
         setHasOlderLogs(data.hasMore)
         olderCursorRef.current = data.nextCursor
@@ -317,6 +369,9 @@ export function useIssueStream({
       onLog: (entry) => {
         if (doneReceivedRef.current) return
         appendEntry(entry)
+      },
+      onLogUpdated: (entry) => {
+        upsertEntry(entry)
       },
       onState: (data) => {
         if (data.state === 'running' || data.state === 'pending') {
@@ -357,7 +412,7 @@ export function useIssueStream({
     return () => {
       cleanup.unsub()
     }
-  }, [projectId, issueId, enabled, queryClient, appendEntry])
+  }, [projectId, issueId, enabled, queryClient, appendEntry, upsertEntry])
 
   return {
     logs,

--- a/apps/frontend/src/lib/event-bus.ts
+++ b/apps/frontend/src/lib/event-bus.ts
@@ -3,6 +3,7 @@ import type { NormalizedLogEntry, SessionStatus } from '@/types/kanban'
 
 export interface IssueEventHandler {
   onLog: (entry: NormalizedLogEntry) => void
+  onLogUpdated: (entry: NormalizedLogEntry) => void
   onState: (data: { executionId: string; state: SessionStatus }) => void
   onDone: (data: { finalStatus: SessionStatus }) => void
 }
@@ -58,6 +59,19 @@ class EventBus {
           entry: NormalizedLogEntry
         }
         this.dispatch(data.issueId, (h) => h.onLog(data.entry))
+        this.notifyActivity(data.issueId)
+      } catch {
+        /* ignore parse errors */
+      }
+    })
+
+    es.addEventListener('log-updated', (e) => {
+      try {
+        const data = JSON.parse(e.data) as {
+          issueId: string
+          entry: NormalizedLogEntry
+        }
+        this.dispatch(data.issueId, (h) => h.onLogUpdated(data.entry))
         this.notifyActivity(data.issueId)
       } catch {
         /* ignore parse errors */

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2026-03-06 19:50 [progress]
+根据 PR review 继续修复 `useIssueStream` 的竞态：当 `log-updated` 在首个 `getIssueLogs()` 返回前到达时，初始日志快照合并现在会优先保留内存中的 SSE 更新版本，不再用陈旧的 pending 元数据覆盖本地状态。新增前端 hook 回归测试覆盖该时序，验证通过。
+
 ## 2026-03-06 19:42 [progress]
 修复 pending 消息被后端消费后前端仍停留在 queued 状态的问题：新增 `log-updated` 事件，后端在 promote pending user-message 后主动广播更新，前端 `useIssueStream` 按 `messageId` 就地 upsert 已有日志项。新增前后端聚焦测试。排查过程中确认后端测试失败并非 `drizzle-orm` 版本问题，而是当前 worktree 的安装产物残缺；定向重装依赖后恢复，`bun test apps/api/test/pending-messages-unit.test.ts` 与前端 hook 测试均通过。
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2026-03-06 19:42 [progress]
+修复 pending 消息被后端消费后前端仍停留在 queued 状态的问题：新增 `log-updated` 事件，后端在 promote pending user-message 后主动广播更新，前端 `useIssueStream` 按 `messageId` 就地 upsert 已有日志项。新增前后端聚焦测试。排查过程中确认后端测试失败并非 `drizzle-orm` 版本问题，而是当前 worktree 的安装产物残缺；定向重装依赖后恢复，`bun test apps/api/test/pending-messages-unit.test.ts` 与前端 hook 测试均通过。
+
 ## 2026-03-04 20:42 [progress]
 启动修复工作并完成二轮修复：1) 修复 `handleTurnCompleted` 自动 flush pending 路径中“先 promote 再 follow-up”导致失败后 pending 语义丢失的问题（改为 follow-up 成功后再 promote）；2) 加固 `withIssueLock` 获取超时分支的 `lockDepth` 清理；3) 新增 `turn-completion-regression.test.ts` 覆盖 auto-flush 失败时 pending 可重试；4) 修复 `followup-reconciliation` 中顺序敏感断言导致的 flaky。回归结果：全仓 `bun run test` 通过，`@bitk/api` 278 pass / 0 fail。
 

--- a/docs/plan/PLAN-011.md
+++ b/docs/plan/PLAN-011.md
@@ -1,10 +1,10 @@
 # PLAN-011 Pending 消息消费后的前后端同步修复
 
-- status: implementing
+- status: completed
 - task: BUG-091
 - owner: codex
 - createdAt: 2026-03-06 19:15 UTC
-- updatedAt: 2026-03-06 19:31 UTC
+- updatedAt: 2026-03-06 19:42 UTC
 
 ## Context
 当前 pending 消息在后端被消费时，会走 `followUpIssue(..., { skipPersistMessage: true })`，随后通过 `promotePendingMessages()` 将原有日志行从 `metadata.type='pending'` 提升为普通 user-message。前端 `useIssueStream()` 是 append-only，并按 `messageId` 去重，无法把同一条消息 ID 的本地 pending 项就地覆盖，因此 UI 会一直显示 pending，直到页面刷新后重新拉取日志快照。
@@ -16,7 +16,8 @@
 - 共享事件类型扩展后，前后端事件名和载荷必须保持完全一致，否则会出现静默丢事件。
 - 前端本地 upsert 需要避免破坏现有 `seenIdsRef` / 排序 / 去重逻辑。
 - 后端 promote 是批量 best-effort 路径，发事件时要基于最终写入成功的内容，避免前端与 DB 再次分叉。
-- 已完成 `bun install`，前端聚焦测试通过；后端聚焦测试仍被 `drizzle-orm` 安装产物异常阻塞，需先修复依赖包缺失的 `column-builder.js` 再补跑。
+- 已完成 `bun install`，前后端聚焦测试均通过。
+- 后端测试阻塞的真实原因是当前 worktree 的 `drizzle-orm` 安装产物残缺，而非版本本身有问题；定向重装该包后问题消失。
 
 ## Scope
 - 扩展共享 SSE/App event 类型与后端事件辅助函数

--- a/docs/plan/PLAN-011.md
+++ b/docs/plan/PLAN-011.md
@@ -4,7 +4,7 @@
 - task: BUG-091
 - owner: codex
 - createdAt: 2026-03-06 19:15 UTC
-- updatedAt: 2026-03-06 19:42 UTC
+- updatedAt: 2026-03-06 19:50 UTC
 
 ## Context
 当前 pending 消息在后端被消费时，会走 `followUpIssue(..., { skipPersistMessage: true })`，随后通过 `promotePendingMessages()` 将原有日志行从 `metadata.type='pending'` 提升为普通 user-message。前端 `useIssueStream()` 是 append-only，并按 `messageId` 去重，无法把同一条消息 ID 的本地 pending 项就地覆盖，因此 UI 会一直显示 pending，直到页面刷新后重新拉取日志快照。
@@ -18,6 +18,7 @@
 - 后端 promote 是批量 best-effort 路径，发事件时要基于最终写入成功的内容，避免前端与 DB 再次分叉。
 - 已完成 `bun install`，前后端聚焦测试均通过。
 - 后端测试阻塞的真实原因是当前 worktree 的 `drizzle-orm` 安装产物残缺，而非版本本身有问题；定向重装该包后问题消失。
+- 已处理 review 指出的首帧快照与 `log-updated` 事件竞态，新增测试覆盖“先收到 SSE 更新、后收到陈旧快照”的场景。
 
 ## Scope
 - 扩展共享 SSE/App event 类型与后端事件辅助函数

--- a/docs/plan/PLAN-011.md
+++ b/docs/plan/PLAN-011.md
@@ -1,0 +1,29 @@
+# PLAN-011 Pending 消息消费后的前后端同步修复
+
+- status: implementing
+- task: BUG-091
+- owner: codex
+- createdAt: 2026-03-06 19:15 UTC
+- updatedAt: 2026-03-06 19:31 UTC
+
+## Context
+当前 pending 消息在后端被消费时，会走 `followUpIssue(..., { skipPersistMessage: true })`，随后通过 `promotePendingMessages()` 将原有日志行从 `metadata.type='pending'` 提升为普通 user-message。前端 `useIssueStream()` 是 append-only，并按 `messageId` 去重，无法把同一条消息 ID 的本地 pending 项就地覆盖，因此 UI 会一直显示 pending，直到页面刷新后重新拉取日志快照。
+
+## Proposal
+新增显式的“日志更新”事件：后端在 pending 消息被 promote 后按 messageId 发出更新事件，前端 SSE/EventBus 接收后，在 `useIssueStream()` 中按 `messageId` 对已有日志项做 upsert/replace，从而立即移除 pending 标记并保留既有顺序与去重语义。
+
+## Risks
+- 共享事件类型扩展后，前后端事件名和载荷必须保持完全一致，否则会出现静默丢事件。
+- 前端本地 upsert 需要避免破坏现有 `seenIdsRef` / 排序 / 去重逻辑。
+- 后端 promote 是批量 best-effort 路径，发事件时要基于最终写入成功的内容，避免前端与 DB 再次分叉。
+- 已完成 `bun install`，前端聚焦测试通过；后端聚焦测试仍被 `drizzle-orm` 安装产物异常阻塞，需先修复依赖包缺失的 `column-builder.js` 再补跑。
+
+## Scope
+- 扩展共享 SSE/App event 类型与后端事件辅助函数
+- 在 pending promote 路径发出日志更新事件
+- 在前端 EventBus 与 `useIssueStream()` 中消费并覆盖已有日志项
+- 补充针对 pending 转正同步的回归测试
+
+## Alternatives
+- 前端定向重拉日志：改动小，但仍有竞态窗口，且缺乏明确语义
+- 复用现有 `issue-updated`：可以承载额外字段，但事件职责会继续膨胀，不如单独 `log-updated` 清晰

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -1,8 +1,9 @@
 # Plan Index
 
-> Updated: 2026-03-04 20:42 UTC
+> Updated: 2026-03-06 19:31 UTC
 
 - [x] **PLAN-010 添加 Notes 笔记功能** - task: `FEAT-006` - owner: claude - file: `docs/plan/PLAN-010.md`
+- [-] **PLAN-011 Pending 消息消费后的前后端同步修复** - task: `BUG-091` - owner: codex - file: `docs/plan/PLAN-011.md`
 - [x] **PLAN-009 深度测试进程与状态编排并产出架构文档** - task: `TEST-003` - owner: codex - file: `docs/plan/PLAN-009.md`
 - [x] **PLAN-008 完善进程与状态管理回归测试** - task: `TEST-002` - owner: codex - file: `docs/plan/PLAN-008.md`
 - [x] **PLAN-007 审计后端进程与 Issue 状态管理** - task: `ENG-015` - owner: codex - file: `docs/plan/PLAN-007.md`

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -1,6 +1,6 @@
 # Plan Index
 
-> Updated: 2026-03-06 19:42 UTC
+> Updated: 2026-03-06 19:50 UTC
 
 - [x] **PLAN-010 添加 Notes 笔记功能** - task: `FEAT-006` - owner: claude - file: `docs/plan/PLAN-010.md`
 - [x] **PLAN-011 Pending 消息消费后的前后端同步修复** - task: `BUG-091` - owner: codex - file: `docs/plan/PLAN-011.md`

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -1,9 +1,9 @@
 # Plan Index
 
-> Updated: 2026-03-06 19:31 UTC
+> Updated: 2026-03-06 19:42 UTC
 
 - [x] **PLAN-010 添加 Notes 笔记功能** - task: `FEAT-006` - owner: claude - file: `docs/plan/PLAN-010.md`
-- [-] **PLAN-011 Pending 消息消费后的前后端同步修复** - task: `BUG-091` - owner: codex - file: `docs/plan/PLAN-011.md`
+- [x] **PLAN-011 Pending 消息消费后的前后端同步修复** - task: `BUG-091` - owner: codex - file: `docs/plan/PLAN-011.md`
 - [x] **PLAN-009 深度测试进程与状态编排并产出架构文档** - task: `TEST-003` - owner: codex - file: `docs/plan/PLAN-009.md`
 - [x] **PLAN-008 完善进程与状态管理回归测试** - task: `TEST-002` - owner: codex - file: `docs/plan/PLAN-008.md`
 - [x] **PLAN-007 审计后端进程与 Issue 状态管理** - task: `ENG-015` - owner: codex - file: `docs/plan/PLAN-007.md`

--- a/docs/task/BUG-091.md
+++ b/docs/task/BUG-091.md
@@ -1,0 +1,31 @@
+# BUG-091 调查 pending 消息消费后前端未即时感知
+
+- status: in_progress
+- priority: P0
+- owner: codex
+- createdAt: 2026-03-06 19:03 UTC
+- updatedAt: 2026-03-06 19:31 UTC
+
+## Summary
+调查消息流中 pending 消息在后端空闲时被发送给 engine 处理，但前端没有先收到对应状态变化/消息更新，导致 UI 仍停留在 pending 视图，只有刷新后才能看出该消息已被消费并开始处理。
+
+## Scope
+- 追踪 pending 消息从后端入队、flush、写库、发事件到前端订阅落地的完整链路
+- 确认缺失的是 DB 持久化、SSE 事件发送，还是前端缓存/状态同步
+- 输出可执行修复建议与风险说明
+
+## Acceptance Criteria
+- 明确指出问题发生的代码路径与根因
+- 给出修复方案，并说明会影响的后端/前端模块
+- 在未获 `proceed` 前不实施业务代码修改
+
+## Notes
+- 关联历史任务：`BUG-085`、`BUG-089`、`ENG-008`
+- 后端消费路径位于 `apps/api/src/engines/issue/lifecycle/turn-completion.ts` 与 `apps/api/src/routes/issues/_shared.ts`，都会走 `followUpIssue(..., { skipPersistMessage: true })` + `promotePendingMessages(...)`
+- 当前 `running` 状态 SSE 已正常发送；真正缺失的是“已有 pending 日志项被转正”的前端更新通道
+- 前端 `apps/frontend/src/hooks/use-issue-stream.ts` 目前是 append-only，并按 `messageId` 去重，无法用同一条消息 ID 覆盖本地 `pending` 元数据
+- 刷新页面后恢复正常，是因为重新拉取日志快照时读取到了 DB 中已被移除 `metadata.type='pending'` 的记录
+- 已按“前后端同步修改”方案实现 `log-updated` 事件链路，覆盖 shared types、后端 promote 广播、前端 EventBus、`useIssueStream` 本地 upsert 与回归测试
+- 已执行 `bun install`
+- 前端聚焦测试已通过：`bun --filter @bitk/frontend test -- run src/__tests__/hooks/use-issue-stream.test.tsx`
+- 后端聚焦测试仍阻塞于依赖产物异常：`bun test apps/api/test/pending-messages-unit.test.ts` 触发 `drizzle-orm/index.js` 引用缺失的 `./column-builder.js`

--- a/docs/task/BUG-091.md
+++ b/docs/task/BUG-091.md
@@ -4,7 +4,7 @@
 - priority: P0
 - owner: codex
 - createdAt: 2026-03-06 19:03 UTC
-- updatedAt: 2026-03-06 19:42 UTC
+- updatedAt: 2026-03-06 19:50 UTC
 
 ## Summary
 调查消息流中 pending 消息在后端空闲时被发送给 engine 处理，但前端没有先收到对应状态变化/消息更新，导致 UI 仍停留在 pending 视图，只有刷新后才能看出该消息已被消费并开始处理。
@@ -30,3 +30,4 @@
 - 前端聚焦测试已通过：`bun --filter @bitk/frontend test -- run src/__tests__/hooks/use-issue-stream.test.tsx`
 - 后端聚焦测试已通过：`bun test apps/api/test/pending-messages-unit.test.ts`
 - 最终根因不是 `drizzle-orm` 版本本身，而是当前 worktree 的 `node_modules/.bun/.../drizzle-orm` 安装产物残缺；定向删除该包并重新 `bun install` 后恢复正常
+- 根据 PR review 再次修正 `useIssueStream` 初始快照合并逻辑：当 `log-updated` 先于首个 `getIssueLogs()` 返回到达时，同一 `messageId` 冲突优先保留内存中的 SSE 更新版本，避免旧快照把 pending 状态写回 UI

--- a/docs/task/BUG-091.md
+++ b/docs/task/BUG-091.md
@@ -1,10 +1,10 @@
 # BUG-091 调查 pending 消息消费后前端未即时感知
 
-- status: in_progress
+- status: completed
 - priority: P0
 - owner: codex
 - createdAt: 2026-03-06 19:03 UTC
-- updatedAt: 2026-03-06 19:31 UTC
+- updatedAt: 2026-03-06 19:42 UTC
 
 ## Summary
 调查消息流中 pending 消息在后端空闲时被发送给 engine 处理，但前端没有先收到对应状态变化/消息更新，导致 UI 仍停留在 pending 视图，只有刷新后才能看出该消息已被消费并开始处理。
@@ -28,4 +28,5 @@
 - 已按“前后端同步修改”方案实现 `log-updated` 事件链路，覆盖 shared types、后端 promote 广播、前端 EventBus、`useIssueStream` 本地 upsert 与回归测试
 - 已执行 `bun install`
 - 前端聚焦测试已通过：`bun --filter @bitk/frontend test -- run src/__tests__/hooks/use-issue-stream.test.tsx`
-- 后端聚焦测试仍阻塞于依赖产物异常：`bun test apps/api/test/pending-messages-unit.test.ts` 触发 `drizzle-orm/index.js` 引用缺失的 `./column-builder.js`
+- 后端聚焦测试已通过：`bun test apps/api/test/pending-messages-unit.test.ts`
+- 最终根因不是 `drizzle-orm` 版本本身，而是当前 worktree 的 `node_modules/.bun/.../drizzle-orm` 安装产物残缺；定向删除该包并重新 `bun install` 后恢复正常

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -1,6 +1,6 @@
 # Task Index
 
-> Updated: 2026-03-06 19:42 UTC
+> Updated: 2026-03-06 19:50 UTC
 
 ## 待处理
 

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -1,12 +1,14 @@
 # Task Index
 
-> Updated: 2026-03-06 19:31 UTC
+> Updated: 2026-03-06 19:42 UTC
 
 ## 待处理
 
-- [-] **BUG-091 调查 pending 消息消费后前端未即时感知** `P0` - owner: codex - file: `docs/task/BUG-091.md`
+- [ ] （暂无）
 
 ## 已完成
+
+- [x] **BUG-091 调查 pending 消息消费后前端未即时感知** `P0` - owner: codex - file: `docs/task/BUG-091.md`
 
 - [x] **FEAT-006 添加 Notes 笔记功能** `P1` - owner: claude - file: `docs/task/FEAT-006.md`
 - [x] **TEST-003 深度测试进程与状态编排并补充架构文档** `P1` - owner: codex - file: `docs/task/TEST-003.md`

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -1,10 +1,10 @@
 # Task Index
 
-> Updated: 2026-03-04 20:42 UTC
+> Updated: 2026-03-06 19:31 UTC
 
 ## 待处理
 
-- [ ] （暂无）
+- [-] **BUG-091 调查 pending 消息消费后前端未即时感知** `P0` - owner: codex - file: `docs/task/BUG-091.md`
 
 ## 已完成
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -215,6 +215,7 @@ export interface ChangesSummary {
 /** SSE wire format — what the frontend receives via EventSource. */
 export interface SSEEventMap {
   log: { issueId: string; entry: NormalizedLogEntry }
+  'log-updated': { issueId: string; entry: NormalizedLogEntry }
   state: { issueId: string; executionId: string; state: string }
   done: { issueId: string; finalStatus: string }
   'issue-updated': { issueId: string; changes: Record<string, unknown> }
@@ -230,6 +231,7 @@ export interface AppEventMap {
     entry: NormalizedLogEntry
     streaming: boolean
   }
+  'log-updated': { issueId: string; entry: NormalizedLogEntry }
   state: { issueId: string; executionId: string; state: string }
   done: { issueId: string; executionId: string; finalStatus: string }
   'issue-updated': { issueId: string; changes: Record<string, unknown> }


### PR DESCRIPTION
## Summary
- add an explicit `log-updated` event so promoted pending messages are pushed to the client without a refresh
- emit the updated user-message payload from both pending flush paths after `promotePendingMessages()` succeeds
- teach the frontend issue stream to upsert existing log entries by `messageId` and cover the behavior with a hook test

## Testing
- `bun --filter @bitk/frontend test -- run src/__tests__/hooks/use-issue-stream.test.tsx`
- `bun test apps/api/test/pending-messages-unit.test.ts` *(blocked: local `drizzle-orm` install is missing `column-builder.js`, so Bun fails before test execution)*
