### PR TITLE
feat: fallback to transcript JSONL when stdout pipe breaks

### DIFF
--- a/apps/api/src/engines/executors/claude/transcript-fallback.ts
+++ b/apps/api/src/engines/executors/claude/transcript-fallback.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { isTurnCompletionEntry } from '@/engines/issue/streams/classification'
+import type { NormalizedLogEntry } from '@/engines/types'
+import { logger } from '@/logger'
+
+// ---------- Transcript fallback ----------
+//
+// When stdout pipe breaks prematurely (Bun pipe bug or Claude CLI hook
+// closing fd 1), the transcript JSONL file — written by Claude CLI via
+// appendFileSync — continues to receive data.  This module reads the
+// transcript, skips already-processed entries, and feeds missing entries
+// through the same normalizer/callbacks pipeline.
+
+/** Minimum fields we need from transcript JSONL entries. */
+interface TranscriptEntry {
+  type: string
+  uuid?: string
+  timestamp?: string
+  message?: {
+    role?: string
+    content?: unknown
+    model?: string
+    id?: string
+    stop_reason?: string | null
+    usage?: Record<string, unknown>
+  }
+  subtype?: string
+  session_id?: string
+  sessionId?: string
+}
+
+/**
+ * Construct the transcript JSONL path from CWD and session ID.
+ * Claude CLI stores transcripts at:
+ *   ~/.claude/projects/${cwd.replaceAll('/', '-')}/${sessionId}.jsonl
+ */
+export function getTranscriptPath(cwd: string, sessionId: string): string {
+  const projectHash = cwd.replaceAll('/', '-')
+  return join(
+    homedir(),
+    '.claude',
+    'projects',
+    projectHash,
+    `${sessionId}.jsonl`,
+  )
+}
+
+/**
+ * Read transcript JSONL and return entries after `afterTimestamp`.
+ * Returns entries converted to stream-json format lines that can be
+ * fed through the existing ClaudeLogNormalizer.
+ */
+function readTranscriptAfter(
+  transcriptPath: string,
+  afterTimestamp: string,
+): string[] {
+  let raw: string
+  try {
+    raw = readFileSync(transcriptPath, 'utf-8')
+  } catch (err) {
+    logger.warn({ transcriptPath, err }, 'transcript_fallback_read_failed')
+    return []
+  }
+
+  const lines = raw.split('\n').filter((l) => l.trim())
+  const outputLines: string[] = []
+
+  for (const line of lines) {
+    let entry: TranscriptEntry
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
+
+    // Skip entries at or before the cutoff timestamp
+    if (!entry.timestamp || entry.timestamp <= afterTimestamp) continue
+
+    // Convert transcript format to stream-json format for the normalizer
+    const converted = convertToStreamJson(entry)
+    if (converted) {
+      outputLines.push(converted)
+    }
+  }
+
+  return outputLines
+}
+
+/**
+ * Convert a transcript JSONL entry to stream-json format.
+ * The normalizer expects `{ type, message, session_id, uuid, ... }` lines.
+ * Transcript entries are nearly identical — just need minor field mapping.
+ */
+function convertToStreamJson(entry: TranscriptEntry): string | null {
+  // Transcript uses `sessionId`, stream-json uses `session_id`
+  const sessionId = entry.session_id ?? entry.sessionId
+
+  switch (entry.type) {
+    case 'assistant':
+    case 'user':
+      // These types have the same structure in both formats
+      if (!entry.message) return null
+      return JSON.stringify({
+        type: entry.type,
+        message: entry.message,
+        session_id: sessionId,
+        uuid: entry.uuid,
+      })
+
+    case 'system':
+      // system entries with subtype stop_hook_summary indicate turn end
+      if (entry.subtype === 'stop_hook_summary') {
+        // Synthesize a result entry to signal turn completion
+        return JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          session_id: sessionId,
+          uuid: entry.uuid,
+        })
+      }
+      return null
+
+    // Skip progress, queue-operation, last-prompt — not useful for log entries
+    default:
+      return null
+  }
+}
+
+/**
+ * Run the transcript fallback: read missed entries, parse them through
+ * the normalizer, and call the same callbacks used by consumeStream.
+ *
+ * Returns true if a turn completion was detected (caller should settle).
+ */
+export function runTranscriptFallback(
+  transcriptPath: string,
+  afterTimestamp: string,
+  parser: (line: string) => NormalizedLogEntry | NormalizedLogEntry[] | null,
+  onEntry: (entry: NormalizedLogEntry) => void,
+): boolean {
+  const lines = readTranscriptAfter(transcriptPath, afterTimestamp)
+  if (lines.length === 0) return false
+
+  logger.info(
+    { transcriptPath, lineCount: lines.length, afterTimestamp },
+    'transcript_fallback_processing',
+  )
+
+  let turnCompleted = false
+
+  for (const line of lines) {
+    try {
+      const result = parser(line)
+      if (!result) continue
+      const entries = Array.isArray(result) ? result : [result]
+      for (const entry of entries) {
+        entry.timestamp = entry.timestamp ?? new Date().toISOString()
+        onEntry(entry)
+        if (isTurnCompletionEntry(entry)) {
+          turnCompleted = true
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { err, line: line.slice(0, 200) },
+        'transcript_fallback_parse_error',
+      )
+    }
+  }
+
+  return turnCompleted
+}

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -140,6 +140,10 @@ export function gcSweep(ctx: EngineContext): void {
       }
 
       // --- Check 2: Stream stall detection (turn in-flight but no output) ---
+      // Skip stall escalation when stdout broke and transcript fallback is
+      // handling recovery (Claude CLI only — other engines have no fallback).
+      if (managed.stdoutBroken && managed.engineType === 'claude-code') continue
+
       // Three-tier approach: give the CLI time to retry internally before we intervene.
       //   Tier 1 (STREAM_STALL_TIMEOUT_MS): Non-destructive liveness check via OS
       //   Tier 2 (+ STALL_LIVENESS_GRACE_MS): Process alive but still silent → send interrupt

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -104,9 +104,13 @@ export async function spawnWithSessionFallback(
       },
       spawnCtx,
     )
