### PR TITLE
fix: improve stream stall detection with 3-tier approach

### DIFF
--- a/apps/api/src/engines/executors/claude/protocol.ts
+++ b/apps/api/src/engines/executors/claude/protocol.ts
@@ -97,9 +97,10 @@ interface ControlRequest {
 export class ClaudeProtocolHandler {
   private stdin: FileSink
   private closed = false
-  /** Called when a control_request is received, signaling the process is alive.
-   *  Used by the engine layer to update lastActivityAt during tool execution
-   *  (when no normal stdout entries are emitted). */
+  /** Called when ANY stdout data is received from the process, signaling it is alive.
+   *  Used by the engine layer to update lastActivityAt at the earliest possible point,
+   *  before downstream consumers (consumeStream) process the data. This prevents
+   *  false stall detection when downstream processing (DB writes, etc.) is slow. */
   onActivity?: () => void
   /** Called when a Result message is received, signaling turn completion. */
   onResult?: (data: unknown) => void
@@ -124,7 +125,7 @@ export class ClaudeProtocolHandler {
     const processControlReq = this.processControlRequest.bind(this)
     const isResultMsg = this.isResultMessage.bind(this)
     // Capture `this` reference instead of the callback value so that
-    // onResult can be set after wrapStdout() is called.
+    // onResult/onActivity can be set after wrapStdout() is called.
     const self = this
 
     return new ReadableStream<Uint8Array>({
@@ -185,6 +186,11 @@ export class ClaudeProtocolHandler {
             return
           }
 
+          // Signal activity at the earliest point — raw data received from process.
+          // This fires before line parsing and downstream consumption, ensuring
+          // lastActivityAt is updated even if downstream processing is slow.
+          self.onActivity?.()
+
           buffer += decoder.decode(value, { stream: true })
         }
       },
@@ -232,9 +238,9 @@ export class ClaudeProtocolHandler {
           'claude_protocol_control_request',
         )
       }
-      // Signal activity so the stall detector knows the process is alive
-      // (control_requests are filtered from the downstream stdout stream,
-      // so consumeStream's lastActivityAt update doesn't fire for them).
+      // onActivity is already called in the pull() loop when raw data arrives,
+      // but control_requests are filtered from the downstream stream — fire again
+      // to ensure the timestamp is fresh for the completed control_request.
       this.onActivity?.()
       this.handleControlRequest(request_id, request)
     } catch (error) {

--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -1,13 +1,17 @@
 export const MAX_LOG_ENTRIES = 10000
 export const AUTO_CLEANUP_DELAY_MS = 5 * 60 * 1000 // 5 minutes
 export const MAX_AUTO_RETRIES = 1
-// Worst-case stall-to-kill: STREAM_STALL_TIMEOUT_MS + GC_INTERVAL_MS + STALL_PROBE_GRACE_MS + GC_INTERVAL_MS ≈ 9 min
+// Stall detection timeline:
+//   T+3m: first check — if process alive, wait for CLI internal retry
+//   T+8m: second check (process alive 5min after first probe) — send interrupt
+//   T+10m: no response after interrupt — force kill
 export const GC_INTERVAL_MS = 60 * 1000 // 1 minute — frequent stall detection
 export const MAX_CONCURRENT_EXECUTIONS =
   Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
 export const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
-export const STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes — send interrupt probe if no stdout/stderr activity
-export const STALL_PROBE_GRACE_MS = 2 * 60 * 1000 // 2 minutes — kill process if no response after interrupt probe
+export const STREAM_STALL_TIMEOUT_MS = 3 * 60 * 1000 // 3 minutes — check process liveness (non-destructive)
+export const STALL_LIVENESS_GRACE_MS = 5 * 60 * 1000 // 5 minutes — wait for CLI internal retry before sending interrupt
+export const STALL_INTERRUPT_GRACE_MS = 2 * 60 * 1000 // 2 minutes — kill process if no response after interrupt
 export const CANCEL_RESPONSE_TIMEOUT_MS = 5_000 // 5s — wait for turn completion after each interrupt retry
 export const CANCEL_MAX_RETRIES = 3 // send interrupt up to 3 times before hard kill (worst case: 3 × 5s = 15s)
 export const WORKTREE_DIR = process.env.WORKTREE_DIR || 'worktrees'

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -7,7 +7,8 @@ import type { ProcessStatus } from '@/engines/types'
 import { logger } from '@/logger'
 import {
   IDLE_TIMEOUT_MS,
-  STALL_PROBE_GRACE_MS,
+  STALL_INTERRUPT_GRACE_MS,
+  STALL_LIVENESS_GRACE_MS,
   STREAM_STALL_TIMEOUT_MS,
 } from './constants'
 import type { EngineContext } from './context'
@@ -74,6 +75,17 @@ function terminateAndSettle(
   })
 }
 
