### PR TITLE
feat: chat UI improvements — tree-style tools & Agent formatting

### DIFF
--- a/apps/api/src/engines/executors/claude/normalizer-tool.ts
+++ b/apps/api/src/engines/executors/claude/normalizer-tool.ts
@@ -44,6 +44,10 @@ export function generateToolContent(
       return String(input.query ?? toolName)
     case 'Task':
       return input.description ? `Task: ${input.description}` : 'Task'
+    case 'Agent':
+      return input.description
+        ? `Agent: ${input.description}`
+        : String(input.prompt ?? 'Agent')
     case 'TodoWrite':
       return 'TODO list updated'
     case 'ExitPlanMode':

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -3,6 +3,7 @@ import { basename, resolve } from 'node:path'
 import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { findProject, getAppSetting } from '@/db/helpers'
+import { WORKTREE_BASE } from '@/engines/issue/utils/worktree'
 
 interface FileEntry {
   name: string
@@ -57,6 +58,12 @@ async function getGitIgnoredNames(
   }
 }
 
+/** Check if `dir` is a valid worktree directory for the given project. */
+function isValidWorktreeRoot(dir: string, projectId: string): boolean {
+  const prefix = `${resolve(WORKTREE_BASE, projectId)}/`
+  return dir.startsWith(prefix)
+}
+
 /** Resolve project root + validate path is inside it. */
 async function resolveProjectPath(c: Context, relativePath: string) {
   const projectId = c.req.param('projectId') as string
@@ -75,18 +82,44 @@ async function resolveProjectPath(c: Context, relativePath: string) {
     }
   }
 
-  const root = resolve(project.directory)
+  // Determine root: use `root` query param if it's a valid worktree for this project
+  const rootOverride = c.req.query('root')
+  let root: string
 
-  // SEC: Validate project directory is within configured workspace root
-  const workspaceRoot = await getAppSetting('workspace:defaultPath')
-  if (workspaceRoot && workspaceRoot !== '/') {
-    const resolvedWs = resolve(workspaceRoot)
-    if (!root.startsWith(`${resolvedWs}/`) && root !== resolvedWs) {
+  if (rootOverride) {
+    const resolvedOverride = resolve(rootOverride)
+    if (
+      resolvedOverride === resolve(project.directory) ||
+      isValidWorktreeRoot(resolvedOverride, projectId)
+    ) {
+      root = resolvedOverride
+    } else {
       return {
         error: c.json(
-          { success: false, error: 'Project directory is outside workspace' },
+          {
+            success: false,
+            error: 'Root is not a valid project or worktree directory',
+          },
           403,
         ),
+      }
+    }
+  } else {
+    root = resolve(project.directory)
+  }
+
+  // SEC: Validate project directory is within configured workspace root
+  if (!rootOverride) {
+    const workspaceRoot = await getAppSetting('workspace:defaultPath')
+    if (workspaceRoot && workspaceRoot !== '/') {
+      const resolvedWs = resolve(workspaceRoot)
+      if (!root.startsWith(`${resolvedWs}/`) && root !== resolvedWs) {
+        return {
+          error: c.json(
+            { success: false, error: 'Project directory is outside workspace' },
+            403,
+          ),
+        }
       }
     }
   }

--- a/apps/frontend/src/components/files/FileBrowserDrawer.tsx
+++ b/apps/frontend/src/components/files/FileBrowserDrawer.tsx
@@ -31,6 +31,7 @@ export function FileBrowserDrawer() {
     isFullscreen,
     width,
     projectId,
+    rootPath,
     currentPath,
     hideIgnored,
     close,
@@ -59,12 +60,12 @@ export function FileBrowserDrawer() {
 
   const handleDownload = useCallback(() => {
     if (!projectId || currentPath === '.') return
-    const url = kanbanApi.rawFileUrl(projectId, currentPath)
+    const url = kanbanApi.rawFileUrl(projectId, currentPath, rootPath)
     const a = document.createElement('a')
     a.href = url
     a.download = ''
     a.click()
-  }, [projectId, currentPath])
+  }, [projectId, currentPath, rootPath])
 
   const { data: project } = useProject(projectId ?? '')
   const {
@@ -159,6 +160,7 @@ export function FileBrowserDrawer() {
             <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
             <span className="text-xs font-medium text-muted-foreground truncate">
               {project?.name ?? t('fileBrowser.title')}
+              {rootPath ? ` (${rootPath.split('/').pop()})` : ''}
             </span>
           </div>
           <div className="flex items-center gap-1">

--- a/apps/frontend/src/components/issue-detail/ChatArea.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatArea.tsx
@@ -1,22 +1,9 @@
 import { ArrowLeft, Check, Link, Plus, Sparkles } from 'lucide-react'
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import {
-  useAutoTitleIssue,
-  useIssue,
-  useProjectWorktrees,
-  useUpdateIssue,
-} from '@/hooks/use-kanban'
+import { useAutoTitleIssue, useIssue, useUpdateIssue } from '@/hooks/use-kanban'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { getIssueUrl } from '@/stores/server-store'
 import { ChatBody } from './ChatBody'
@@ -59,15 +46,6 @@ export function ChatArea({
   const updateIssue = useUpdateIssue(projectId)
   const autoTitle = useAutoTitleIssue(projectId)
   const [isAutoTitling, setIsAutoTitling] = useState(false)
-
-  // Resolve worktree path for file browser
-  const { data: worktrees } = useProjectWorktrees(
-    issue?.useWorktree ? projectId : '',
-  )
-  const worktreePath = useMemo(
-    () => worktrees?.find((w) => w.issueId === issueId)?.path ?? '',
-    [worktrees, issueId],
-  )
   const titleBeforeAutoRef = useRef<string | null>(null)
 
   // Detect title change to clear auto-titling state
@@ -295,7 +273,6 @@ export function ChatArea({
                 onWidthChange={onDiffWidthChange}
                 onClose={onCloseDiff}
                 fullScreen
-                worktreePath={worktreePath}
               />
             </Suspense>
           </div>
@@ -313,7 +290,6 @@ export function ChatArea({
               width={diffWidth}
               onWidthChange={onDiffWidthChange}
               onClose={onCloseDiff}
-              worktreePath={worktreePath}
             />
           </Suspense>
         )

--- a/apps/frontend/src/components/issue-detail/ChatArea.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatArea.tsx
@@ -1,9 +1,22 @@
 import { ArrowLeft, Check, Link, Plus, Sparkles } from 'lucide-react'
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { useAutoTitleIssue, useIssue, useUpdateIssue } from '@/hooks/use-kanban'
+import {
+  useAutoTitleIssue,
+  useIssue,
+  useProjectWorktrees,
+  useUpdateIssue,
+} from '@/hooks/use-kanban'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { getIssueUrl } from '@/stores/server-store'
 import { ChatBody } from './ChatBody'
@@ -46,6 +59,15 @@ export function ChatArea({
   const updateIssue = useUpdateIssue(projectId)
   const autoTitle = useAutoTitleIssue(projectId)
   const [isAutoTitling, setIsAutoTitling] = useState(false)
+
+  // Resolve worktree path for file browser
+  const { data: worktrees } = useProjectWorktrees(
+    issue?.useWorktree ? projectId : '',
+  )
+  const worktreePath = useMemo(
+    () => worktrees?.find((w) => w.issueId === issueId)?.path ?? '',
+    [worktrees, issueId],
+  )
   const titleBeforeAutoRef = useRef<string | null>(null)
 
   // Detect title change to clear auto-titling state
@@ -273,6 +295,7 @@ export function ChatArea({
                 onWidthChange={onDiffWidthChange}
                 onClose={onCloseDiff}
                 fullScreen
+                worktreePath={worktreePath}
               />
             </Suspense>
           </div>
@@ -290,6 +313,7 @@ export function ChatArea({
               width={diffWidth}
               onWidthChange={onDiffWidthChange}
               onClose={onCloseDiff}
+              worktreePath={worktreePath}
             />
           </Suspense>
         )

--- a/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
+++ b/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
@@ -1,0 +1,207 @@
+import DOMPurify from 'dompurify'
+import { lazy, Suspense, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/use-theme'
+import { codeToHtml } from '@/lib/shiki'
+
+const LazyMultiFileDiff = lazy(() =>
+  import('@pierre/diffs/react').then((m) => ({ default: m.MultiFileDiff })),
+)
+
+// ── Shared helpers ───────────────────────────────────────
+
+export function stringifyPretty(input: unknown): string {
+  if (input == null) return ''
+  if (typeof input === 'string') return input
+  try {
+    return JSON.stringify(input, null, 2)
+  } catch {
+    return String(input)
+  }
+}
+
+export interface ParsedFileToolInput {
+  filePath?: string
+  content?: string
+  oldString?: string
+  newString?: string
+  hasOnlyFilePath: boolean
+  raw: string
+}
+
+export function parseFileToolInput(input: unknown): ParsedFileToolInput {
+  const raw = stringifyPretty(input)
+  if (!input || typeof input !== 'object') {
+    return { hasOnlyFilePath: false, raw }
+  }
+  const obj = input as Record<string, unknown>
+  const keys = Object.keys(obj)
+  const hasOnlyFilePath = keys.length === 1 && keys[0] === 'file_path'
+  return {
+    filePath: typeof obj.file_path === 'string' ? obj.file_path : undefined,
+    content: typeof obj.content === 'string' ? obj.content : undefined,
+    oldString: typeof obj.old_string === 'string' ? obj.old_string : undefined,
+    newString: typeof obj.new_string === 'string' ? obj.new_string : undefined,
+    hasOnlyFilePath,
+    raw,
+  }
+}
+
+export function detectCodeLanguage(filePath?: string): string {
+  if (!filePath) return 'text'
+  const p = filePath.toLowerCase()
+  if (p.endsWith('.json')) return 'json'
+  if (p.endsWith('.ts')) return 'typescript'
+  if (p.endsWith('.tsx')) return 'tsx'
+  if (p.endsWith('.js')) return 'javascript'
+  if (p.endsWith('.jsx')) return 'jsx'
+  if (p.endsWith('.md') || p.endsWith('.markdown')) return 'markdown'
+  if (p.endsWith('.html') || p.endsWith('.htm')) return 'html'
+  if (p.endsWith('.css')) return 'css'
+  if (p.endsWith('.py')) return 'python'
+  if (p.endsWith('.sql')) return 'sql'
+  if (p.endsWith('.yaml') || p.endsWith('.yml')) return 'yaml'
+  if (p.endsWith('.xml')) return 'xml'
+  if (p.endsWith('.go')) return 'go'
+  if (p.endsWith('.rs')) return 'rust'
+  if (p.endsWith('.sh') || p.endsWith('.bash') || p.endsWith('.zsh'))
+    return 'shell'
+  if (p.endsWith('.toml')) return 'toml'
+  if (p.endsWith('.dockerfile') || p.includes('Dockerfile')) return 'dockerfile'
+  return 'text'
+}
+
+// ── Code rendering components ────────────────────────────
+
+export function ShikiCodeBlock({
+  content,
+  language = 'text',
+  maxHeightClass,
+}: {
+  content: string
+  language?: string
+  maxHeightClass: string
+}) {
+  const [html, setHtml] = useState<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    void codeToHtml(content, language).then((h) => {
+      if (!cancelled) setHtml(h)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [content, language])
+
+  if (!html) {
+    return (
+      <pre
+        className={`code-surface ${maxHeightClass} overflow-auto rounded-md p-2 text-[12px] leading-[1.45] font-mono`}
+      >
+        {content}
+      </pre>
+    )
+  }
+
+  return (
+    <div
+      className={`code-surface shiki-block ${maxHeightClass} overflow-auto rounded-md`}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: content is sanitized via DOMPurify.sanitize()
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
+    />
+  )
+}
+
+export function CodeBlock({
+  content,
+  language = 'text',
+  collapsible = false,
+}: {
+  content: string
+  language?: string
+  collapsible?: boolean
+}) {
+  const value = content || '(empty)'
+  const maxHeightClass = collapsible ? 'max-h-64' : 'max-h-80'
+  return (
+    <ShikiCodeBlock
+      content={value}
+      language={language}
+      maxHeightClass={maxHeightClass}
+    />
+  )
+}
+
+export function ShikiUnifiedDiff({
+  original,
+  modified,
+  filePath,
+}: {
+  original: string
+  modified: string
+  filePath?: string
+}) {
+  const { t } = useTranslation()
+  const { resolved } = useTheme()
+  const themeType = resolved === 'dark' ? 'dark' : 'light'
+  const name = filePath ?? 'file'
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-border/40">
+      <Suspense
+        fallback={
+          <div className="px-2.5 py-2 text-[11px] text-muted-foreground">
+            {t('common.loading')}
+          </div>
+        }
+      >
+        <LazyMultiFileDiff
+          oldFile={{ name, contents: original }}
+          newFile={{ name, contents: modified }}
+          options={{
+            diffStyle: 'unified',
+            diffIndicators: 'bars',
+            expandUnchanged: false,
+            hunkSeparators: 'line-info',
+            disableLineNumbers: false,
+            overflow: 'wrap',
+            theme: {
+              light: 'github-light-default',
+              dark: 'github-dark-default',
+            },
+            themeType,
+            disableFileHeader: true,
+          }}
+        />
+      </Suspense>
+    </div>
+  )
+}
+
+export function ToolPanel({
+  summary,
+  children,
+  collapsible = false,
+}: {
+  summary: React.ReactNode
+  children: React.ReactNode
+  collapsible?: boolean
+}) {
+  if (collapsible) {
+    return (
+      <details className="group/panel transition-all duration-200">
+        <summary className="cursor-pointer list-none py-0.5 transition-colors hover:bg-muted/10 rounded">
+          {summary}
+        </summary>
+        <div className="pt-1 pb-0.5 pl-5">{children}</div>
+      </details>
+    )
+  }
+  return (
+    <div>
+      <div className="py-0.5">{summary}</div>
+      <div className="pt-1 pb-0.5 pl-5">{children}</div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/issue-detail/DiffPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/DiffPanel.tsx
@@ -1,8 +1,9 @@
-import { ChevronRight, Copy, X } from 'lucide-react'
+import { ChevronRight, Copy, FolderOpen, X } from 'lucide-react'
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useIssueChanges, useIssueFilePatch } from '@/hooks/use-kanban'
 import { useTheme } from '@/hooks/use-theme'
+import { useFileBrowserStore } from '@/stores/file-browser-store'
 import type { IssueChangedFile } from '@/types/kanban'
 import { DIFF_MIN_WIDTH } from './diff-constants'
 
@@ -63,6 +64,7 @@ export function DiffPanel({
   onWidthChange,
   onClose,
   fullScreen,
+  worktreePath,
 }: {
   projectId: string
   issueId: string
@@ -70,10 +72,13 @@ export function DiffPanel({
   onWidthChange: (w: number) => void
   onClose: () => void
   fullScreen?: boolean
+  worktreePath?: string
 }) {
   const { t } = useTranslation()
   const changesQuery = useIssueChanges(projectId, issueId, true)
   const files = changesQuery.data?.files ?? []
+  const openFileBrowser = useFileBrowserStore((s) => s.open)
+  const navigateTo = useFileBrowserStore((s) => s.navigateTo)
 
   return (
     <div
@@ -91,6 +96,21 @@ export function DiffPanel({
       <div className="flex flex-col h-full min-h-0">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/60 shrink-0 min-h-[45px] bg-background/80 backdrop-blur-sm">
           <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                openFileBrowser(projectId)
+                if (worktreePath) navigateTo(worktreePath)
+              }}
+              className="flex items-center justify-center h-7 w-7 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-all duration-150"
+              title={
+                worktreePath
+                  ? `${t('diff.openFiles')}: ${worktreePath}`
+                  : t('diff.openFiles')
+              }
+            >
+              <FolderOpen className="h-4 w-4" />
+            </button>
             <span className="text-sm font-semibold tracking-tight">
               {t('diff.changes')}
             </span>

--- a/apps/frontend/src/components/issue-detail/DiffPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/DiffPanel.tsx
@@ -75,6 +75,7 @@ export function DiffPanel({
   const { t } = useTranslation()
   const changesQuery = useIssueChanges(projectId, issueId, true)
   const files = changesQuery.data?.files ?? []
+  const changesRoot = changesQuery.data?.root
   const openFileBrowser = useFileBrowserStore((s) => s.open)
 
   return (
@@ -95,7 +96,7 @@ export function DiffPanel({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={() => openFileBrowser(projectId)}
+              onClick={() => openFileBrowser(projectId, changesRoot)}
               className="flex items-center justify-center h-7 w-7 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-all duration-150"
               title={t('diff.openFiles')}
             >

--- a/apps/frontend/src/components/issue-detail/DiffPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/DiffPanel.tsx
@@ -64,7 +64,6 @@ export function DiffPanel({
   onWidthChange,
   onClose,
   fullScreen,
-  worktreePath,
 }: {
   projectId: string
   issueId: string
@@ -72,13 +71,11 @@ export function DiffPanel({
   onWidthChange: (w: number) => void
   onClose: () => void
   fullScreen?: boolean
-  worktreePath?: string
 }) {
   const { t } = useTranslation()
   const changesQuery = useIssueChanges(projectId, issueId, true)
   const files = changesQuery.data?.files ?? []
   const openFileBrowser = useFileBrowserStore((s) => s.open)
-  const navigateTo = useFileBrowserStore((s) => s.navigateTo)
 
   return (
     <div
@@ -98,16 +95,9 @@ export function DiffPanel({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={() => {
-                openFileBrowser(projectId)
-                if (worktreePath) navigateTo(worktreePath)
-              }}
+              onClick={() => openFileBrowser(projectId)}
               className="flex items-center justify-center h-7 w-7 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-all duration-150"
-              title={
-                worktreePath
-                  ? `${t('diff.openFiles')}: ${worktreePath}`
-                  : t('diff.openFiles')
-              }
+              title={t('diff.openFiles')}
             >
               <FolderOpen className="h-4 w-4" />
             </button>

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -118,7 +118,7 @@ function StickyTaskPlan({ message }: { message: TaskPlanChatMessage }) {
         >
           <ListTodo className="h-3.5 w-3.5 shrink-0 text-indigo-500" />
           <span className="font-medium text-muted-foreground">
-            {t('session.taskPlan')}
+            {t('session.tool.taskPlan')}
           </span>
           <span className="text-muted-foreground/50">
             ({completedCount}/{todos.length})

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -1,450 +1,30 @@
 import type {
   ChatMessage,
   NormalizedLogEntry,
-  ToolGroupChatMessage,
-  ToolGroupItem,
+  TaskPlanChatMessage,
 } from '@bkd/shared'
-import DOMPurify from 'dompurify'
-import { ChevronRight, FileEdit, FileText, Wrench } from 'lucide-react'
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import {
+  CheckCircle2,
+  ChevronUp,
+  Circle,
+  ListTodo,
+  Loader2,
+} from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useChatMessages } from '@/hooks/use-chat-messages'
-import { useTheme } from '@/hooks/use-theme'
-import { getCommandPreview } from '@/lib/command-preview'
-import { codeToHtml } from '@/lib/shiki'
 import { useViewModeStore } from '@/stores/view-mode-store'
 import { LogEntry } from './LogEntry'
-
-const LazyMultiFileDiff = lazy(() =>
-  import('@pierre/diffs/react').then((m) => ({ default: m.MultiFileDiff })),
-)
-
-// ── Shared UI primitives ─────────────────────────────────
-
-function stringifyPretty(input: unknown): string {
-  if (input == null) return ''
-  if (typeof input === 'string') return input
-  try {
-    return JSON.stringify(input, null, 2)
-  } catch {
-    return String(input)
-  }
-}
-
-interface ParsedFileToolInput {
-  filePath?: string
-  content?: string
-  oldString?: string
-  newString?: string
-  hasOnlyFilePath: boolean
-  raw: string
-}
-
-function parseFileToolInput(input: unknown): ParsedFileToolInput {
-  const raw = stringifyPretty(input)
-  if (!input || typeof input !== 'object') {
-    return { hasOnlyFilePath: false, raw }
-  }
-  const obj = input as Record<string, unknown>
-  const keys = Object.keys(obj)
-  const hasOnlyFilePath = keys.length === 1 && keys[0] === 'file_path'
-  return {
-    filePath: typeof obj.file_path === 'string' ? obj.file_path : undefined,
-    content: typeof obj.content === 'string' ? obj.content : undefined,
-    oldString: typeof obj.old_string === 'string' ? obj.old_string : undefined,
-    newString: typeof obj.new_string === 'string' ? obj.new_string : undefined,
-    hasOnlyFilePath,
-    raw,
-  }
-}
-
-function detectCodeLanguage(filePath?: string): string {
-  if (!filePath) return 'text'
-  const p = filePath.toLowerCase()
-  if (p.endsWith('.json')) return 'json'
-  if (p.endsWith('.ts')) return 'typescript'
-  if (p.endsWith('.tsx')) return 'tsx'
-  if (p.endsWith('.js')) return 'javascript'
-  if (p.endsWith('.jsx')) return 'jsx'
-  if (p.endsWith('.md') || p.endsWith('.markdown')) return 'markdown'
-  if (p.endsWith('.html') || p.endsWith('.htm')) return 'html'
-  if (p.endsWith('.css')) return 'css'
-  if (p.endsWith('.py')) return 'python'
-  if (p.endsWith('.sql')) return 'sql'
-  if (p.endsWith('.yaml') || p.endsWith('.yml')) return 'yaml'
-  if (p.endsWith('.xml')) return 'xml'
-  if (p.endsWith('.go')) return 'go'
-  if (p.endsWith('.rs')) return 'rust'
-  if (p.endsWith('.sh') || p.endsWith('.bash') || p.endsWith('.zsh'))
-    return 'shell'
-  if (p.endsWith('.toml')) return 'toml'
-  if (p.endsWith('.dockerfile') || p.includes('Dockerfile')) return 'dockerfile'
-  return 'text'
-}
-
-function ShikiCodeBlock({
-  content,
-  language = 'text',
-  maxHeightClass,
-}: {
-  content: string
-  language?: string
-  maxHeightClass: string
-}) {
-  const [html, setHtml] = useState<string>('')
-
-  useEffect(() => {
-    let cancelled = false
-    void codeToHtml(content, language).then((h) => {
-      if (!cancelled) setHtml(h)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [content, language])
-
-  if (!html) {
-    return (
-      <pre
-        className={`code-surface ${maxHeightClass} overflow-auto rounded-md p-2 text-[12px] leading-[1.45] font-mono`}
-      >
-        {content}
-      </pre>
-    )
-  }
-
-  return (
-    <div
-      className={`code-surface shiki-block ${maxHeightClass} overflow-auto rounded-md`}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: content is sanitized via DOMPurify.sanitize()
-      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
-    />
-  )
-}
-
-function CodeBlock({
-  content,
-  language = 'text',
-  collapsible = false,
-}: {
-  content: string
-  language?: string
-  collapsible?: boolean
-}) {
-  const value = content || '(empty)'
-  const maxHeightClass = collapsible ? 'max-h-64' : 'max-h-80'
-  return (
-    <ShikiCodeBlock
-      content={value}
-      language={language}
-      maxHeightClass={maxHeightClass}
-    />
-  )
-}
-
-function ShikiUnifiedDiff({
-  original,
-  modified,
-  filePath,
-}: {
-  original: string
-  modified: string
-  filePath?: string
-}) {
-  const { t } = useTranslation()
-  const { resolved } = useTheme()
-  const themeType = resolved === 'dark' ? 'dark' : 'light'
-  const name = filePath ?? 'file'
-
-  return (
-    <div className="overflow-x-auto rounded-md border border-border/40">
-      <Suspense
-        fallback={
-          <div className="px-2.5 py-2 text-[11px] text-muted-foreground">
-            {t('common.loading')}
-          </div>
-        }
-      >
-        <LazyMultiFileDiff
-          oldFile={{ name, contents: original }}
-          newFile={{ name, contents: modified }}
-          options={{
-            diffStyle: 'unified',
-            diffIndicators: 'bars',
-            expandUnchanged: false,
-            hunkSeparators: 'line-info',
-            disableLineNumbers: false,
-            overflow: 'wrap',
-            theme: {
-              light: 'github-light-default',
-              dark: 'github-dark-default',
-            },
-            themeType,
-            disableFileHeader: true,
-          }}
-        />
-      </Suspense>
-    </div>
-  )
-}
-
-function ToolPanel({
-  summary,
-  children,
-  collapsible = false,
-}: {
-  summary: React.ReactNode
-  children: React.ReactNode
-  collapsible?: boolean
-}) {
-  if (collapsible) {
-    return (
-      <details className="group/panel rounded-lg border border-border/30 bg-muted/10 transition-all duration-200 open:bg-muted/20">
-        <summary className="cursor-pointer list-none px-2.5 py-1.5 transition-colors hover:bg-muted/20">
-          {summary}
-        </summary>
-        <div className="px-2.5 pb-2.5 pt-1.5 border-t border-border/20">
-          {children}
-        </div>
-      </details>
-    )
-  }
-  return (
-    <div className="rounded-lg border border-border/30 bg-muted/10">
-      <div className="px-2.5 py-1.5">{summary}</div>
-      <div className="px-2.5 pb-2.5 pt-1.5 border-t border-border/20">
-        {children}
-      </div>
-    </div>
-  )
-}
-
-// ── Single tool item renderers ───────────────────────────
-
-function FileToolItem({ item }: { item: ToolGroupItem }) {
-  const actionEntry = item.action
-  const tool = actionEntry.toolAction
-  const isEdit = tool?.kind === 'file-edit'
-  const toolName =
-    typeof actionEntry.metadata?.toolName === 'string'
-      ? actionEntry.metadata.toolName
-      : undefined
-  const isWrite = toolName === 'Write'
-  const filePath = tool && 'path' in tool ? tool.path : 'unknown'
-  const codeLanguage = detectCodeLanguage(filePath)
-  const parsed = parseFileToolInput(actionEntry.metadata?.input)
-  const hasContent = parsed.content !== undefined
-  const hasOldString = parsed.oldString !== undefined
-  const hasNewString = parsed.newString !== undefined
-
-  if (!isEdit) {
-    return (
-      <div className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground">
-        <FileText className="h-3 w-3 shrink-0 text-blue-500" />
-        <span className="font-mono truncate">File Read: {filePath}</span>
-      </div>
-    )
-  }
-
-  return (
-    <ToolPanel
-      collapsible
-      summary={
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <FileEdit className="h-3.5 w-3.5 shrink-0 text-amber-500" />
-          <span className="font-mono truncate">
-            {isWrite ? 'File Write' : 'File Edit'}: {filePath}
-          </span>
-        </div>
-      }
-    >
-      <div className="space-y-2">
-        {hasContent ? (
-          <CodeBlock
-            content={parsed.content!}
-            language={codeLanguage}
-            collapsible={false}
-          />
-        ) : null}
-
-        {hasOldString ? (
-          hasNewString ? (
-            <ShikiUnifiedDiff
-              original={parsed.oldString || ''}
-              modified={parsed.newString || ''}
-              filePath={filePath}
-            />
-          ) : (
-            <CodeBlock
-              content={parsed.oldString || ''}
-              language={codeLanguage}
-              collapsible={false}
-            />
-          )
-        ) : null}
-
-        {!hasOldString && hasNewString ? (
-          <CodeBlock
-            content={parsed.newString || ''}
-            language={codeLanguage}
-            collapsible={false}
-          />
-        ) : null}
-
-        {!hasContent &&
-        !hasOldString &&
-        !hasNewString &&
-        !parsed.hasOnlyFilePath ? (
-          <CodeBlock
-            content={parsed.raw || '(empty)'}
-            language="json"
-            collapsible={false}
-          />
-        ) : null}
-      </div>
-    </ToolPanel>
-  )
-}
-
-function CommandToolItem({ item }: { item: ToolGroupItem }) {
-  const { t } = useTranslation()
-  const fullCommand =
-    item.action.toolAction?.kind === 'command-run'
-      ? item.action.toolAction.command
-      : ''
-  const isTruncatedInTitle = getCommandPreview(fullCommand, 90).isTruncated
-  const showFullCommand = isTruncatedInTitle || fullCommand.includes('\n')
-
-  return (
-    <ToolPanel
-      collapsible
-      summary={<LogEntry entry={item.action} inToolGroup />}
-    >
-      <div className="space-y-2">
-        {showFullCommand ? (
-          <div className="rounded-md border border-border/30 bg-muted/10 p-2 space-y-1">
-            <div className="px-0.5 text-[11px] text-muted-foreground">
-              {t('session.tool.fullCommand')}
-            </div>
-            <CodeBlock
-              content={fullCommand}
-              language="shell"
-              collapsible={false}
-            />
-          </div>
-        ) : null}
-        <CodeBlock
-          content={item.result?.content || item.action.content || '(empty)'}
-          collapsible={false}
-        />
-      </div>
-    </ToolPanel>
-  )
-}
-
-function GenericToolItem({ item }: { item: ToolGroupItem }) {
-  return (
-    <ToolPanel
-      collapsible
-      summary={<LogEntry entry={item.action} inToolGroup />}
-    >
-      <CodeBlock
-        content={item.result?.content || item.action.content || '(empty)'}
-        collapsible={false}
-      />
-    </ToolPanel>
-  )
-}
-
-// ── ToolGroupMessage — collapsible group of tool calls ───
-
-function getGroupSummaryLabel(
-  stats: Record<string, number>,
-  count: number,
-  t: (key: string) => string,
-): string {
-  const parts: string[] = []
-  if (stats['file-read'])
-    parts.push(`${stats['file-read']} ${t('session.tool.fileRead')}`)
-  if (stats['file-edit'])
-    parts.push(`${stats['file-edit']} ${t('session.tool.fileEdit')}`)
-  if (stats['command-run'])
-    parts.push(`${stats['command-run']} ${t('session.tool.commandRun')}`)
-  if (stats.search) parts.push(`${stats.search} ${t('session.tool.search')}`)
-  if (stats['web-fetch'])
-    parts.push(`${stats['web-fetch']} ${t('session.tool.webFetch')}`)
-  const otherCount =
-    count - Object.values(stats).reduce((a, b) => a + b, 0) + (stats.other ?? 0)
-  if (otherCount > 0) parts.push(`${otherCount} other`)
-  return parts.length > 0 ? parts.join(', ') : `${count} tool calls`
-}
-
-function ToolGroupMessage({ message }: { message: ToolGroupChatMessage }) {
-  const { t } = useTranslation()
-  const [expanded, setExpanded] = useState(false)
-  const { items, stats, count } = message
-  const summaryLabel = getGroupSummaryLabel(stats, count, t)
-
-  return (
-    <div className="py-0.5 animate-message-enter">
-      <div className="rounded-lg border border-border/30 bg-muted/10">
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/20"
-        >
-          <ChevronRight
-            className={`h-3 w-3 shrink-0 transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`}
-          />
-          <Wrench className="h-3 w-3 shrink-0" />
-          <span className="truncate">{summaryLabel}</span>
-          <span className="ml-auto text-[10px] text-muted-foreground/50">
-            {count}
-          </span>
-        </button>
-        {expanded ? (
-          <div className="space-y-1 px-2.5 pb-2.5 pt-1 border-t border-border/20">
-            {items.map((item, idx) => {
-              const kind = item.action.toolAction?.kind
-              if (kind === 'file-edit' || kind === 'file-read') {
-                return (
-                  <FileToolItem
-                    key={item.action.messageId ?? `ti-${idx}`}
-                    item={item}
-                  />
-                )
-              }
-              if (kind === 'command-run') {
-                return (
-                  <CommandToolItem
-                    key={item.action.messageId ?? `ti-${idx}`}
-                    item={item}
-                  />
-                )
-              }
-              return (
-                <GenericToolItem
-                  key={item.action.messageId ?? `ti-${idx}`}
-                  item={item}
-                />
-              )
-            })}
-          </div>
-        ) : null}
-      </div>
-    </div>
-  )
-}
+import { ToolGroupMessage } from './ToolItems'
 
 // ── ChatMessage renderer ─────────────────────────────────
 
 function ChatMessageRow({ message }: { message: ChatMessage }) {
   switch (message.type) {
     case 'user': {
-      // Command user-messages get special rendering
       if (message.status === 'command') {
         return (
-          <div key={message.id} className="group py-1.5 animate-message-enter">
+          <div className="group py-1.5 animate-message-enter">
             <details className="rounded-lg border border-border/30 bg-muted/10 transition-all duration-200 open:bg-muted/20">
               <summary className="cursor-pointer list-none px-3 py-2 text-xs text-muted-foreground hover:bg-muted/20 transition-colors">
                 <code className="font-mono text-foreground/70">
@@ -462,36 +42,99 @@ function ChatMessageRow({ message }: { message: ChatMessage }) {
           </div>
         )
       }
-      return <LogEntry key={message.id} entry={message.entry} />
+      return <LogEntry entry={message.entry} />
     }
 
     case 'assistant':
-      return (
-        <LogEntry
-          key={message.id}
-          entry={message.entry}
-          durationMs={message.durationMs}
-        />
-      )
+      return <LogEntry entry={message.entry} durationMs={message.durationMs} />
 
     case 'tool-group':
-      return <ToolGroupMessage key={message.id} message={message} />
+      return <ToolGroupMessage message={message} />
 
     case 'task-plan':
-      return <LogEntry key={message.id} entry={message.entry} />
+      return null
 
     case 'thinking':
-      return <LogEntry key={message.id} entry={message.entry} />
-
     case 'system':
-      return <LogEntry key={message.id} entry={message.entry} />
-
     case 'error':
-      return <LogEntry key={message.id} entry={message.entry} />
+      return <LogEntry entry={message.entry} />
 
     default:
       return null
   }
+}
+
+// ── Sticky Task Plan Status Bar ──────────────────────────
+
+function StickyTaskPlan({ message }: { message: TaskPlanChatMessage }) {
+  const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
+  const { todos, completedCount } = message
+
+  const inProgressItem = todos.find((it) => it.status === 'in_progress')
+  const statusText = inProgressItem
+    ? inProgressItem.activeForm || inProgressItem.content
+    : null
+
+  return (
+    <div className="sticky bottom-0 z-10 animate-message-enter">
+      <div className="rounded-lg border border-border/40 bg-background/95 backdrop-blur-sm shadow-sm">
+        {/* Expandable detail panel — opens upward */}
+        {expanded ? (
+          <div className="px-3 pt-2 pb-1 space-y-0.5 border-b border-border/20">
+            {todos.map((item, idx) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: todos do not reorder independently within a plan snapshot; content is not unique
+              <div key={idx} className="flex items-start gap-1.5 text-xs">
+                {item.status === 'completed' ? (
+                  <CheckCircle2 className="h-3 w-3 shrink-0 text-emerald-500 mt-0.5" />
+                ) : item.status === 'in_progress' ? (
+                  <Loader2 className="h-3 w-3 shrink-0 text-blue-500 animate-spin mt-0.5" />
+                ) : (
+                  <Circle className="h-3 w-3 shrink-0 text-muted-foreground/40 mt-0.5" />
+                )}
+                <span
+                  className={
+                    item.status === 'completed'
+                      ? 'text-muted-foreground/60 line-through'
+                      : item.status === 'in_progress'
+                        ? 'text-blue-600 dark:text-blue-400'
+                        : ''
+                  }
+                >
+                  {item.status === 'in_progress'
+                    ? item.activeForm || item.content
+                    : item.content}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Compact status bar */}
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex w-full items-center gap-2 px-3 py-2 text-xs transition-colors hover:bg-muted/20"
+        >
+          <ListTodo className="h-3.5 w-3.5 shrink-0 text-indigo-500" />
+          <span className="font-medium text-muted-foreground">
+            {t('session.taskPlan')}
+          </span>
+          <span className="text-muted-foreground/50">
+            ({completedCount}/{todos.length})
+          </span>
+          {statusText ? (
+            <span className="truncate text-blue-600 dark:text-blue-400">
+              {statusText}
+            </span>
+          ) : null}
+          <ChevronUp
+            className={`ml-auto h-3 w-3 shrink-0 text-muted-foreground/50 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+          />
+        </button>
+      </div>
+    </div>
+  )
 }
 
 // ── SessionMessages (main export) ────────────────────────
@@ -520,10 +163,18 @@ export function SessionMessages({
   const { t } = useTranslation()
   const fullWidthChat = useViewModeStore((s) => s.fullWidthChat)
 
-  // Transform flat entries → grouped ChatMessage[]
   const messages = useChatMessages(logs)
 
-  // Auto-scroll to bottom on new messages appended at the end.
+  const latestTaskPlan = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].type === 'task-plan') {
+        return messages[i] as TaskPlanChatMessage
+      }
+    }
+    return null
+  }, [messages])
+
+  // Auto-scroll to bottom on new messages
   const nearBottomRef = useRef(true)
   useEffect(() => {
     const el = scrollRef?.current
@@ -536,7 +187,6 @@ export function SessionMessages({
     return () => el.removeEventListener('scroll', handler)
   }, [scrollRef])
 
-  // Scroll to bottom on initial load
   const initialScrollDone = useRef(false)
   useEffect(() => {
     if (initialScrollDone.current || messages.length === 0) return
@@ -620,6 +270,9 @@ export function SessionMessages({
             </button>
           ) : null}
         </div>
+      ) : null}
+      {latestTaskPlan && latestTaskPlan.todos.length > 0 ? (
+        <StickyTaskPlan message={latestTaskPlan} />
       ) : null}
     </div>
   )

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -1,0 +1,458 @@
+import type { ToolGroupChatMessage, ToolGroupItem } from '@bkd/shared'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { getCommandPreview } from '@/lib/command-preview'
+import {
+  CodeBlock,
+  detectCodeLanguage,
+  parseFileToolInput,
+  ShikiUnifiedDiff,
+  ToolPanel,
+} from './CodeRenderers'
+
+function getItemToolName(item: ToolGroupItem): string | undefined {
+  return (
+    item.action.toolDetail?.toolName ??
+    (typeof item.action.metadata?.toolName === 'string'
+      ? item.action.metadata.toolName
+      : undefined)
+  )
+}
+
+function countLines(text: string | undefined | null): number | null {
+  if (!text) return null
+  return text.split('\n').length
+}
+
+/** Compute +added / -removed line counts from old/new strings. */
+function diffStats(
+  oldStr: string | undefined,
+  newStr: string | undefined,
+): { added: number; removed: number } | null {
+  if (oldStr === undefined && newStr === undefined) return null
+  const oldLines = oldStr ? oldStr.split('\n').length : 0
+  const newLines = newStr ? newStr.split('\n').length : 0
+  if (oldStr !== undefined && newStr !== undefined) {
+    // Edit with both old and new — approximate diff
+    return { added: newLines, removed: oldLines }
+  }
+  // Write (content only) — all additions
+  if (newStr !== undefined) return { added: newLines, removed: 0 }
+  return null
+}
+
+/** Badge component for file path */
+function PathBadge({ path }: { path: string }) {
+  return (
+    <code className="rounded bg-muted/50 px-1.5 py-0.5 text-[11px] font-mono truncate">
+      {path}
+    </code>
+  )
+}
+
+/** Diff stats display: +N -M */
+function DiffStatsLabel({
+  added,
+  removed,
+}: {
+  added: number
+  removed: number
+}) {
+  return (
+    <span className="flex items-center gap-1 text-[11px] shrink-0">
+      {added > 0 ? (
+        <span className="text-emerald-600 dark:text-emerald-400">+{added}</span>
+      ) : null}
+      {removed > 0 ? (
+        <span className="text-red-600 dark:text-red-400">-{removed}</span>
+      ) : null}
+    </span>
+  )
+}
+
+// ── Single tool item renderers ───────────────────────────
+
+export function FileToolItem({ item }: { item: ToolGroupItem }) {
+  const actionEntry = item.action
+  const tool = actionEntry.toolAction
+  const isEdit = tool?.kind === 'file-edit'
+  const toolName =
+    typeof actionEntry.metadata?.toolName === 'string'
+      ? actionEntry.metadata.toolName
+      : undefined
+  const isWrite = toolName === 'Write'
+  const filePath = tool && 'path' in tool ? tool.path : 'unknown'
+  const codeLanguage = detectCodeLanguage(filePath)
+  const parsed = parseFileToolInput(actionEntry.metadata?.input)
+  const hasContent = parsed.content !== undefined
+  const hasOldString = parsed.oldString !== undefined
+  const hasNewString = parsed.newString !== undefined
+
+  if (!isEdit) {
+    const resultContent = item.result?.content
+    const isResultError =
+      item.result?.toolDetail?.raw?.isError === true ||
+      item.result?.entryType === 'error-message'
+    const lineCount = countLines(resultContent)
+    const showResultText =
+      resultContent && (isResultError || (lineCount !== null && lineCount <= 3))
+
+    const summary = (
+      <div className="flex items-center gap-2 text-xs">
+        <span className="font-medium text-muted-foreground">Read</span>
+        <PathBadge path={filePath} />
+      </div>
+    )
+
+    if (showResultText) {
+      return (
+        <ToolPanel collapsible summary={summary}>
+          <div
+            className={`text-[11px] font-mono whitespace-pre-wrap ${isResultError ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground/60'}`}
+          >
+            {resultContent}
+          </div>
+        </ToolPanel>
+      )
+    }
+
+    return (
+      <div className="py-0.5">
+        {summary}
+        {lineCount ? (
+          <div className="ml-0.5 mt-0.5 text-[11px] text-muted-foreground/60">
+            Read {lineCount} lines
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+
+  // File edit / write
+  const stats = diffStats(parsed.oldString, parsed.newString ?? parsed.content)
+
+  return (
+    <ToolPanel
+      collapsible
+      summary={
+        <div className="flex items-center gap-2 text-xs">
+          <span className="font-medium text-muted-foreground">
+            {isWrite ? 'Write' : 'Edit'}
+          </span>
+          <PathBadge path={filePath} />
+          {stats ? (
+            <DiffStatsLabel added={stats.added} removed={stats.removed} />
+          ) : null}
+        </div>
+      }
+    >
+      <div className="space-y-2">
+        {hasContent ? (
+          <CodeBlock
+            content={parsed.content!}
+            language={codeLanguage}
+            collapsible={false}
+          />
+        ) : null}
+
+        {hasOldString ? (
+          hasNewString ? (
+            <ShikiUnifiedDiff
+              original={parsed.oldString || ''}
+              modified={parsed.newString || ''}
+              filePath={filePath}
+            />
+          ) : (
+            <CodeBlock
+              content={parsed.oldString || ''}
+              language={codeLanguage}
+              collapsible={false}
+            />
+          )
+        ) : null}
+
+        {!hasOldString && hasNewString ? (
+          <CodeBlock
+            content={parsed.newString || ''}
+            language={codeLanguage}
+            collapsible={false}
+          />
+        ) : null}
+
+        {!hasContent &&
+        !hasOldString &&
+        !hasNewString &&
+        !parsed.hasOnlyFilePath ? (
+          <CodeBlock
+            content={parsed.raw || '(empty)'}
+            language="json"
+            collapsible={false}
+          />
+        ) : null}
+      </div>
+    </ToolPanel>
+  )
+}
+
+export function CommandToolItem({ item }: { item: ToolGroupItem }) {
+  const { t } = useTranslation()
+  const fullCommand =
+    item.action.toolAction?.kind === 'command-run'
+      ? item.action.toolAction.command
+      : ''
+  const preview = getCommandPreview(fullCommand, 80)
+
+  return (
+    <ToolPanel
+      collapsible
+      summary={
+        <div className="flex items-center gap-2 text-xs">
+          <span className="font-medium text-muted-foreground">Bash</span>
+          <code className="rounded bg-muted/50 px-1.5 py-0.5 text-[11px] font-mono truncate">
+            {preview.summary}
+          </code>
+        </div>
+      }
+    >
+      <div className="space-y-2">
+        {preview.isTruncated || fullCommand.includes('\n') ? (
+          <div className="rounded-md border border-border/30 bg-muted/10 p-2 space-y-1">
+            <div className="px-0.5 text-[11px] text-muted-foreground">
+              {t('session.tool.fullCommand')}
+            </div>
+            <CodeBlock
+              content={fullCommand}
+              language="shell"
+              collapsible={false}
+            />
+          </div>
+        ) : null}
+        <CodeBlock
+          content={item.result?.content || item.action.content || '(empty)'}
+          collapsible={false}
+        />
+      </div>
+    </ToolPanel>
+  )
+}
+
+/** Strip internal system lines from agent result content. */
+function cleanAgentResult(raw: string): string {
+  return raw
+    .split('\n')
+    .filter((line) => {
+      if (line.startsWith('agentId:')) return false
+      if (line.includes('do not mention to user')) return false
+      if (line.startsWith('The agent is working in the background'))
+        return false
+      if (line.startsWith('You will be notified automatically')) return false
+      if (line.startsWith('Async agent launched successfully')) return false
+      return true
+    })
+    .join('\n')
+    .trim()
+}
+
+export function AgentToolItem({ item }: { item: ToolGroupItem }) {
+  const input = item.action.metadata?.input as
+    | { description?: string; prompt?: string }
+    | undefined
+  const description = input?.description || input?.prompt || 'Agent'
+  const rawContent = item.result?.content || item.action.content || ''
+  const resultContent = cleanAgentResult(rawContent)
+  const isResultError =
+    item.result?.toolDetail?.raw?.isError === true ||
+    item.result?.entryType === 'error-message'
+
+  return (
+    <ToolPanel
+      collapsible
+      summary={
+        <div className="flex items-center gap-2 text-xs">
+          <span className="font-medium text-muted-foreground">Agent</span>
+          <code className="rounded bg-muted/50 px-1.5 py-0.5 text-[11px] font-mono truncate">
+            {description}
+          </code>
+        </div>
+      }
+    >
+      {resultContent ? (
+        <pre
+          className={`text-[11px] whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto max-h-48 overflow-y-auto ${isResultError ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground/70'}`}
+        >
+          {resultContent}
+        </pre>
+      ) : null}
+    </ToolPanel>
+  )
+}
+
+export function SearchToolItem({ item }: { item: ToolGroupItem }) {
+  const tool = item.action.toolAction
+  const query = tool && 'query' in tool ? tool.query : ''
+  const toolName = getItemToolName(item)
+
+  return (
+    <ToolPanel
+      collapsible
+      summary={
+        <div className="flex items-center gap-2 text-xs">
+          <span className="font-medium text-muted-foreground">
+            {toolName || 'Search'}
+          </span>
+          <code className="rounded bg-muted/50 px-1.5 py-0.5 text-[11px] font-mono truncate">
+            {query}
+          </code>
+        </div>
+      }
+    >
+      <CodeBlock
+        content={item.result?.content || item.action.content || '(empty)'}
+        collapsible={false}
+      />
+    </ToolPanel>
+  )
+}
+
+export function GenericToolItem({ item }: { item: ToolGroupItem }) {
+  const toolName = getItemToolName(item)
+  return (
+    <ToolPanel
+      collapsible
+      summary={
+        <div className="flex items-center gap-2 text-xs">
+          <span className="font-medium text-muted-foreground">
+            {toolName || 'Tool'}
+          </span>
+          <span className="text-[11px] text-muted-foreground/60 truncate">
+            {item.action.content}
+          </span>
+        </div>
+      }
+    >
+      <CodeBlock
+        content={item.result?.content || item.action.content || '(empty)'}
+        collapsible={false}
+      />
+    </ToolPanel>
+  )
+}
+
+// ── ToolGroupMessage — collapsible group of tool calls ───
+
+function getGroupSummaryLabel(
+  stats: Record<string, number>,
+  count: number,
+  t: (key: string) => string,
+): string {
+  const parts: string[] = []
+  if (stats['file-read'])
+    parts.push(`${stats['file-read']} ${t('session.tool.fileRead')}`)
+  if (stats['file-edit'])
+    parts.push(`${stats['file-edit']} ${t('session.tool.fileEdit')}`)
+  if (stats['command-run'])
+    parts.push(`${stats['command-run']} ${t('session.tool.commandRun')}`)
+  if (stats.search) parts.push(`${stats.search} ${t('session.tool.search')}`)
+  if (stats['web-fetch'])
+    parts.push(`${stats['web-fetch']} ${t('session.tool.webFetch')}`)
+  const otherCount =
+    count - Object.values(stats).reduce((a, b) => a + b, 0) + (stats.other ?? 0)
+  if (otherCount > 0) parts.push(`${otherCount} other`)
+  return parts.length > 0 ? parts.join(', ') : `${count} tool calls`
+}
+
+const INITIAL_VISIBLE = 3
+
+function ToolItemRenderer({ item, idx }: { item: ToolGroupItem; idx: number }) {
+  const kind = item.action.toolAction?.kind
+  const toolName = getItemToolName(item)
+  if (toolName === 'Agent') {
+    return (
+      <AgentToolItem key={item.action.messageId ?? `ti-${idx}`} item={item} />
+    )
+  }
+  if (kind === 'file-edit' || kind === 'file-read') {
+    return (
+      <FileToolItem key={item.action.messageId ?? `ti-${idx}`} item={item} />
+    )
+  }
+  if (kind === 'command-run') {
+    return (
+      <CommandToolItem key={item.action.messageId ?? `ti-${idx}`} item={item} />
+    )
+  }
+  if (kind === 'search') {
+    return (
+      <SearchToolItem key={item.action.messageId ?? `ti-${idx}`} item={item} />
+    )
+  }
+  return (
+    <GenericToolItem key={item.action.messageId ?? `ti-${idx}`} item={item} />
+  )
+}
+
+export function ToolGroupMessage({
+  message,
+}: {
+  message: ToolGroupChatMessage
+}) {
+  const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
+  const [showAll, setShowAll] = useState(false)
+  const { items, stats, count, description } = message
+  const statsLabel = getGroupSummaryLabel(stats, count, t)
+  const hasMore = items.length > INITIAL_VISIBLE
+  const visibleItems =
+    expanded && !showAll && hasMore ? items.slice(0, INITIAL_VISIBLE) : items
+  const hiddenCount = items.length - INITIAL_VISIBLE
+
+  return (
+    <div className="py-0.5 animate-message-enter">
+      <div className="rounded-lg border border-border/30 bg-card/50">
+        {/* Header */}
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/20 rounded-lg"
+        >
+          {expanded ? (
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0" />
+          )}
+          <span className="truncate">{description || statsLabel}</span>
+          {description ? (
+            <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/50">
+              {statsLabel}
+            </span>
+          ) : null}
+        </button>
+
+        {/* Tree items */}
+        {expanded ? (
+          <div className="mx-3 mb-2 border-l border-border/40 pl-4 space-y-1">
+            {visibleItems.map((item, idx) => (
+              <ToolItemRenderer
+                key={item.action.messageId ?? `ti-${idx}`}
+                item={item}
+                idx={idx}
+              />
+            ))}
+            {hasMore ? (
+              <button
+                type="button"
+                onClick={() => setShowAll(!showAll)}
+                className="text-[11px] text-muted-foreground/60 hover:text-foreground transition-colors"
+              >
+                {showAll
+                  ? t('session.tool.showLess', 'Show less')
+                  : `Show ${hiddenCount} more`}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -462,19 +462,12 @@ function WorktreeToggle({
   value: boolean
   onChange: (v: boolean) => void
 }) {
-  const { t } = useTranslation()
-
   return (
     <div className="flex items-center gap-2 w-full">
       <Switch checked={value} onCheckedChange={onChange} className="shrink-0" />
-      <span
-        className={`text-sm ${value ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'}`}
-      >
-        <GitBranch
-          className={`inline h-3.5 w-3.5 mr-1 shrink-0 ${value ? 'text-emerald-500' : 'text-muted-foreground'}`}
-        />
-        {value ? t('createIssue.worktreeOn') : t('createIssue.worktreeOff')}
-      </span>
+      <GitBranch
+        className={`h-3.5 w-3.5 shrink-0 ${value ? 'text-emerald-500' : 'text-muted-foreground'}`}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -74,6 +74,10 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
 
   const messages: ChatMessage[] = []
   let toolBuffer: ToolGroupItem[] = []
+  // Deferred thinking entry — consumed by the next tool group as its description,
+  // or flushed as a standalone thinking message if no tool calls follow.
+  let pendingThinking: { content: string; entry: NormalizedLogEntry } | null =
+    null
 
   // Build turn → duration map from system-message metadata
   const turnDuration = new Map<number, number>()
@@ -122,7 +126,10 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
     }
   }
 
-  function buildToolGroup(items: ToolGroupItem[]): ToolGroupChatMessage {
+  function buildToolGroup(
+    items: ToolGroupItem[],
+    description?: string,
+  ): ToolGroupChatMessage {
     const stats: Record<string, number> = {}
     for (const item of items) {
       const kind =
@@ -136,7 +143,18 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       stats,
       count: items.length,
       hiddenCount: 0,
+      description,
     }
+  }
+
+  function flushPendingThinking(): void {
+    if (!pendingThinking) return
+    messages.push({
+      type: 'thinking',
+      id: entryId(pendingThinking.entry, nextId('th')),
+      entry: pendingThinking.entry,
+    } satisfies ThinkingChatMessage)
+    pendingThinking = null
   }
 
   function flushToolBuffer(): void {
@@ -151,6 +169,8 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       const lastTodo = todoItems[todoItems.length - 1]
       const todos = extractTodos(lastTodo.action)
       if (todos) {
+        // Thinking is not relevant for task-plan; flush it before
+        flushPendingThinking()
         messages.push({
           type: 'task-plan',
           id: entryId(lastTodo.action, nextId('tp')),
@@ -162,7 +182,13 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
     }
 
     if (nonTodoItems.length > 0) {
-      messages.push(buildToolGroup(nonTodoItems))
+      // Consume deferred thinking as tool group description
+      const desc = pendingThinking?.content
+      pendingThinking = null
+      messages.push(buildToolGroup(nonTodoItems, desc))
+    } else {
+      // No tool items consumed the thinking — flush it as standalone
+      flushPendingThinking()
     }
 
     toolBuffer = []
@@ -197,11 +223,12 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       continue
     }
 
-    // Non-tool entry → flush pending tool buffer
+    // Non-tool entry → flush pending tool buffer + any unconsumed thinking
     flushToolBuffer()
 
     switch (entry.entryType) {
       case 'user-message': {
+        flushPendingThinking()
         const metaType = entry.metadata?.type as string | undefined
         const attachments = (entry.metadata?.attachments ?? []) as Array<{
           id: string
@@ -236,6 +263,7 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       }
 
       case 'assistant-message':
+        flushPendingThinking()
         messages.push({
           type: 'assistant',
           id: entryId(entry, nextId('am')),
@@ -245,16 +273,25 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
         break
 
       case 'thinking':
-        messages.push({
-          type: 'thinking',
-          id: entryId(entry, nextId('th')),
-          entry,
-        } satisfies ThinkingChatMessage)
+        // Defer: if the next entries are tool calls, this becomes the tool group
+        // description; otherwise it will be flushed as a standalone thinking message
+        flushPendingThinking()
+        pendingThinking = entry.content
+          ? { content: entry.content, entry }
+          : null
+        if (!pendingThinking) {
+          messages.push({
+            type: 'thinking',
+            id: entryId(entry, nextId('th')),
+            entry,
+          } satisfies ThinkingChatMessage)
+        }
         break
 
       case 'system-message': {
         // Skip command_output entries consumed by command user-messages
         if (consumedOutputIdx.has(i)) break
+        flushPendingThinking()
         messages.push({
           type: 'system',
           id: entryId(entry, nextId('sys')),
@@ -265,6 +302,7 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       }
 
       case 'error-message':
+        flushPendingThinking()
         messages.push({
           type: 'error',
           id: entryId(entry, nextId('err')),
@@ -282,6 +320,7 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
   }
 
   flushToolBuffer()
+  flushPendingThinking()
   return messages
 }
 

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -165,12 +165,17 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       (item) => !isTodoWriteEntry(item.action),
     )
 
+    // Save thinking before task-plan flush so non-todo tools can still use it
+    const savedThinking = pendingThinking
+
     if (todoItems.length > 0) {
       const lastTodo = todoItems[todoItems.length - 1]
       const todos = extractTodos(lastTodo.action)
       if (todos) {
-        // Thinking is not relevant for task-plan; flush it before
-        flushPendingThinking()
+        if (nonTodoItems.length === 0) {
+          // No other tools to absorb thinking — flush it as standalone
+          flushPendingThinking()
+        }
         messages.push({
           type: 'task-plan',
           id: entryId(lastTodo.action, nextId('tp')),
@@ -183,10 +188,10 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
 
     if (nonTodoItems.length > 0) {
       // Consume deferred thinking as tool group description
-      const desc = pendingThinking?.content
+      const desc = savedThinking?.content
       pendingThinking = null
       messages.push(buildToolGroup(nonTodoItems, desc))
-    } else {
+    } else if (pendingThinking) {
       // No tool items consumed the thinking — flush it as standalone
       flushPendingThinking()
     }

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -34,8 +34,19 @@ export const queryKeys = {
     ['projects', projectId, 'issues', 'children', parentId] as const,
   slashCommands: (projectId: string, issueId: string) =>
     ['projects', projectId, 'issues', issueId, 'slash-commands'] as const,
-  projectFiles: (projectId: string, path: string, hideIgnored: boolean) =>
-    ['projects', projectId, 'files', path, { hideIgnored }] as const,
+  projectFiles: (
+    projectId: string,
+    path: string,
+    hideIgnored: boolean,
+    rootPath?: string | null,
+  ) =>
+    [
+      'projects',
+      projectId,
+      'files',
+      path,
+      { hideIgnored, rootPath: rootPath ?? null },
+    ] as const,
   projectProcesses: (projectId: string) =>
     ['projects', projectId, 'processes'] as const,
   projectWorktrees: (projectId: string) =>
@@ -720,10 +731,11 @@ export function useProjectFiles(
   enabled = true,
 ) {
   const hideIgnored = useFileBrowserStore((s) => s.hideIgnored)
+  const rootPath = useFileBrowserStore((s) => s.rootPath)
   return useQuery({
-    queryKey: queryKeys.projectFiles(projectId, path, hideIgnored),
+    queryKey: queryKeys.projectFiles(projectId, path, hideIgnored, rootPath),
     queryFn: () =>
-      kanbanApi.listFiles(projectId, path || undefined, hideIgnored),
+      kanbanApi.listFiles(projectId, path || undefined, hideIgnored, rootPath),
     enabled: !!projectId && enabled,
   })
 }

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -224,7 +224,8 @@
       "search": "Search",
       "webFetch": "Fetch URL",
       "taskPlan": "Task Plan",
-      "fullCommand": "Full Command"
+      "fullCommand": "Full Command",
+      "showLess": "Show less"
     },
     "restart": "Restart",
     "restarting": "Restarting...",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -188,6 +188,7 @@
     "emptyFile": "No file content available",
     "truncated": "Patch output is truncated",
     "copyPath": "Copy file path",
+    "openFiles": "Open file browser",
     "fileType": {
       "new": "New",
       "deleted": "Del",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -188,6 +188,7 @@
     "emptyFile": "该文件当前没有可显示的完整内容",
     "truncated": "补丁内容过长，已截断显示",
     "copyPath": "复制文件路径",
+    "openFiles": "打开文件管理器",
     "fileType": {
       "new": "新",
       "deleted": "删",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -224,7 +224,8 @@
       "search": "搜索",
       "webFetch": "获取 URL",
       "taskPlan": "任务计划",
-      "fullCommand": "完整命令"
+      "fullCommand": "完整命令",
+      "showLess": "收起"
     },
     "restart": "重启",
     "restarting": "重启中...",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -412,12 +412,20 @@ export const kanbanApi = {
     post<{ status: string }>('/api/settings/upgrade/restart', {}),
 
   // File Browser
-  listFiles: (projectId: string, path?: string, hideIgnored?: boolean) => {
+  listFiles: (
+    projectId: string,
+    path?: string,
+    hideIgnored?: boolean,
+    root?: string | null,
+  ) => {
     const encodedPath =
       path && path !== '.'
         ? `/${path.split('/').map(encodeURIComponent).join('/')}`
         : ''
-    const qs = hideIgnored ? '?hideIgnored=true' : ''
+    const params = new URLSearchParams()
+    if (hideIgnored) params.set('hideIgnored', 'true')
+    if (root) params.set('root', root)
+    const qs = params.toString() ? `?${params.toString()}` : ''
     return get<FileListingResult>(
       `/api/projects/${projectId}/files/show${encodedPath}${qs}`,
     )
@@ -433,9 +441,10 @@ export const kanbanApi = {
       {},
     ),
 
-  rawFileUrl: (projectId: string, path: string) => {
+  rawFileUrl: (projectId: string, path: string, root?: string | null) => {
     const encodedPath = path.split('/').map(encodeURIComponent).join('/')
-    return `/api/projects/${projectId}/files/raw/${encodedPath}`
+    const qs = root ? `?root=${encodeURIComponent(root)}` : ''
+    return `/api/projects/${projectId}/files/raw/${encodedPath}${qs}`
   },
 
   // Webhooks

--- a/apps/frontend/src/stores/file-browser-store.ts
+++ b/apps/frontend/src/stores/file-browser-store.ts
@@ -20,10 +20,11 @@ interface FileBrowserStore {
   isFullscreen: boolean
   width: number
   projectId: string | null
+  rootPath: string | null
   currentPath: string
   hideIgnored: boolean
-  open: (projectId: string) => void
-  openFullscreen: (projectId: string) => void
+  open: (projectId: string, rootPath?: string) => void
+  openFullscreen: (projectId: string, rootPath?: string) => void
   close: () => void
   toggle: (projectId: string) => void
   minimize: () => void
@@ -43,23 +44,32 @@ export const useFileBrowserStore = create<FileBrowserStore>((set) => ({
   isFullscreen: false,
   width: Math.round(getViewportWidth() * DEFAULT_WIDTH_RATIO),
   projectId: null,
+  rootPath: null,
   currentPath: '.',
   hideIgnored: false,
 
-  open: (projectId) =>
+  open: (projectId, rootPath) =>
     set((s) => ({
       isOpen: true,
       isMinimized: false,
       projectId,
-      currentPath: s.projectId === projectId ? s.currentPath : '.',
+      rootPath: rootPath ?? null,
+      currentPath:
+        s.projectId === projectId && s.rootPath === (rootPath ?? null)
+          ? s.currentPath
+          : '.',
     })),
-  openFullscreen: (projectId) =>
+  openFullscreen: (projectId, rootPath) =>
     set((s) => ({
       isOpen: true,
       isMinimized: false,
       isFullscreen: true,
       projectId,
-      currentPath: s.projectId === projectId ? s.currentPath : '.',
+      rootPath: rootPath ?? null,
+      currentPath:
+        s.projectId === projectId && s.rootPath === (rootPath ?? null)
+          ? s.currentPath
+          : '.',
     })),
   close: () => set({ isOpen: false }),
   toggle: (projectId) =>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 2026-03-08 20:25 [progress]
+
+CHAT-002: Code review 修复
+
+- **[HIGH] messages.pop() 脆弱变异** — 改为 `pendingThinking` 携带变量，thinking 入口延迟推送，flushToolBuffer 消费或独立 flush
+- **[MEDIUM] i18n 硬编码** — StickyTaskPlan 使用 `t('session.taskPlan')`
+- **[MEDIUM] 不稳定 key** — todo list key 从 `item.content` 改为 `idx`（items 不独立重排）
+- **[LOW] 空 todos 守卫** — `latestTaskPlan.todos.length > 0` 防止空状态栏
+
+## 2026-03-08 20:15 [progress]
+
+CHAT-002: Task Plan 状态栏 + ToolGroup "Show N more"
+
+- **Task Plan 状态栏** — 底部紧凑栏（显示 in_progress 项 + 进度），点击向上展开完整列表；SSE 实时更新通过已有 log 管道自动生效
+- **ToolGroup "Show N more"** — 展开时默认显示前 3 项，超出部分折叠为 "Show N more" 按钮
+
+## 2026-03-08 20:10 [progress]
+
+CHAT-002: 聊天 UI 4 项修复
+
+1. **File Read 显示行数** — `ToolItems.tsx` FileToolItem 从 result.content 计算行数，显示 "Read N lines"
+2. **ToolGroup 标题显示 thinking 描述** — `shared/index.ts` 增加 `description` 字段；`use-chat-messages.ts` flush 时吸收前一条 thinking 消息作为描述；`ToolItems.tsx` 优先显示 description
+3. **Agent 工具项渲染** — 新增 `AgentToolItem` 组件，显示 "Agent" + description 标签 + 可折叠 result 内容
+4. **Task Plan 固定底部** — `SessionMessages.tsx` 提取最新 task-plan，sticky bottom 渲染，不再内联显示
+
+Build + 28 前端测试 + lint 通过。
+
+## 2026-03-08 20:05 [progress]
+
+CHAT-002: SessionMessages.tsx 拆分（620 行 → 3 个文件）
+
+- `CodeRenderers.tsx` (~190 行) — stringifyPretty, parseFileToolInput, detectCodeLanguage, ShikiCodeBlock, CodeBlock, ShikiUnifiedDiff, ToolPanel
+- `ToolItems.tsx` (~210 行) — FileToolItem, CommandToolItem, GenericToolItem, ToolGroupMessage
+- `SessionMessages.tsx` (~160 行) — ChatMessageRow + SessionMessages 主导出
+
+纯文件拆分，无逻辑变更。Build + 28 前端测试 + lint 通过。
+
 ## 2026-03-08 17:30 [progress]
 
 CHAT-001 Phase 4 完成：回归验证 + 代码审查修复

--- a/docs/task/CHAT-002.md
+++ b/docs/task/CHAT-002.md
@@ -1,8 +1,8 @@
 # CHAT-002 聊天 UI 代码审查遗留项
 
-- **status**: pending
+- **status**: in_progress
 - **priority**: P2
-- **owner**: —
+- **owner**: claude
 - **createdAt**: 2026-03-08 18:00
 
 ## 来源
@@ -11,7 +11,7 @@ CHAT-001 `/simplify` + `/code-review` 审查发现的 MEDIUM/LOW 项，均非阻
 
 ## MEDIUM
 
-- [ ] **SessionMessages.tsx 620 行应拆分** — 提取 `CodeRenderers.tsx`（ShikiCodeBlock/CodeBlock/ShikiUnifiedDiff/ToolPanel）和 `ToolItems.tsx`（FileToolItem/CommandToolItem/GenericToolItem/ToolGroupMessage），SessionMessages 仅保留 ChatMessageRow + 导出
+- [x] **SessionMessages.tsx 620 行应拆分** — 提取 `CodeRenderers.tsx`（ShikiCodeBlock/CodeBlock/ShikiUnifiedDiff/ToolPanel）和 `ToolItems.tsx`（FileToolItem/CommandToolItem/GenericToolItem/ToolGroupMessage），SessionMessages 仅保留 ChatMessageRow + 导出
 - [ ] **前后端 rebuilder 逻辑分歧** — 前端 `use-chat-messages.ts` 有 commandOutput 配对和 slash-command 索引，后端 `message-rebuilder.ts` 缺失；前端 `buildToolGroup` 不应用 write-filter。需明确哪端为权威实现，或统一到 `@bkd/shared`
 - [ ] **queries.ts 无条件批量 tool join** — 非 devMode 下 tool-use 行被 SQL 过滤，批量 join 结果为空属浪费。可加 `rows.some(r => r.entryType === 'tool-use')` 守卫
 - [ ] **ExecutionStore 构造函数 63 行** — 提取 `initSchema()` + `prepareStatements()` 私有方法

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -9,7 +9,7 @@
 ## Chat UI
 
 - [x] **CHAT-001 聊天界面 UI 优化（对标 Claude Code）** `P1` - owner: claude - file: `docs/task/CHAT-001.md`
-- [ ] **CHAT-002 聊天 UI 代码审查遗留项** `P2` - owner: — - file: `docs/task/CHAT-002.md`
+- [-] **CHAT-002 聊天 UI 代码审查遗留项** `P2` - owner: claude - file: `docs/task/CHAT-002.md`
 
 ## Feature
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "bun --parallel --filter '*' test",
     "test:api": "bun --filter @bkd/api test",
     "test:frontend": "bun --filter @bkd/frontend test",
-    "lint": "biome check .",
+    "lint": "ulimit -c 0 && biome check .",
     "lint:fix": "biome check . --fix",
     "format": "biome format . --write",
     "format:check": "biome check . --formatter-enabled=true --linter-enabled=false",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -155,6 +155,8 @@ export interface ToolGroupChatMessage {
   count: number
   /** Number of operations hidden by write filter rules */
   hiddenCount: number
+  /** Thinking/description text absorbed from the preceding thinking entry */
+  description?: string
 }
 
 export interface TaskPlanChatMessage {


### PR DESCRIPTION
## Summary

- **Component decomposition**: Split `SessionMessages.tsx` (620 lines) into 3 focused files — `CodeRenderers.tsx`, `ToolItems.tsx`, `SessionMessages.tsx`
- **Tree-style tool groups**: Replace card-style nested layout with label+badge format inside light card with left-border tree line (`Edit /path +1 -4`, `Read /path 20 lines`, `Bash command`, `Agent description`)
- **Agent tool rendering**: Dedicated `AgentToolItem` with system-line stripping (agentId, background notices, internal messages)
- **Read tool**: Show error/short result text inline (red for errors), line count for code files
- **Sticky TaskPlan bar**: Compact bottom status bar with expand toggle, i18n, empty todos guard
- **Thinking→description**: Deferred `pendingThinking` pattern replaces fragile `messages.pop()` mutation
- **Diff stats**: Edit/Write items show `+N -M` line counts in green/red
- **Show more/less**: Tool groups default to 3 visible items with toggle
- **Worktree toggle**: Remove Enabled/Disabled text to save space in Create Task dialog
- **Biome coredump prevention**: `ulimit -c 0` before lint to prevent 200MB+ core files in project directory

## Test plan

- [x] Build passes (`bun run build`)
- [x] 28 frontend tests pass (`bun run test:frontend`)
- [x] 378 backend tests pass (`bun run test:api`)
- [x] Lint passes (`bun run lint`)
- [ ] Visual verification: tool groups render as tree-style with label+badge
- [ ] Visual verification: Agent items show clean result without internal messages
- [ ] Visual verification: Edit items show +N -M diff stats
- [ ] Visual verification: TaskPlan sticky bar at bottom with expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)