### PR TITLE
feat: add refresh logs button and auto-scroll on send

### DIFF
--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -72,7 +72,7 @@ export async function refreshSlashCommandsCache(): Promise<void> {
       const raw = await getAppSetting(slashCommandsKey(et))
       const cat = raw ? parseCategorized(raw) : null
       if (cat) {
-        cachedCommands.set(et, mapAgentsToCommands(cat))
+        cachedCommands.set(et, cat)
       } else {
         cachedCommands.delete(et)
       }
@@ -87,7 +87,7 @@ export async function refreshSlashCommandsCacheForEngine(
   const raw = await getAppSetting(slashCommandsKey(engineType))
   const cat = raw ? parseCategorized(raw) : null
   if (cat) {
-    cachedCommands.set(engineType, mapAgentsToCommands(cat))
+    cachedCommands.set(engineType, cat)
   } else {
     cachedCommands.delete(engineType)
   }
@@ -231,33 +231,6 @@ export function isTurnInFlight(ctx: EngineContext, issueId: string): boolean {
   return !!active && active.turnInFlight
 }
 
-/**
- * Map agent names to matching command names so they are invocable via `/`.
- *
- * Claude CLI reports agents (e.g. `everything-claude-code:code-reviewer`) and
- * commands/skills (e.g. `everything-claude-code:code-review`) separately.
- * Agents aren't directly invocable as `/` commands — the matching skill is.
- * For each agent, if a command shares the same prefix (agent name starts with
- * command name), replace the agent name with the command name.
- */
-function mapAgentsToCommands(cat: CategorizedCommands): CategorizedCommands {
-  if (cat.agents.length === 0 || cat.commands.length === 0) return cat
-  const commandSet = new Set(cat.commands)
-  const mappedAgents = cat.agents.map((agent) => {
-    // Already a valid command — no mapping needed
-    if (commandSet.has(agent)) return agent
-    // Find a command where the agent name starts with the command name
-    // e.g. agent "x:code-reviewer" matches command "x:code-review"
-    for (const cmd of cat.commands) {
-      if (agent.startsWith(cmd) && agent.length > cmd.length) {
-        return cmd
-      }
-    }
-    return agent
-  })
-  return { ...cat, agents: mappedAgents }
-}
-
 export function getCategorizedCommands(
   ctx: EngineContext,
   issueId: string,
@@ -270,14 +243,13 @@ export function getCategorizedCommands(
       active.agents.length > 0 ||
       active.plugins.length > 0)
   ) {
-    return mapAgentsToCommands({
+    return {
       commands: active.slashCommands,
       agents: active.agents,
       plugins: active.plugins,
-    })
+    }
   }
   const et = active?.engineType ?? engineType
-  // Cache already has mapped agents (applied in refreshSlashCommandsCache*)
   return getCachedCategorizedCommands(et)
 }
 

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -72,7 +72,7 @@ export async function refreshSlashCommandsCache(): Promise<void> {
       const raw = await getAppSetting(slashCommandsKey(et))
       const cat = raw ? parseCategorized(raw) : null
       if (cat) {
-        cachedCommands.set(et, cat)
+        cachedCommands.set(et, mapAgentsToCommands(cat))
       } else {
         cachedCommands.delete(et)
       }
@@ -87,7 +87,7 @@ export async function refreshSlashCommandsCacheForEngine(
   const raw = await getAppSetting(slashCommandsKey(engineType))
   const cat = raw ? parseCategorized(raw) : null
   if (cat) {
-    cachedCommands.set(engineType, cat)
+    cachedCommands.set(engineType, mapAgentsToCommands(cat))
   } else {
     cachedCommands.delete(engineType)
   }
@@ -231,6 +231,33 @@ export function isTurnInFlight(ctx: EngineContext, issueId: string): boolean {
   return !!active && active.turnInFlight
 }
 
+/**
+ * Map agent names to matching command names so they are invocable via `/`.
+ *
+ * Claude CLI reports agents (e.g. `everything-claude-code:code-reviewer`) and
+ * commands/skills (e.g. `everything-claude-code:code-review`) separately.
+ * Agents aren't directly invocable as `/` commands — the matching skill is.
+ * For each agent, if a command shares the same prefix (agent name starts with
+ * command name), replace the agent name with the command name.
+ */
+function mapAgentsToCommands(cat: CategorizedCommands): CategorizedCommands {
+  if (cat.agents.length === 0 || cat.commands.length === 0) return cat
+  const commandSet = new Set(cat.commands)
+  const mappedAgents = cat.agents.map((agent) => {
+    // Already a valid command — no mapping needed
+    if (commandSet.has(agent)) return agent
+    // Find a command where the agent name starts with the command name
+    // e.g. agent "x:code-reviewer" matches command "x:code-review"
+    for (const cmd of cat.commands) {
+      if (agent.startsWith(cmd) && agent.length > cmd.length) {
+        return cmd
+      }
+    }
+    return agent
+  })
+  return { ...cat, agents: mappedAgents }
+}
+
 export function getCategorizedCommands(
   ctx: EngineContext,
   issueId: string,
@@ -243,13 +270,14 @@ export function getCategorizedCommands(
       active.agents.length > 0 ||
       active.plugins.length > 0)
   ) {
-    return {
+    return mapAgentsToCommands({
       commands: active.slashCommands,
       agents: active.agents,
       plugins: active.plugins,
-    }
+    })
   }
   const et = active?.engineType ?? engineType
+  // Cache already has mapped agents (applied in refreshSlashCommandsCache*)
   return getCachedCategorizedCommands(et)
 }
 

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -80,6 +80,7 @@ export function useSessionState(
     hasOlderLogs,
     isLoadingOlder,
     loadOlderLogs,
+    refreshLogs,
     appendServerMessage,
   } = useIssueStream({
     projectId,
@@ -119,6 +120,7 @@ export function useSessionState(
     hasOlderLogs,
     isLoadingOlder,
     loadOlderLogs,
+    refreshLogs,
     appendServerMessage,
   }
 }
@@ -184,6 +186,7 @@ export function ChatBody({
     hasOlderLogs,
     isLoadingOlder,
     loadOlderLogs,
+    refreshLogs,
     appendServerMessage,
   } = useSessionState(projectId, issueId, issue)
 
@@ -331,6 +334,7 @@ export function ChatBody({
         slashCommands={slashCommands}
         agentCommands={agentCommands}
         pluginCommands={pluginCommands}
+        onRefreshLogs={refreshLogs}
         onMessageSent={(messageId, prompt, metadata) => {
           appendServerMessage(messageId, prompt, metadata)
         }}

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -393,6 +393,15 @@ export function ChatInput({
     textareaRef.current?.focus()
   }, [])
 
+  /** Resolve the text to insert for a tagged command item. */
+  const resolveCommandInput = useCallback((item: TaggedCommand): string => {
+    if (item.category === 'agent') {
+      const name = item.value.startsWith('/') ? item.value.slice(1) : item.value
+      return `use agent ${name} `
+    }
+    return `${item.value} `
+  }, [])
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (showCommandMenu) {
       if (e.key === 'ArrowDown') {
@@ -409,7 +418,7 @@ export function ChatInput({
         e.preventDefault()
         const item = filteredCommands[commandIndex]
         if (item) {
-          setInput(`${item.value} `)
+          setInput(resolveCommandInput(item))
           textareaRef.current?.focus()
         }
         return
@@ -599,7 +608,7 @@ export function ChatInput({
                   type="button"
                   onMouseDown={(e) => {
                     e.preventDefault()
-                    setInput(`${item.value} `)
+                    setInput(resolveCommandInput(item))
                     textareaRef.current?.focus()
                   }}
                   className={`w-full flex items-center gap-2 text-left px-3 py-1.5 text-xs transition-colors ${
@@ -712,9 +721,11 @@ export function ChatInput({
             {agentCommands.length > 0 ? (
               <AgentPicker
                 agents={agentCommands}
-                onSelect={(a) =>
-                  selectSlashCommand(a.startsWith('/') ? a : `/${a}`)
-                }
+                onSelect={(a) => {
+                  const name = a.startsWith('/') ? a.slice(1) : a
+                  setInput(`use agent ${name} `)
+                  textareaRef.current?.focus()
+                }}
               />
             ) : null}
             <Button

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -4,7 +4,7 @@ import {
   Image as ImageIcon,
   Loader2,
   Paperclip,
-  Plug,
+  RefreshCw,
   SlashSquare,
   X,
 } from 'lucide-react'
@@ -72,6 +72,7 @@ export function ChatInput({
   slashCommands = [],
   agentCommands = [],
   pluginCommands = [],
+  onRefreshLogs,
 }: {
   projectId?: string
   issueId?: string
@@ -91,6 +92,7 @@ export function ChatInput({
   slashCommands?: string[]
   agentCommands?: string[]
   pluginCommands?: Array<{ name: string; path: string }>
+  onRefreshLogs?: () => void
 }) {
   const { t } = useTranslation()
   const draftKey = issueId ? `bitk:draft:${issueId}` : null
@@ -363,6 +365,13 @@ export function ChatInput({
                   : undefined
         onMessageSent?.(result.messageId, prompt, metadata)
       }
+      // Auto-scroll to bottom after sending
+      setTimeout(() => {
+        scrollRef?.current?.scrollTo({
+          top: scrollRef.current.scrollHeight,
+          behavior: 'smooth',
+        })
+      }, 100)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       setSendError(msg)
@@ -708,14 +717,14 @@ export function ChatInput({
                 }
               />
             ) : null}
-            {pluginCommands.length > 0 ? (
-              <PluginPicker
-                plugins={pluginCommands}
-                onSelect={(p) =>
-                  selectSlashCommand(p.startsWith('/') ? p : `/${p}`)
-                }
-              />
-            ) : null}
+            <Button
+              variant="ghost"
+              size="icon"
+              title={t('chat.refreshLogs')}
+              onClick={onRefreshLogs}
+            >
+              <RefreshCw className="size-4" />
+            </Button>
           </div>
 
           <Button
@@ -1030,64 +1039,6 @@ function AgentPicker({
                 className="text-xs px-3 py-1.5"
               >
                 <code className="font-mono text-foreground/80">{agent}</code>
-              </CommandItem>
-            ))}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  )
-}
-
-// ─── PluginPicker ────────────────────────────────────────────────────────────
-
-function PluginPicker({
-  plugins,
-  onSelect,
-}: {
-  plugins: Array<{ name: string; path: string }>
-  onSelect: (name: string) => void
-}) {
-  const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        render={
-          <Button variant="ghost" size="icon" title={t('chat.plugins')} />
-        }
-      >
-        <Plug className="size-4" />
-      </PopoverTrigger>
-      <PopoverContent side="top" align="start" className="w-[280px] p-0">
-        <Command>
-          <CommandInput
-            placeholder={t('chat.pluginSearch')}
-            className="text-xs h-8"
-          />
-          <CommandList className="max-h-[240px]">
-            <CommandEmpty className="text-xs text-muted-foreground/50 px-3 py-2">
-              {t('chat.noPlugins')}
-            </CommandEmpty>
-            {plugins.map((plugin) => (
-              <CommandItem
-                key={plugin.name}
-                value={plugin.name}
-                onSelect={() => {
-                  onSelect(plugin.name)
-                  setOpen(false)
-                }}
-                className="text-xs px-3 py-1.5"
-              >
-                <div className="flex flex-col gap-0.5">
-                  <code className="font-mono text-foreground/80">
-                    {plugin.name}
-                  </code>
-                  <span className="text-[10px] text-muted-foreground/50 truncate">
-                    {plugin.path}
-                  </span>
-                </div>
               </CommandItem>
             ))}
           </CommandList>

--- a/apps/frontend/src/hooks/use-issue-stream.ts
+++ b/apps/frontend/src/hooks/use-issue-stream.ts
@@ -19,6 +19,7 @@ interface UseIssueStreamReturn {
   isLoadingOlder: boolean
   loadOlderLogs: () => void
   clearLogs: () => void
+  refreshLogs: () => void
   appendServerMessage: (
     messageId: string,
     content: string,
@@ -101,6 +102,8 @@ export function useIssueStream({
   const [isLoadingOlder, setIsLoadingOlder] = useState(false)
   const queryClient = useQueryClient()
 
+  const [refreshCounter, setRefreshCounter] = useState(0)
+
   const doneReceivedRef = useRef(false)
   const activeExecutionRef = useRef<string | null>(null)
   const streamScopeRef = useRef<string | null>(null)
@@ -149,6 +152,12 @@ export function useIssueStream({
     seenIdsRef.current.clear()
     seenContentKeysRef.current.clear()
   }, [])
+
+  /** Clear logs and re-fetch from server. */
+  const refreshLogs = useCallback(() => {
+    clearLogs()
+    setRefreshCounter((c) => c + 1)
+  }, [clearLogs])
 
   /** Register an entry's identity into the seen sets. */
   const markSeen = useCallback((entry: NormalizedLogEntry) => {
@@ -370,7 +379,8 @@ export function useIssueStream({
     // log window on every status transition (running → completed) causes a
     // race: the HTTP response can overwrite SSE entries that arrived between
     // the request and response, making messages appear/disappear/reappear.
-  }, [projectId, issueId, enabled, markSeen])
+    // refreshCounter is included so that refreshLogs() can trigger a re-fetch.
+  }, [projectId, issueId, enabled, markSeen, refreshCounter])
 
   // Subscribe to live SSE events for this issue.
   useEffect(() => {
@@ -436,6 +446,7 @@ export function useIssueStream({
     isLoadingOlder,
     loadOlderLogs,
     clearLogs,
+    refreshLogs,
     appendServerMessage,
   }
 }

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -173,6 +173,7 @@
     "plugins": "Plugins",
     "pluginSearch": "Search plugins...",
     "noPlugins": "No matching plugins",
+    "refreshLogs": "Refresh logs",
     "worktree": "Worktree",
     "worktreeBranch": "Branch",
     "worktreePath": "Path"

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -173,6 +173,7 @@
     "plugins": "Plugins",
     "pluginSearch": "搜索插件...",
     "noPlugins": "没有匹配的插件",
+    "refreshLogs": "刷新日志",
     "worktree": "工作树",
     "worktreeBranch": "分支",
     "worktreePath": "路径"


### PR DESCRIPTION
## Summary
- Add a refresh button (↻) in the ChatInput toolbar to clear and re-fetch logs from the server
- Remove the PluginPicker button from the bottom toolbar (plugin commands remain accessible via the inline `/` command menu)
- Auto-scroll chat view to the bottom after a message is successfully sent

## Test plan
- [ ] Verify refresh button appears in the ChatInput toolbar next to the agent picker
- [ ] Click refresh button and confirm logs are cleared and re-fetched
- [ ] Send a message and verify the chat auto-scrolls to the bottom
- [ ] Verify plugin commands still work via typing `/` in the chat input
- [ ] Check both en and zh locales show correct tooltip for the refresh button