+/** Check if a process is still alive via kill(pid, 0). */
+function isProcessAlive(pid: number | undefined): boolean {
+  if (!pid) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
 // ---------- Domain GC sweep ----------
 
 export function gcSweep(ctx: EngineContext): void {
@@ -124,16 +136,18 @@ export function gcSweep(ctx: EngineContext): void {
     }
 
     // --- Check 2: Stream stall detection (turn in-flight but no output) ---
-    // Two-tier approach to avoid killing legitimate long-running operations:
-    //   Tier 1 (STREAM_STALL_TIMEOUT_MS): Send interrupt probe to check responsiveness
-    //   Tier 2 (+ STALL_PROBE_GRACE_MS): No response after probe → force kill
+    // Three-tier approach: give the CLI time to retry internally before we intervene.
+    //   Tier 1 (STREAM_STALL_TIMEOUT_MS): Non-destructive liveness check via OS
+    //   Tier 2 (+ STALL_LIVENESS_GRACE_MS): Process alive but still silent → send interrupt
+    //   Tier 3 (+ STALL_INTERRUPT_GRACE_MS): No response after interrupt → force kill
     if (managed.turnInFlight) {
       const silenceMs = now - managed.lastActivityAt.getTime()
+      const pid = (managed.process.subprocess as { pid?: number }).pid
 
-      // Tier 2: probe was sent but process still hasn't responded
+      // Tier 3: interrupt was sent but process still hasn't responded
       if (
         managed.stallProbeAt &&
-        now - managed.stallProbeAt.getTime() > STALL_PROBE_GRACE_MS
+        now - managed.stallProbeAt.getTime() > STALL_INTERRUPT_GRACE_MS
       ) {
         const stallMinutes = Math.round(silenceMs / 60000)
         logger.warn(
@@ -146,15 +160,37 @@ export function gcSweep(ctx: EngineContext): void {
           },
           'stream_stall_terminate',
         )
+        managed.stallDetectedAt = undefined
         managed.stallProbeAt = undefined
         terminateAndSettle(ctx, entry.id, managed, 'failed')
         cleaned++
         continue
       }
 
-      // Tier 1: no output for STREAM_STALL_TIMEOUT_MS — send interrupt probe
-      if (!managed.stallProbeAt && silenceMs > STREAM_STALL_TIMEOUT_MS) {
+      // Tier 2: stall detected for STALL_LIVENESS_GRACE_MS, process still alive → send interrupt
+      if (
+        managed.stallDetectedAt &&
+        !managed.stallProbeAt &&
+        now - managed.stallDetectedAt.getTime() > STALL_LIVENESS_GRACE_MS
+      ) {
         const stallMinutes = Math.round(silenceMs / 60000)
+        const alive = isProcessAlive(pid)
+        if (!alive) {
+          // Process already dead — skip interrupt, just terminate
+          logger.warn(
+            {
+              issueId: managed.issueId,
+              executionId: managed.executionId,
+              stallMinutes,
+              pid,
+            },
+            'stream_stall_process_dead',
+          )
+          managed.stallDetectedAt = undefined
+          terminateAndSettle(ctx, entry.id, managed, 'failed')
+          cleaned++
+          continue
+        }
         logger.warn(
           {
             issueId: managed.issueId,
@@ -165,10 +201,8 @@ export function gcSweep(ctx: EngineContext): void {
           'stream_stall_probe_sent',
         )
         managed.stallProbeAt = new Date()
-        // Send interrupt to probe process responsiveness. If the process is
-        // alive (e.g. waiting on a slow API call), it will respond with an
-        // error/result entry, which updates lastActivityAt and clears the stall.
-        // Fire-and-forget: Tier 2 will force-kill if no response after grace period.
+        // Send interrupt to probe process responsiveness. The CLI had
+        // STALL_LIVENESS_GRACE_MS to recover on its own — now we intervene.
         // Fire-and-forget: use Promise.resolve() to normalize void | Promise<void>
         // since Codex's implementation is genuinely async while Claude's is sync.
         void Promise.resolve(
@@ -179,6 +213,37 @@ export function gcSweep(ctx: EngineContext): void {
             'stall_probe_interrupt_failed',
           )
         })
+        continue
+      }
+
+      // Tier 1: no output for STREAM_STALL_TIMEOUT_MS — non-destructive liveness check
+      if (
+        !managed.stallDetectedAt &&
+        !managed.stallProbeAt &&
+        silenceMs > STREAM_STALL_TIMEOUT_MS
+      ) {
+        const alive = isProcessAlive(pid)
+        const stallMinutes = Math.round(silenceMs / 60000)
+        logger.warn(
+          {
+            issueId: managed.issueId,
+            executionId: managed.executionId,
+            stallMinutes,
+            lastActivityAt: managed.lastActivityAt.toISOString(),
+            pid,
+            processAlive: alive,
+          },
+          'stream_stall_detected',
+        )
+        if (!alive) {
+          // Process already dead — terminate immediately
+          terminateAndSettle(ctx, entry.id, managed, 'failed')
+          cleaned++
+          continue
+        }
+        // Process is alive — likely retrying API connection internally.
+        // Mark stall detected and give CLI time to recover on its own.
+        managed.stallDetectedAt = new Date()
       }
     }
   }

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -90,10 +90,11 @@ export function register(
       handleStderrEntry(issueId, executionId, entry),
   }
 
-  // Wire up protocol handler activity callback so control_request messages
-  // (filtered from the downstream stdout stream) still update lastActivityAt.
-  // This prevents false stall detection during long-running tool executions
-  // where the process is alive but not producing normal log entries.
+  // Wire up protocol handler activity callback. This fires at two points:
+  // 1. When raw data arrives from the process (earliest signal of liveness)
+  // 2. When control_request messages are processed (filtered from downstream)
+  // This prevents false stall detection when downstream processing is slow or
+  // the process is alive but only sending control_requests (tool execution).
   // Wire once — guard prevents overwriting if register() is called multiple times.
   if (process.protocolHandler && !process.protocolHandler.onActivity) {
     const getManagedRef = stdoutCallbacks.getManaged
@@ -101,6 +102,7 @@ export function register(
       const m = getManagedRef()
       if (m) {
         m.lastActivityAt = new Date()
+        if (m.stallDetectedAt) m.stallDetectedAt = undefined
         if (m.stallProbeAt) m.stallProbeAt = undefined
       }
     }

--- a/apps/api/src/engines/issue/state/index.ts
+++ b/apps/api/src/engines/issue/state/index.ts
@@ -16,6 +16,8 @@ export function dispatch(managed: ManagedProcess, action: ManagedAction): void {
       managed.logicalFailureReason = undefined
       managed.lastInterruptAt = undefined
       managed.cancelEscalationId = undefined // Invalidate stale cancel escalation
+      managed.stallDetectedAt = undefined
+      managed.stallProbeAt = undefined
       managed.metaTurn = action.metaTurn
       break
     case 'TURN_COMPLETED':

--- a/apps/api/src/engines/issue/streams/consumer.ts
+++ b/apps/api/src/engines/issue/streams/consumer.ts
@@ -71,7 +71,8 @@ export async function consumeStream(
         const managed = callbacks.getManaged()
         if (!managed) break
         managed.lastActivityAt = new Date()
-        // Clear stall probe if activity resumed after the GC-sent interrupt
+        // Clear stall state if activity resumed (CLI recovered on its own or after interrupt)
+        if (managed.stallDetectedAt) managed.stallDetectedAt = undefined
         if (managed.stallProbeAt) managed.stallProbeAt = undefined
         const turnIdx = callbacks.getTurnIndex()
 
@@ -171,6 +172,7 @@ export async function consumeStderr(
           const managed = callbacks.getManaged()
           if (!managed) return
           managed.lastActivityAt = new Date()
+          if (managed.stallDetectedAt) managed.stallDetectedAt = undefined
           if (managed.stallProbeAt) managed.stallProbeAt = undefined
           pushStderrEntry(line, callbacks.getTurnIndex(), callbacks.onEntry)
         } catch (entryError) {

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -42,9 +42,12 @@ export interface ManagedProcess {
   lastIdleAt?: Date
   /** Timestamp of the last stdout/stderr activity (updated on every stream entry) */
   lastActivityAt: Date
+  /** Timestamp when stall was first detected (non-destructive liveness check).
+   *  If activity resumes, this is cleared in consumeStream. */
+  stallDetectedAt?: Date
   /** Timestamp when a stall-probe interrupt was sent (set by gcSweep).
    *  If activity resumes after the probe, this is cleared in consumeStream.
-   *  If still no activity after STALL_PROBE_GRACE_MS, the process is force-killed. */
+   *  If still no activity after STALL_INTERRUPT_GRACE_MS, the process is force-killed. */
   stallProbeAt?: Date
   /** Unique ID for the current cancel escalation. Set when cancelIssue fires
    *  the async escalation loop, cleared when a new turn starts (START_TURN).

--- a/apps/api/test/gc-stall-detection.test.ts
+++ b/apps/api/test/gc-stall-detection.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, mock, test } from 'bun:test'
 import {
   IDLE_TIMEOUT_MS,
-  STALL_PROBE_GRACE_MS,
+  STALL_INTERRUPT_GRACE_MS,
+  STALL_LIVENESS_GRACE_MS,
   STREAM_STALL_TIMEOUT_MS,
 } from '@/engines/issue/constants'
 import type { EngineContext } from '@/engines/issue/context'
@@ -10,10 +11,11 @@ import type { ManagedProcess } from '@/engines/issue/types'
 
 /**
  * GC sweep stall detection tests — verifies:
- * 1. Two-tier stall detection: probe first (interrupt), kill if no response
+ * 1. Three-tier stall detection: detect → wait for CLI retry → interrupt → kill
  * 2. Active processes with recent output are NOT killed
  * 3. Idle processes are killed after IDLE_TIMEOUT_MS (existing behavior)
- * 4. Stall probe is cleared when activity resumes
+ * 4. Stall state is cleared when activity resumes
+ * 5. Dead processes are terminated immediately
  */
 
 // ---------- Mock helpers ----------
@@ -23,7 +25,9 @@ function makeManagedProcess(
 ): ManagedProcess {
   return {
     engineType: 'claude-code',
-    process: {} as unknown as ManagedProcess['process'],
+    process: {
+      subprocess: { pid: process.pid },
+    } as unknown as ManagedProcess['process'],
     state: 'running',
     startedAt: new Date(),
     logs: { toArray: () => [] } as unknown as ManagedProcess['logs'],
@@ -35,6 +39,8 @@ function makeManagedProcess(
     metaTurn: false,
     lastActivityAt: new Date(),
     slashCommands: [],
+    agents: [],
+    plugins: [],
     pendingInputs: [],
     ...overrides,
   }
@@ -79,7 +85,7 @@ function makeContext(entries: MockEntry[]): {
 // ---------- Tests ----------
 
 describe('gcSweep — stream stall detection', () => {
-  test('Tier 1: sends probe (sets stallProbeAt) but does NOT kill on first detection', () => {
+  test('Tier 1: detects stall and sets stallDetectedAt (non-destructive)', () => {
     const stalledAt = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS - 60_000)
     const managed = makeManagedProcess({
       issueId: 'issue-1',
@@ -93,22 +99,64 @@ describe('gcSweep — stream stall detection', () => {
 
     gcSweep(ctx)
 
-    // Should NOT be killed yet — only probed
+    // Should NOT be killed — only detected
     expect(forceKillCalls).not.toContain('exec-1')
-    // stallProbeAt should be set
-    expect(managed.stallProbeAt).toBeDefined()
+    // stallDetectedAt should be set, stallProbeAt should NOT
+    expect(managed.stallDetectedAt).toBeDefined()
+    expect(managed.stallProbeAt).toBeUndefined()
   })
 
-  test('Tier 2: kills process if no response after probe grace period', () => {
+  test('Tier 2: sends interrupt after liveness grace period', () => {
     const stalledAt = new Date(
-      Date.now() - STREAM_STALL_TIMEOUT_MS - STALL_PROBE_GRACE_MS - 60_000,
+      Date.now() - STREAM_STALL_TIMEOUT_MS - STALL_LIVENESS_GRACE_MS - 60_000,
     )
-    const probeAt = new Date(Date.now() - STALL_PROBE_GRACE_MS - 60_000)
+    const detectedAt = new Date(
+      Date.now() - STALL_LIVENESS_GRACE_MS - 60_000,
+    )
+    const interruptMock = mock(() => {})
     const managed = makeManagedProcess({
       issueId: 'issue-1',
       executionId: 'exec-1',
       turnInFlight: true,
       lastActivityAt: stalledAt,
+      stallDetectedAt: detectedAt,
+      process: {
+        subprocess: { pid: process.pid },
+        protocolHandler: { interrupt: interruptMock },
+      } as unknown as ManagedProcess['process'],
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-1', meta: managed },
+    ])
+
+    gcSweep(ctx)
+
+    // Should NOT be killed yet — interrupt probe sent
+    expect(forceKillCalls).not.toContain('exec-1')
+    expect(managed.stallProbeAt).toBeDefined()
+    expect(interruptMock).toHaveBeenCalled()
+  })
+
+  test('Tier 3: kills process if no response after interrupt grace period', () => {
+    const stalledAt = new Date(
+      Date.now() -
+        STREAM_STALL_TIMEOUT_MS -
+        STALL_LIVENESS_GRACE_MS -
+        STALL_INTERRUPT_GRACE_MS -
+        60_000,
+    )
+    const detectedAt = new Date(
+      Date.now() - STALL_LIVENESS_GRACE_MS - STALL_INTERRUPT_GRACE_MS - 60_000,
+    )
+    const probeAt = new Date(
+      Date.now() - STALL_INTERRUPT_GRACE_MS - 60_000,
+    )
+    const managed = makeManagedProcess({
+      issueId: 'issue-1',
+      executionId: 'exec-1',
+      turnInFlight: true,
+      lastActivityAt: stalledAt,
+      stallDetectedAt: detectedAt,
       stallProbeAt: probeAt,
     })
     const { ctx, forceKillCalls } = makeContext([
@@ -118,6 +166,28 @@ describe('gcSweep — stream stall detection', () => {
     gcSweep(ctx)
 
     expect(forceKillCalls).toContain('exec-1')
+  })
+
+  test('Tier 1: immediately kills dead process', () => {
+    const stalledAt = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS - 60_000)
+    const managed = makeManagedProcess({
+      issueId: 'issue-dead',
+      executionId: 'exec-dead',
+      turnInFlight: true,
+      lastActivityAt: stalledAt,
+      // Use a PID that doesn't exist
+      process: {
+        subprocess: { pid: 999999999 },
+      } as unknown as ManagedProcess['process'],
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-dead', meta: managed },
+    ])
+
+    gcSweep(ctx)
+
+    // Dead process should be terminated immediately at Tier 1
+    expect(forceKillCalls).toContain('exec-dead')
   })
 
   test('does NOT kill process with recent stream activity', () => {
@@ -137,8 +207,8 @@ describe('gcSweep — stream stall detection', () => {
     expect(forceKillCalls).not.toContain('exec-2')
   })
 
-  test('does NOT kill process at exactly STREAM_STALL_TIMEOUT_MS (boundary)', () => {
-    // Activity exactly at timeout boundary — should NOT be killed (must be strictly past)
+  test('does NOT detect stall at exactly STREAM_STALL_TIMEOUT_MS (boundary)', () => {
+    // Activity exactly at timeout boundary — should NOT be detected (must be strictly past)
     const atBoundary = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS + 1000)
     const managed = makeManagedProcess({
       issueId: 'issue-3',
@@ -153,6 +223,7 @@ describe('gcSweep — stream stall detection', () => {
     gcSweep(ctx)
 
     expect(forceKillCalls).not.toContain('exec-3')
+    expect(managed.stallDetectedAt).toBeUndefined()
   })
 
   test('kills idle process after IDLE_TIMEOUT_MS (existing behavior)', () => {
@@ -191,7 +262,7 @@ describe('gcSweep — stream stall detection', () => {
     expect(forceKillCalls).not.toContain('exec-5')
   })
 
-  test('handles multiple processes — probes stalled, skips active and idle', () => {
+  test('handles multiple processes — detects stalled, skips active and idle', () => {
     const stalledManaged = makeManagedProcess({
       issueId: 'issue-stalled',
       executionId: 'exec-stalled',
@@ -219,23 +290,36 @@ describe('gcSweep — stream stall detection', () => {
 
     gcSweep(ctx)
 
-    // Tier 1: stalled is probed, not killed
+    // Tier 1: stalled is detected, not killed
     expect(forceKillCalls).not.toContain('exec-stalled')
-    expect(stalledManaged.stallProbeAt).toBeDefined()
+    expect(stalledManaged.stallDetectedAt).toBeDefined()
+    expect(stalledManaged.stallProbeAt).toBeUndefined()
     // Others untouched
     expect(forceKillCalls).not.toContain('exec-active')
     expect(forceKillCalls).not.toContain('exec-idle')
   })
 
-  test('handles multiple processes — kills stalled after probe grace, skips others', () => {
+  test('handles multiple processes — kills stalled after full escalation, skips others', () => {
     const stalledManaged = makeManagedProcess({
       issueId: 'issue-stalled',
       executionId: 'exec-stalled',
       turnInFlight: true,
       lastActivityAt: new Date(
-        Date.now() - STREAM_STALL_TIMEOUT_MS - STALL_PROBE_GRACE_MS - 120_000,
+        Date.now() -
+          STREAM_STALL_TIMEOUT_MS -
+          STALL_LIVENESS_GRACE_MS -
+          STALL_INTERRUPT_GRACE_MS -
+          120_000,
       ),
-      stallProbeAt: new Date(Date.now() - STALL_PROBE_GRACE_MS - 120_000),
+      stallDetectedAt: new Date(
+        Date.now() -
+          STALL_LIVENESS_GRACE_MS -
+          STALL_INTERRUPT_GRACE_MS -
+          120_000,
+      ),
+      stallProbeAt: new Date(
+        Date.now() - STALL_INTERRUPT_GRACE_MS - 120_000,
+      ),
     })
     const activeManaged = makeManagedProcess({
       issueId: 'issue-active',
@@ -258,15 +342,13 @@ describe('gcSweep — stream stall detection', () => {
 
     gcSweep(ctx)
 
-    // Tier 2: stalled is killed after probe grace period
+    // Tier 3: stalled is killed after full escalation
     expect(forceKillCalls).toContain('exec-stalled')
     expect(forceKillCalls).not.toContain('exec-active')
     expect(forceKillCalls).not.toContain('exec-idle')
   })
 
-  test('does NOT probe or kill process within stall timeout even with probe set', () => {
-    // Edge case: stallProbeAt set but process produced output since then
-    // (probe was sent, process responded — activity cleared stallProbeAt in consumer)
+  test('does NOT detect or kill process within stall timeout', () => {
     const managed = makeManagedProcess({
       issueId: 'issue-recovered',
       executionId: 'exec-recovered',
@@ -280,6 +362,7 @@ describe('gcSweep — stream stall detection', () => {
     gcSweep(ctx)
 
     expect(forceKillCalls).not.toContain('exec-recovered')
+    expect(managed.stallDetectedAt).toBeUndefined()
     expect(managed.stallProbeAt).toBeUndefined()
   })
 })

--- a/apps/api/test/gc-stall-detection.test.ts
+++ b/apps/api/test/gc-stall-detection.test.ts
@@ -110,9 +110,7 @@ describe('gcSweep — stream stall detection', () => {
     const stalledAt = new Date(
       Date.now() - STREAM_STALL_TIMEOUT_MS - STALL_LIVENESS_GRACE_MS - 60_000,
     )
-    const detectedAt = new Date(
-      Date.now() - STALL_LIVENESS_GRACE_MS - 60_000,
-    )
+    const detectedAt = new Date(Date.now() - STALL_LIVENESS_GRACE_MS - 60_000)
     const interruptMock = mock(() => {})
     const managed = makeManagedProcess({
       issueId: 'issue-1',
@@ -148,9 +146,7 @@ describe('gcSweep — stream stall detection', () => {
     const detectedAt = new Date(
       Date.now() - STALL_LIVENESS_GRACE_MS - STALL_INTERRUPT_GRACE_MS - 60_000,
     )
-    const probeAt = new Date(
-      Date.now() - STALL_INTERRUPT_GRACE_MS - 60_000,
-    )
+    const probeAt = new Date(Date.now() - STALL_INTERRUPT_GRACE_MS - 60_000)
     const managed = makeManagedProcess({
       issueId: 'issue-1',
       executionId: 'exec-1',
@@ -317,9 +313,7 @@ describe('gcSweep — stream stall detection', () => {
           STALL_INTERRUPT_GRACE_MS -
           120_000,
       ),
-      stallProbeAt: new Date(
-        Date.now() - STALL_INTERRUPT_GRACE_MS - 120_000,
-      ),
+      stallProbeAt: new Date(Date.now() - STALL_INTERRUPT_GRACE_MS - 120_000),
     })
     const activeManaged = makeManagedProcess({
       issueId: 'issue-active',


### PR DESCRIPTION
## Summary

- **Fix critical bug**: `content_block_delta` events return `null` from normalizer, so `lastActivityAt` was never updated during text streaming — stall detector could mis-detect active streams as stalled
- **Fix destructive probe**: old 2-tier approach sent `interrupt` at T+5min, destroying Claude CLI's internal API retry mechanism
- **Add early activity tracking**: `onActivity()` now fires in `wrapStdout()` when raw data arrives from `reader.read()`, before line parsing or downstream consumption
- **Upgrade to 3-tier stall detection**: non-destructive OS check → wait for CLI retry → interrupt → force kill

### Stall detection timeline

| Stage | Time | Action |
|-------|------|--------|
| Tier 1 | T+3min | `kill(pid, 0)` liveness check — dead → cleanup immediately, alive → wait |
| Wait | T+3min ~ T+8min | Let CLI retry API connection internally |
| Tier 2 | T+8min | Still silent → send `interrupt` |
| Tier 3 | T+10min | No response → `SIGKILL` + auto retry |

### Root cause analysis

Log analysis of a real incident revealed:
1. Claude API stream disconnected mid-response (after outputting partial text)
2. `wrapStdout()` logged the deltas in IO log, but normalizer returned `null` for all `content_block_delta` — `consumeStream` never updated `lastActivityAt`
3. `lastActivityAt` was stuck at `init` time (3.8s before the last delta), not at the last delta time
4. At T+5min, old code sent `interrupt` which killed CLI's internal retry attempt
5. At T+7min, force killed the process (exitCode 137)

## Test plan

- [x] Updated `gc-stall-detection.test.ts` covering all 3 tiers + dead process fast-path
- [ ] Manual: verify long text streaming (>3min) no longer triggers false stall detection
- [ ] Manual: verify API disconnect recovery within the 5min liveness grace window