### PR TITLE
feat: improve homepage UX and remove upload restrictions

### DIFF
--- a/apps/api/src/db/pending-messages.ts
+++ b/apps/api/src/db/pending-messages.ts
@@ -1,5 +1,5 @@
-import type { NormalizedLogEntry } from '@bitk/shared'
 import { resolve } from 'node:path'
+import type { NormalizedLogEntry } from '@bitk/shared'
 import { and, asc, eq, inArray, isNotNull } from 'drizzle-orm'
 import { UPLOAD_DIR } from '@/uploads'
 import { db } from '.'

--- a/apps/api/src/engines/executors/codex/protocol.ts
+++ b/apps/api/src/engines/executors/codex/protocol.ts
@@ -188,7 +188,10 @@ export class CodexProtocolHandler {
     threadId: string
     model?: string
   }> {
-    const result = (await this.sendRequest('thread/start', threadParamsToRpc(params))) as {
+    const result = (await this.sendRequest(
+      'thread/start',
+      threadParamsToRpc(params),
+    )) as {
       thread?: { id?: string }
       model?: string
     }

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -9,11 +9,11 @@ import {
 } from '@/engines/engine-store'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled, emitStateChange } from '@/engines/issue/events'
-import { emitIssueLogUpdated } from '@/events/issue-events'
 import { dispatch } from '@/engines/issue/state'
 import type { ManagedProcess } from '@/engines/issue/types'
 import { sendInputToRunningProcess } from '@/engines/issue/user-message'
 import type { ProcessStatus } from '@/engines/types'
+import { emitIssueLogUpdated } from '@/events/issue-events'
 import { logger } from '@/logger'
 
 // ---------- Turn completion ----------

--- a/apps/api/src/uploads.ts
+++ b/apps/api/src/uploads.ts
@@ -51,7 +51,6 @@ export function validateFiles(
         error: `File "${file.name}" exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`,
       }
     }
-
   }
   return { ok: true }
 }

--- a/apps/api/src/uploads.ts
+++ b/apps/api/src/uploads.ts
@@ -6,28 +6,6 @@ export const UPLOAD_DIR = resolve(process.cwd(), 'data/uploads')
 export const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
 export const MAX_FILES = 10
 
-// MIME type prefixes that are safe to accept
-const ALLOWED_MIME_PREFIXES = [
-  'image/',
-  'text/',
-  'application/json',
-  'application/pdf',
-]
-
-// File extensions that are never allowed regardless of MIME type
-const BLOCKED_EXTENSIONS = new Set([
-  '.exe',
-  '.bat',
-  '.cmd',
-  '.sh',
-  '.ps1',
-  '.dll',
-  '.so',
-  '.html',
-  '.htm',
-  '.svg',
-])
-
 export interface SavedFile {
   id: string
   originalName: string
@@ -74,21 +52,6 @@ export function validateFiles(
       }
     }
 
-    const ext = extname(file.name).toLowerCase()
-    if (ext && BLOCKED_EXTENSIONS.has(ext)) {
-      return { ok: false, error: `File type "${ext}" is not allowed` }
-    }
-
-    // Allow empty or generic MIME (browser detection is unreliable for many types)
-    const mime = file.type
-    if (mime && mime !== 'application/octet-stream') {
-      const allowed = ALLOWED_MIME_PREFIXES.some((prefix) =>
-        mime.startsWith(prefix),
-      )
-      if (!allowed) {
-        return { ok: false, error: `MIME type "${mime}" is not allowed` }
-      }
-    }
   }
   return { ok: true }
 }