+    const finalSessionId = spawned.externalSessionId ?? externalSessionId
     await updateIssueSession(issueId, {
-      externalSessionId: spawned.externalSessionId ?? externalSessionId,
+      externalSessionId: finalSessionId,
     })
+    if (!spawned.externalSessionId) {
+      spawned.externalSessionId = finalSessionId
+    }
     return spawned
   }
 }
@@ -140,9 +144,15 @@ export async function spawnFresh(
       issueId,
     },
   )
+  const finalSessionId = spawned.externalSessionId ?? externalSessionId
   await updateIssueSession(issueId, {
-    externalSessionId: spawned.externalSessionId ?? externalSessionId,
+    externalSessionId: finalSessionId,
   })
+  // Ensure the returned object always carries the session ID so callers
+  // (e.g. managed.externalSessionId) don't end up with undefined.
+  if (!spawned.externalSessionId) {
+    spawned.externalSessionId = finalSessionId
+  }
   return spawned
 }
 
@@ -209,7 +219,7 @@ export async function spawnRetry(
   const normalizer = createLogNormalizer(executor)
 
   const turnIndex = getNextTurnIndex(issueId)
-  register(
+  const retryManaged = register(
     ctx,
     executionId,
     issueId,
@@ -222,6 +232,11 @@ export async function spawnRetry(
     () => handleTurnCompleted(ctx, issueId, executionId),
     worktreePath ? baseDir : undefined,
   )
+  retryManaged.spawnCwd = workingDir
+  retryManaged.externalSessionId =
+    spawned.externalSessionId ??
+    issue.sessionFields.externalSessionId ??
+    undefined
   monitorCompletion(ctx, executionId, issueId, engineType, true)
   logger.debug(
     { issueId, executionId, engineType, turnIndex },
@@ -378,7 +393,7 @@ export async function spawnFollowUpProcess(
 
   const normalizer = createLogNormalizer(executor)
 
-  register(
+  const followUpManaged = register(
     ctx,
     executionId,
     issueId,
@@ -391,6 +406,11 @@ export async function spawnFollowUpProcess(
     () => handleTurnCompleted(ctx, issueId, executionId),
     worktreePath ? baseDir : undefined,
   )
+  followUpManaged.spawnCwd = workingDir
+  followUpManaged.externalSessionId =
+    spawned.externalSessionId ??
+    issue.sessionFields.externalSessionId ??
+    undefined
   // User message already persisted above (before spawn)
   monitorCompletion(ctx, executionId, issueId, engineType, false)
   const followUpPid = getPidFromSubprocess(spawned.subprocess)

--- a/apps/api/src/engines/issue/orchestration/execute.ts
+++ b/apps/api/src/engines/issue/orchestration/execute.ts
@@ -158,7 +158,7 @@ export async function executeIssue(
     )
     const normalizer = createLogNormalizer(executor)
 
-    register(
+    const execManaged = register(
       ctx,
       executionId,
       issueId,
@@ -171,6 +171,8 @@ export async function executeIssue(
       () => handleTurnCompleted(ctx, issueId, executionId),
       worktreePath ? baseDir : undefined,
     )
+    execManaged.spawnCwd = workingDir
+    execManaged.externalSessionId = finalExternalSessionId
     emitDiagnosticLog(
       issueId,
       executionId,

--- a/apps/api/src/engines/issue/orchestration/restart.ts
+++ b/apps/api/src/engines/issue/orchestration/restart.ts
@@ -127,7 +127,7 @@ export async function restartIssue(
     const normalizer = createLogNormalizer(executor)
 
     const turnIndex = getNextTurnIndex(issueId)
-    register(
+    const restartManaged = register(
       ctx,
       executionId,
       issueId,
@@ -140,6 +140,11 @@ export async function restartIssue(
       () => handleTurnCompleted(ctx, issueId, executionId),
       worktreePath ? baseDir : undefined,
     )
+    restartManaged.spawnCwd = workingDir
+    restartManaged.externalSessionId =
+      spawned.externalSessionId ??
+      issue.sessionFields.externalSessionId ??
+      undefined
     monitorCompletion(ctx, executionId, issueId, engineType, false)
 
     // Mark pending messages as dispatched after successful spawn

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -1,8 +1,13 @@
+import {
+  getTranscriptPath,
+  runTranscriptFallback,
+} from '@/engines/executors/claude/transcript-fallback'
 import type { EngineContext } from '@/engines/issue/context'
 import {
   createIssueDebugLog,
   teeStreamToDebug,
 } from '@/engines/issue/debug-log'
+import { emitDiagnosticLog } from '@/engines/issue/diagnostic'
 import { emitStateChange } from '@/engines/issue/events'
 import { ExecutionStore } from '@/engines/issue/store/execution-store'
 import type { StreamCallbacks } from '@/engines/issue/streams/consumer'
@@ -132,6 +137,116 @@ export function register(
     .then(() => {
       debugLog.event('stdout_stream_ended')
       logger.debug({ issueId, executionId }, 'consume_stream_promise_resolved')
+
+      // Detect stdout pipe breakage: stream ended but process is still alive
+      const m = ctx.pm.get(executionId)?.meta
+      if (!m || m.turnSettled || m.state !== 'running') return
+      const pid = getPidFromManaged(m)
+      if (!pid) return
+      let alive = false
+      try {
+        process.kill(pid, 0)
+        alive = true
+      } catch {
+        // process already dead — normal exit path
+      }
+      if (!alive) return
+
+      // stdout broke while process is still running
+      m.stdoutBroken = true
+
+      // Transcript JSONL fallback is Claude CLI-specific — other engines
+      // (codex, gemini, echo) don't write transcript files.
+      if (engineType !== 'claude-code') {
+        debugLog.event(
+          `stdout_broken pid=${pid} engine=${engineType} — no transcript fallback`,
+        )
+        logger.warn(
+          { issueId, executionId, pid, engineType },
+          'stdout_broken_no_fallback_non_claude',
+        )
+        return
+      }
+
+      const cwd = m.spawnCwd
+      const sessionId = m.externalSessionId
+      if (!cwd || !sessionId) {
+        logger.warn(
+          { issueId, executionId, hasCwd: !!cwd, hasSessionId: !!sessionId },
+          'transcript_fallback_skipped_missing_context',
+        )
+        return
+      }
+
+      const transcriptPath = getTranscriptPath(cwd, sessionId)
+      const cutoffTimestamp = m.lastActivityAt.toISOString()
+      debugLog.event(
+        `stdout_broken pid=${pid} alive=true — starting transcript fallback from ${cutoffTimestamp}`,
+      )
+      logger.warn(
+        { issueId, executionId, pid, transcriptPath, cutoffTimestamp },
+        'stdout_broken_transcript_fallback_starting',
+      )
+      emitDiagnosticLog(
+        issueId,
+        executionId,
+        `[BKD] stdout pipe broke — falling back to transcript JSONL (pid=${pid})`,
+        { event: 'stdout_broken_fallback', pid },
+      )
+
+      // Poll transcript JSONL until turn completion is detected or
+      // the process exits.  The process may still be mid-turn (running
+      // tool calls) when stdout breaks, so a single read is not enough.
+      const POLL_INTERVAL_MS = 5_000
+      const MAX_POLL_MS = 10 * 60_000 // 10 min safety cap
+      const pollStart = Date.now()
+      let lastCutoff = cutoffTimestamp
+
+      const pollTimer = setInterval(() => {
+        const current = ctx.pm.get(executionId)?.meta
+        if (!current || current.turnSettled || current.state !== 'running') {
+          clearInterval(pollTimer)
+          return
+        }
+
+        // Safety: stop polling after MAX_POLL_MS to avoid infinite loop.
+        // Clear stdoutBroken so stall detection can take over again.
+        if (Date.now() - pollStart > MAX_POLL_MS) {
+          clearInterval(pollTimer)
+          current.stdoutBroken = false
+          debugLog.event('transcript_fallback_timeout')
+          logger.warn(
+            { issueId, executionId },
+            'transcript_fallback_poll_timeout',
+          )
+          return
+        }
+
+        const turnCompleted = runTranscriptFallback(
+          transcriptPath,
+          lastCutoff,
+          logParser,
+          (entry) => {
+            const turnIdx = ctx.turnIndexes.get(executionId) ?? 0
+            handleStreamEntry(issueId, executionId, {
+              ...entry,
+              turnIndex: turnIdx,
+            })
+            // Advance cutoff so next poll skips already-processed entries
+            if (entry.timestamp) lastCutoff = entry.timestamp
+          },
+        )
+
+        if (turnCompleted) {
+          clearInterval(pollTimer)
+          debugLog.event('transcript_fallback_turn_completed')
+          logger.info(
+            { issueId, executionId },
+            'transcript_fallback_turn_completed',
+          )
+          onTurnCompleted()
+        }
+      }, POLL_INTERVAL_MS)
     })
     .catch((err) => {
       debugLog.event(`stdout_stream_error: ${err}`)

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -67,4 +67,14 @@ export interface ManagedProcess {
   }>
   /** Per-issue debug file logger for raw I/O and lifecycle events */
   debugLog?: IssueDebugLog
+  /** True when stdout pipe closed prematurely while the process is still alive.
+   *  Transcript fallback is in progress — stall detection should not escalate. */
+  stdoutBroken?: boolean
+  /** UUID of the last stdout message processed (used by transcript fallback
+   *  to skip already-seen entries). */
+  lastSeenUuid?: string
+  /** CWD of the spawned process (needed to construct transcript JSONL path). */
+  spawnCwd?: string
+  /** External session ID (Claude CLI session UUID). */
+  externalSessionId?: string
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-03-08 23:00 [progress]
+
+STALL-001：stdout pipe 断裂后 fallback 到 transcript JSONL
+
+解决 Claude CLI stdout pipe 偶发性异常关闭导致 9 分钟 stall detection 延迟的问题。
+
+修改：
+- `streams/transcript-fallback.ts`（新建）— 读取 transcript JSONL，转换格式后复用 normalizer 补齐缺失条目
+- `process/register.ts` — consumeStream 结束后检测进程是否存活，存活则启动 transcript fallback，检测到 turn completion 后主动 settle
+- `types.ts` — ManagedProcess 添加 `stdoutBroken`/`spawnCwd`/`externalSessionId` 字段
+- `gc.ts` — stdoutBroken 时跳过 stall escalation
+- `orchestration/execute.ts`、`restart.ts`、`lifecycle/spawn.ts` — 所有 register() 调用点设置 spawnCwd 和 externalSessionId
+
 ## 2026-03-08 21:00 [progress]
 
 BUG-004：非 dev 模式不再返回 tool-use 和 system-message 条目

--- a/docs/plan/PLAN-006.md
+++ b/docs/plan/PLAN-006.md
@@ -1,0 +1,102 @@
+# PLAN-006 stdout 断裂后 fallback 到 transcript JSONL
+
+- **status**: completed
+- **task**: STALL-001
+
+## 背景
+
+Claude CLI 进程的 stdout pipe 偶发性异常关闭（Bun pipe bug 或 Claude CLI hook 子进程关闭 fd），
+但进程继续运行并写入 transcript JSONL。BKD 的 consumeStream 提前结束后，
+只能等 stall detection（3+3+3=9 分钟）才能 force-kill 并 resume，导致时间浪费和日志丢失。
+
+## 调查发现
+
+### 时间线（真实案例）
+- `21:59:24` — stdout_stream_ended（pipe 断裂），consumeStream resolve
+- `21:59:24-21:59:33` — Claude CLI 继续执行：Bash(git commit)、新 API 请求、Stop hook
+- `22:02:11` — stall_detected（3min 静默）
+- `22:05:11` — stall_probe（6min，发送 interrupt）
+- `22:08:11` — stall_force_kill（9min，SIGKILL）
+
+### transcript JSONL
+- 路径：`~/.claude/projects/${cwd.replaceAll('/', '-')}/${sessionId}.jsonl`
+- 格式：每行一个 JSON 对象，`type` 字段有 `assistant`/`user`/`system`/`progress`/`queue-operation`
+- 由 Claude CLI 内部直接写入（appendFileSync），与 stdout fd 无关
+- stdout 断裂时仍在正常写入
+
+### 关键代码路径
+- `register.ts:125-142` — consumeStream resolve 后只记日志，不做任何恢复
+- `completion-monitor.ts:61` — 等待 subprocess.exited（如果进程不退出就一直等）
+- `gc.ts:142-289` — stall detection 三阶段（2+2+2=6min 检测 + force kill）
+- `normalizer.ts` — stream-json → NormalizedLogEntry 解析器
+
+## 方案
+
+### 核心思路
+
+在 `register.ts` 的 consumeStream `.then()` 中检测 stdout 断裂（进程仍存活），
+启动 transcript tail fallback：
+
+1. 从 transcript JSONL 读取 stdout 断裂后的新条目
+2. 用现有 normalizer 解析为 NormalizedLogEntry，push 到 callbacks
+3. 检测到 turn completion 后主动 settle
+
+### 改动文件
+
+1. **`apps/api/src/engines/issue/streams/transcript-fallback.ts`**（新建）
+   - `tailTranscript(transcriptPath, lastSeenUuid, parser, callbacks)` 函数
+   - 读取 JSONL 文件，跳过 lastSeenUuid 之前的条目
+   - 将 transcript 格式转换为 stream-json 格式，复用 normalizer 解析
+   - 检测 `system.subtype === 'stop_hook_summary'` 或助理最终消息作为 turn completion 信号
+   - 处理完后返回，由调用方 settle
+
+2. **`apps/api/src/engines/issue/process/register.ts`**（修改）
+   - consumeStream `.then()` 中：检测进程是否存活
+   - 如果存活：构造 transcript path，调用 tailTranscript fallback
+   - fallback 完成后：标记 turnSettled，主动 settle issue
+
+3. **`apps/api/src/engines/issue/types.ts`**（修改）
+   - ManagedProcess 添加 `stdoutBroken?: boolean` 字段标记断裂状态
+   - 添加 `lastSeenUuid?: string` 跟踪最后处理的消息 UUID
+
+4. **`apps/api/src/engines/issue/gc.ts`**（修改）
+   - stall detection 检查 `stdoutBroken` 标记
+   - 如果已标记且 fallback 正在进行，跳过 stall escalation
+
+### transcript 格式转换
+
+transcript JSONL 的 `assistant` 条目结构：
+```json
+{
+  "type": "assistant",
+  "message": { "role": "assistant", "content": [...] },
+  "uuid": "...",
+  "timestamp": "..."
+}
+```
+
+stream-json stdout 的 `assistant` 条目结构：
+```json
+{
+  "type": "assistant",
+  "message": { "role": "assistant", "content": [...] },
+  "session_id": "...",
+  "uuid": "..."
+}
+```
+
+两者的 `message` 结构一致，差异仅在顶层元数据字段。
+normalizer 的 `parse()` 方法只关心 `type` 和 `message`，可以直接复用。
+
+### 风险
+
+1. **transcript 写入延迟** — Claude CLI 可能缓冲写入，但实际使用 `appendFileSync` 所以立即落盘
+2. **格式耦合** — transcript 是 Claude CLI 内部格式，升级可能变化。
+   但核心的 `assistant.message` 结构与公开的 stream-json 一致，风险低
+3. **并发读写** — BKD 读取时 Claude CLI 可能正在追加。
+   逐行读取 + 容忍不完整尾行即可
+
+## 替代方案
+
+- **方案 4（简单 settle）**：stdout 断裂即 settle + resume。缺点：丢失断裂后的日志和工作。
+- **Bun.file() 重定向**：如果是 Claude CLI 侧问题（关闭 fd 1），同样无效。

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -8,3 +8,4 @@
 - [x] **PLAN-003 聊天界面 UI 优化（对标 Claude Code）** - task: `CHAT-001` - file: `docs/plan/PLAN-003.md`
 - [x] **PLAN-004 历史消息分页按会话消息计数** - task: `CHAT-003` - file: `docs/plan/PLAN-004.md`
 - [x] **PLAN-005 Pending 消息改造** - task: `FEAT-002` - file: `docs/plan/PLAN-005.md`
+- [x] **PLAN-006 stdout 断裂后 fallback 到 transcript JSONL** - task: `STALL-001` - owner: claude - file: `docs/plan/PLAN-006.md`

--- a/docs/task/STALL-001.md
+++ b/docs/task/STALL-001.md
@@ -1,0 +1,17 @@
+# STALL-001 stdout 断裂后 fallback 到 transcript JSONL
+
+- **status**: completed
+- **priority**: P1
+- **owner**: claude
+- **plan**: PLAN-006
+
+## 描述
+
+Claude CLI 的 stdout pipe 偶发性异常关闭（进程仍存活但 stdout ReadableStream 返回 done=true），
+导致 BKD 的 consumeStream 提前结束，引发 9 分钟的 stall detection 才能 settle。
+
+## 需求
+
+1. 保留 stdout pipe 作为主通道（零延迟）
+2. stdout 断裂时（consumeStream 结束但进程仍存活），fallback 到 tail transcript JSONL 补齐缺失条目
+3. transcript 处理完后主动 settle（不等 stall detection 的 9 分钟超时）

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -67,6 +67,10 @@
 
 - [x] **FEAT-002 Pending 消息改造** `P1` - owner: claude - plan: `PLAN-005` - file: `docs/task/FEAT-002.md`
 
+## Stream Reliability
+
+- [x] **STALL-001 stdout 断裂后 fallback 到 transcript JSONL** `P1` - owner: claude - plan: `PLAN-006` - file: `docs/task/STALL-001.md`
+
 ## Bug Fix
 
 - [x] **BUG-001 未指定 root 目录时以自身所在目录为 root** `P1` - file: `docs/task/BUG-001.md`


### PR DESCRIPTION
## Summary

- When Claude CLI's stdout pipe closes prematurely (process alive but `ReadableStream` returns `done`), poll the transcript JSONL file to recover missed log entries
- Proactively settle on turn completion instead of waiting 9min for stall detection timeout
- Skip stall escalation in `gc.ts` while transcript fallback is active (Claude CLI only)

## Changed files

- `executors/claude/transcript-fallback.ts` (new) — read transcript JSONL, convert format, reuse normalizer
- `process/register.ts` — detect stdout breakage after `consumeStream` ends, start polling fallback
- `types.ts` — add `stdoutBroken` / `spawnCwd` / `externalSessionId` to `ManagedProcess`
- `gc.ts` — skip stall escalation when `stdoutBroken && engineType === 'claude-code'`
- `orchestration/execute.ts`, `restart.ts`, `lifecycle/spawn.ts` — set `spawnCwd` and `externalSessionId` on all `register()` call sites

## Test plan

- [ ] Normal stdout flow unaffected (no `stdoutBroken` flag set)
- [ ] Simulate early stdout close — verify transcript fallback recovers logs
- [ ] Verify proactive settle on turn completion (no stall detection wait)
- [ ] Verify `gc.ts` skips stall escalation for `stdoutBroken` claude-code processes
- [ ] Verify 10min safety timeout clears poll timer