### PR TITLE
fix: diff panel shows directories instead of files

### DIFF
--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -125,7 +125,7 @@ function parsePorcelainLine(line: string): GitChangedFile | null {
 }
 
 async function listChangedFiles(cwd: string): Promise<GitChangedFile[]> {
-  const { code, stdout } = await runGit(['status', '--porcelain=v1'], cwd)
+  const { code, stdout } = await runGit(['status', '--porcelain=v1', '-uall'], cwd)
   if (code !== 0) return []
   return stdout
     .split('\n')


### PR DESCRIPTION
## Summary
- Add `-uall` flag to `git status --porcelain=v1` so untracked directories are expanded into individual files
- Fixes diff panel error when clicking on a directory entry

## Test plan
- [ ] Create untracked directory with files, verify diff panel lists individual files
- [ ] Click on listed files, verify patch loads correctly
- [ ] Verify tracked/staged files still display normally