--- a/apps/api/test/pending-messages-unit.test.ts
+++ b/apps/api/test/pending-messages-unit.test.ts
@@ -1,12 +1,12 @@
 import { beforeAll, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { db } from '@/db'
+import { promotePendingMessages } from '@/db/pending-messages'
 import {
   issueLogs,
   issues as issuesTable,
   projects as projectsTable,
 } from '@/db/schema'
-import { promotePendingMessages } from '@/db/pending-messages'
 // We import the shared helpers directly
 import {
   getPendingMessages,

--- a/apps/frontend/src/__tests__/hooks/use-issue-stream.test.tsx
+++ b/apps/frontend/src/__tests__/hooks/use-issue-stream.test.tsx
@@ -2,9 +2,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useIssueStream } from '@/hooks/use-issue-stream'
 import type { IssueEventHandler } from '@/lib/event-bus'
 import type { NormalizedLogEntry } from '@/types/kanban'
-import { useIssueStream } from '@/hooks/use-issue-stream'
 
 const subscribeMock = vi.fn()
 const getIssueLogsMock = vi.fn()

--- a/apps/frontend/src/components/CreateProjectDialog.tsx
+++ b/apps/frontend/src/components/CreateProjectDialog.tsx
@@ -25,7 +25,7 @@ export function CreateProjectDialog({
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onCreated: (p: Project) => void
+  onCreated?: (p: Project) => void
 }) {
   const { t } = useTranslation()
   const { data: wsData } = useWorkspacePath(true)
@@ -71,7 +71,7 @@ export function CreateProjectDialog({
       },
       {
         onSuccess: (project) => {
-          onCreated(project)
+          onCreated?.(project)
           onOpenChange(false)
           reset()
         },

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -1,4 +1,6 @@
 import {
+  Check,
+  Copy,
   FileText,
   FolderOpen,
   GitBranch,
@@ -12,6 +14,16 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { DirectoryPicker } from '@/components/DirectoryPicker'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -116,6 +128,7 @@ function WorktreeSection({ project }: { project: Project }) {
   const { data: worktrees, isLoading } = useProjectWorktrees(project.id)
   const deleteWorktree = useDeleteWorktree()
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [confirmId, setConfirmId] = useState<string | null>(null)
 
   if (isLoading) {
     return (
@@ -135,54 +148,76 @@ function WorktreeSection({ project }: { project: Project }) {
   }
 
   return (
-    <div className="space-y-2">
-      {worktrees.map((wt) => (
-        <div
-          key={wt.issueId}
-          className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
-        >
-          <div className="min-w-0 flex-1 space-y-0.5">
-            <p className="truncate text-sm font-medium font-mono">
-              {wt.issueId}
-            </p>
-            {wt.branch ? (
-              <p className="flex items-center gap-1 text-xs text-muted-foreground">
-                <GitBranch className="size-3" />
-                <span className="truncate">{wt.branch}</span>
-              </p>
-            ) : null}
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="shrink-0 text-muted-foreground hover:text-destructive"
-            disabled={deleteWorktree.isPending && deletingId === wt.issueId}
-            onClick={() => {
-              if (
-                !window.confirm(
-                  t('project.worktreeDeleteConfirm', {
-                    issueId: wt.issueId,
-                  }),
-                )
-              ) {
-                return
-              }
-              setDeletingId(wt.issueId)
-              deleteWorktree.mutate(
-                { projectId: project.id, issueId: wt.issueId },
-                { onSettled: () => setDeletingId(null) },
-              )
-            }}
+    <>
+      <div className="space-y-2">
+        {worktrees.map((wt) => (
+          <div
+            key={wt.issueId}
+            className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
           >
-            {deleteWorktree.isPending && deletingId === wt.issueId ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Trash2 className="size-4" />
-            )}
-          </Button>
-        </div>
-      ))}
-    </div>
+            <div className="min-w-0 flex-1 space-y-0.5">
+              <p className="truncate text-sm font-medium font-mono">
+                {wt.issueId}
+              </p>
+              {wt.branch ? (
+                <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <GitBranch className="size-3" />
+                  <span className="truncate">{wt.branch}</span>
+                </p>
+              ) : null}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="shrink-0 text-muted-foreground hover:text-destructive"
+              disabled={deleteWorktree.isPending && deletingId === wt.issueId}
+              onClick={() => setConfirmId(wt.issueId)}
+            >
+              {deleteWorktree.isPending && deletingId === wt.issueId ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Trash2 className="size-4" />
+              )}
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={confirmId !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmId(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('project.worktreeDelete')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('project.worktreeDeleteConfirm', {
+                issueId: confirmId ?? '',
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (!confirmId) return
+                setDeletingId(confirmId)
+                deleteWorktree.mutate(
+                  { projectId: project.id, issueId: confirmId },
+                  { onSettled: () => setDeletingId(null) },
+                )
+                setConfirmId(null)
+              }}
+            >
+              {t('project.worktreeDelete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }
 
@@ -299,6 +334,14 @@ export function ProjectSettingsDialog({
         title={t('project.settings')}
         items={navItems}
         defaultItem="general"
+        sidebarFooter={
+          <div className="flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5">
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/50">
+              ID
+            </span>
+            <CopyableId value={project.id} />
+          </div>
+        }
         footer={(active) =>
           active !== 'worktrees' ? (
             <div className="flex items-center justify-between border-t px-5 py-3">
@@ -380,6 +423,32 @@ export function ProjectSettingsDialog({
         }}
       />
     </>
+  )
+}
+
+function CopyableId({ value }: { value: string }) {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        })
+      }}
+      className="group/id inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-xs text-muted-foreground hover:bg-muted transition-colors"
+      title={t('project.copyId')}
+    >
+      {value}
+      {copied ? (
+        <Check className="size-3 text-green-500" />
+      ) : (
+        <Copy className="size-3 opacity-0 group-hover/id:opacity-100 transition-opacity" />
+      )}
+    </button>
   )
 }
 

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -337,7 +337,7 @@ export function ProjectSettingsDialog({
         sidebarFooter={
           <div className="flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5">
             <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/50">
-              ID
+              {t('project.projectId')}
             </span>
             <CopyableId value={project.id} />
           </div>

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -630,7 +630,9 @@ export function SessionMessages({
   }
 
   return (
-    <div className={`flex flex-col py-2 px-5${fullWidthChat ? '' : ' max-w-4xl'}`}>
+    <div
+      className={`flex flex-col py-2 px-5${fullWidthChat ? '' : ' max-w-4xl'}`}
+    >
       {hasOlderLogs && onLoadOlder ? (
         <div className="flex justify-center py-2">
           <button

--- a/apps/frontend/src/components/terminal/TerminalView.tsx
+++ b/apps/frontend/src/components/terminal/TerminalView.tsx
@@ -125,7 +125,8 @@ function getOrCreateTerminal(): { terminal: Terminal; fitAddon: FitAddon } {
   const terminal = new Terminal({
     cursorBlink: true,
     fontSize: 14,
-    fontFamily: 'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace',
+    fontFamily:
+      'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace',
     theme: getTerminalTheme(),
     allowProposedApi: true,
   })

--- a/apps/frontend/src/components/ui/settings-layout.tsx
+++ b/apps/frontend/src/components/ui/settings-layout.tsx
@@ -24,6 +24,7 @@ export function SettingsLayout({
   defaultItem,
   children,
   footer,
+  sidebarFooter,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -32,6 +33,7 @@ export function SettingsLayout({
   defaultItem?: string
   children: (activeItem: string) => React.ReactNode
   footer?: (activeItem: string) => React.ReactNode
+  sidebarFooter?: React.ReactNode
 }) {
   const [active, setActive] = useState(defaultItem ?? items[0]?.id ?? '')
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
@@ -103,6 +105,9 @@ export function SettingsLayout({
                 )
               })}
             </div>
+            {sidebarFooter && (
+              <div className="mt-auto pt-3">{sidebarFooter}</div>
+            )}
           </nav>
 
           {/* Mobile nav backdrop */}

--- a/apps/frontend/src/hooks/use-issue-stream.ts
+++ b/apps/frontend/src/hooks/use-issue-stream.ts
@@ -196,7 +196,9 @@ export function useIssueStream({
       }
 
       if (
-        olderLogsRef.current.some((entry) => entry.messageId === incoming.messageId)
+        olderLogsRef.current.some(
+          (entry) => entry.messageId === incoming.messageId,
+        )
       ) {
         setOlderLogs((prev) => {
           const next = prev.map((entry) =>
@@ -209,7 +211,9 @@ export function useIssueStream({
       }
 
       if (
-        liveLogsRef.current.some((entry) => entry.messageId === incoming.messageId)
+        liveLogsRef.current.some(
+          (entry) => entry.messageId === incoming.messageId,
+        )
       ) {
         setLiveLogs((prev) => {
           const next = prev.map((entry) =>

--- a/apps/frontend/src/hooks/use-project-stats.ts
+++ b/apps/frontend/src/hooks/use-project-stats.ts
@@ -1,4 +1,3 @@
-import { STATUSES } from '@/lib/statuses'
 import { useIssues } from './use-kanban'
 
 export function useProjectStats(projectId: string) {
@@ -6,6 +5,5 @@ export function useProjectStats(projectId: string) {
 
   return {
     issueCount: issues?.length ?? 0,
-    statusCount: STATUSES.length,
   }
 }

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -30,6 +30,8 @@
     "newProject": "New Project",
     "issueCount": "{{count}} issues",
     "statusCount": "{{count}} statuses",
+    "copyId": "Click to copy ID",
+    "copyPath": "Click to copy path",
     "browseDirectories": "Browse directories",
     "directoryAlreadyUsed": "This directory is already used by another project",
     "delete": "Delete Project",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -30,6 +30,7 @@
     "newProject": "New Project",
     "issueCount": "{{count}} issues",
     "statusCount": "{{count}} statuses",
+    "projectId": "ID",
     "copyId": "Click to copy ID",
     "copyPath": "Click to copy path",
     "browseDirectories": "Browse directories",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -30,6 +30,8 @@
     "newProject": "新建项目",
     "issueCount": "{{count}} 个任务",
     "statusCount": "{{count}} 个状态",
+    "copyId": "点击复制 ID",
+    "copyPath": "点击复制路径",
     "browseDirectories": "浏览目录",
     "directoryAlreadyUsed": "该目录已被其他项目使用",
     "delete": "删除项目",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -30,6 +30,7 @@
     "newProject": "新建项目",
     "issueCount": "{{count}} 个任务",
     "statusCount": "{{count}} 个状态",
+    "projectId": "ID",
     "copyId": "点击复制 ID",
     "copyPath": "点击复制路径",
     "browseDirectories": "浏览目录",

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -83,8 +83,12 @@
 }
 
 @theme inline {
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica,
+    Arial, sans-serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -1,10 +1,11 @@
 import {
+  Check,
+  Copy,
+  FolderOpen,
   Hash,
-  Layers,
   LayoutGrid,
   List,
   Menu,
-  MoreVertical,
   Plus,
   Settings,
   StickyNote,
@@ -42,11 +43,21 @@ function ProjectCard({
   const { t } = useTranslation()
   const stats = useProjectStats(project.id)
   const [showSettings, setShowSettings] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyPath = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!project.directory) return
+    void navigator.clipboard.writeText(project.directory).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
 
   return (
     <>
       <Card
-        className="bg-card/70 hover:bg-card cursor-pointer transition-all hover:shadow-md hover:border-primary/20 group"
+        className="h-full bg-card/70 hover:bg-card cursor-pointer transition-all hover:shadow-md hover:border-primary/20 group"
         onClick={onClick}
       >
         <CardHeader>
@@ -55,8 +66,11 @@ function ProjectCard({
               {getProjectInitials(project.name)}
             </div>
             <div className="min-w-0 flex-1">
-              <CardTitle className="text-base group-hover:text-primary transition-colors truncate">
-                {project.name}
+              <CardTitle className="flex items-baseline gap-1.5 text-base group-hover:text-primary transition-colors">
+                <span className="truncate">{project.name}</span>
+                <span className="shrink-0 text-[10px] font-normal font-mono text-muted-foreground/60">
+                  {project.id}
+                </span>
               </CardTitle>
               {project.description && (
                 <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
@@ -74,19 +88,33 @@ function ProjectCard({
               aria-label={t('project.settings')}
               title={t('project.settings')}
             >
-              <MoreVertical className="h-4 w-4" />
+              <Settings className="h-4 w-4" />
             </button>
           </div>
         </CardHeader>
-        <CardContent>
-          <div className="flex items-center gap-4 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1">
+        <CardContent className="mt-auto">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {project.directory ? (
+              <button
+                type="button"
+                onClick={handleCopyPath}
+                className="group/path flex min-w-0 items-center gap-1 hover:text-foreground transition-colors text-left"
+                title={t('project.copyPath')}
+              >
+                <FolderOpen className="h-3 w-3 shrink-0" />
+                <span className="truncate font-mono">
+                  {project.directory}
+                </span>
+                {copied ? (
+                  <Check className="h-3 w-3 shrink-0 text-green-500" />
+                ) : (
+                  <Copy className="h-3 w-3 shrink-0 opacity-0 group-hover/path:opacity-100 transition-opacity" />
+                )}
+              </button>
+            ) : null}
+            <span className="ml-auto flex shrink-0 items-center gap-1">
               <Hash className="h-3 w-3" />
-              {t('project.issueCount', { count: stats.issueCount })}
-            </span>
-            <span className="flex items-center gap-1">
-              <Layers className="h-3 w-3" />
-              {t('project.statusCount', { count: stats.statusCount })}
+              {stats.issueCount}
             </span>
           </div>
         </CardContent>

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -102,9 +102,7 @@ function ProjectCard({
                 title={t('project.copyPath')}
               >
                 <FolderOpen className="h-3 w-3 shrink-0" />
-                <span className="truncate font-mono">
-                  {project.directory}
-                </span>
+                <span className="truncate font-mono">{project.directory}</span>
                 {copied ? (
                   <Check className="h-3 w-3 shrink-0 text-green-500" />
                 ) : (
@@ -389,10 +387,7 @@ export default function HomePage() {
         )}
       </section>
 
-      <CreateProjectDialog
-        open={showCreate}
-        onOpenChange={setShowCreate}
-      />
+      <CreateProjectDialog open={showCreate} onOpenChange={setShowCreate} />
       <AppSettingsDialog open={showSettings} onOpenChange={setShowSettings} />
     </main>
   )

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -320,13 +320,6 @@ export default function HomePage() {
     [isMobile, globalProjectPath],
   )
 
-  const handleProjectCreated = useCallback(
-    (project: Project) => {
-      void navigate(projectPath(project.alias))
-    },
-    [navigate, projectPath],
-  )
-
   return (
     <main className="min-h-screen text-foreground animate-page-enter">
       <section className="mx-auto max-w-6xl px-4 py-6 md:px-6 md:py-12">
@@ -399,7 +392,6 @@ export default function HomePage() {
       <CreateProjectDialog
         open={showCreate}
         onOpenChange={setShowCreate}
-        onCreated={handleProjectCreated}
       />
       <AppSettingsDialog open={showSettings} onOpenChange={setShowSettings} />
     </main>


### PR DESCRIPTION
## Summary

- **Homepage project cards**: replaced settings icon, removed fixed status count, added copyable directory path with truncation, added inline project ID display, fixed card height inconsistency
- **Project settings**: added copyable project ID in sidebar footer, replaced browser `window.confirm` with AlertDialog for worktree deletion
- **Settings layout**: added `sidebarFooter` slot to reusable SettingsLayout component
- **Create project**: removed auto-navigate to project after creation, stays on homepage
- **File uploads**: removed all file type restrictions (MIME prefix and extension blocklist), only size and count limits remain

## Test plan

- [ ] Verify homepage project cards display correctly with/without description
- [ ] Verify project directory path is shown and copyable on cards
- [ ] Verify project ID is displayed inline on cards
- [ ] Verify project settings dialog shows copyable ID in sidebar footer
- [ ] Verify worktree deletion uses AlertDialog confirmation instead of browser confirm
- [ ] Verify creating a project stays on homepage
- [ ] Verify uploading HTML, SVG, and other previously blocked file types works