### PR TITLE
fix: improve chat message display and tool group stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ apps/api/src/_static-assets.generated.ts
 
 # core dumps
 core
+core.*
 
 # temp
 tmp/

--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_LOG_PAGE_SIZE = 10
+export const LOG_PAGE_SIZE_KEY = 'log:pageSize'
 export const MAX_LOG_ENTRIES = 10000
 export const AUTO_CLEANUP_DELAY_MS = 5 * 60 * 1000 // 5 minutes
 export const MAX_AUTO_RETRIES = 1

--- a/apps/api/src/routes/issues/logs.ts
+++ b/apps/api/src/routes/issues/logs.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono'
-import { findProject } from '@/db/helpers'
+import { findProject, getAppSetting } from '@/db/helpers'
 import { issueEngine } from '@/engines/issue'
+import {
+  DEFAULT_LOG_PAGE_SIZE,
+  LOG_PAGE_SIZE_KEY,
+} from '@/engines/issue/constants'
 import { getProjectOwnedIssue, serializeIssue } from './_shared'
 
 const logs = new Hono()
@@ -24,9 +28,15 @@ logs.get('/:id/logs', async (c) => {
   const before = c.req.query('before') || undefined
   const limitParam = c.req.query('limit')
 
-  const limit = limitParam
-    ? Math.min(Math.max(Math.floor(Number(limitParam)) || 30, 1), 1000)
-    : undefined
+  let limit: number | undefined
+  if (limitParam) {
+    limit = Math.min(Math.max(Math.floor(Number(limitParam)) || 30, 1), 1000)
+  } else {
+    const pageSizeRaw = await getAppSetting(LOG_PAGE_SIZE_KEY)
+    limit = pageSizeRaw
+      ? Number(pageSizeRaw) || DEFAULT_LOG_PAGE_SIZE
+      : DEFAULT_LOG_PAGE_SIZE
+  }
 
   // Pagination now counts only conversation messages (user + assistant)
   // but returns all visible entries within the range.

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -13,6 +13,10 @@ import {
   setServerName,
   setServerUrl,
 } from '@/db/helpers'
+import {
+  DEFAULT_LOG_PAGE_SIZE,
+  LOG_PAGE_SIZE_KEY,
+} from '@/engines/issue/constants'
 import { getCachedCategorizedCommands } from '@/engines/issue/queries'
 import type { WriteFilterRule } from '@/engines/write-filter'
 import {
@@ -190,6 +194,42 @@ general.patch(
     const { enabled } = c.req.valid('json')
     await setAppSetting(WORKTREE_AUTO_CLEANUP_KEY, String(enabled))
     return c.json({ success: true, data: { enabled } })
+  },
+)
+
+// --- Log Page Size ---
+
+// GET /api/settings/log-page-size
+general.get('/log-page-size', async (c) => {
+  const value = await getAppSetting(LOG_PAGE_SIZE_KEY)
+  return c.json({
+    success: true,
+    data: { size: value ? Number(value) : DEFAULT_LOG_PAGE_SIZE },
+  })
+})
+
+// PATCH /api/settings/log-page-size
+general.patch(
+  '/log-page-size',
+  zValidator(
+    'json',
+    z.object({ size: z.number().int().min(5).max(200) }),
+    (result, c) => {
+      if (!result.success) {
+        return c.json(
+          {
+            success: false,
+            error: result.error.issues.map((i) => i.message).join(', '),
+          },
+          400,
+        )
+      }
+    },
+  ),
+  async (c) => {
+    const { size } = c.req.valid('json')
+    await setAppSetting(LOG_PAGE_SIZE_KEY, String(size))
+    return c.json({ success: true, data: { size } })
   },
 )
 

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -49,11 +49,13 @@ import {
   useEngineAvailability,
   useEngineProfiles,
   useEngineSettings,
+  useLogPageSize,
   useProbeEngines,
   useRestartWithUpgrade,
   useRestoreDeletedIssue,
   useRunCleanup,
   useServerInfo,
+  useSetLogPageSize,
   useSetUpgradeEnabled,
   useSetWorktreeAutoCleanup,
   useSystemInfo,
@@ -139,6 +141,8 @@ function GeneralSection({ open }: { open: boolean }) {
   const [dirPickerOpen, setDirPickerOpen] = useState(false)
   const fullWidthChat = useViewModeStore((s) => s.fullWidthChat)
   const setFullWidthChat = useViewModeStore((s) => s.setFullWidthChat)
+  const { data: logPageSizeData } = useLogPageSize(open)
+  const setLogPageSize = useSetLogPageSize()
   const { data: serverData } = useServerInfo(open)
   const updateServerInfo = useUpdateServerInfo()
   const [serverName, setServerName] = useState('')
@@ -306,6 +310,28 @@ function GeneralSection({ open }: { open: boolean }) {
           onCheckedChange={setFullWidthChat}
         />
       </div>
+
+      <Field>
+        <Label>{t('settings.logPageSize')}</Label>
+        <Select
+          value={String(logPageSizeData?.size ?? 10)}
+          onValueChange={(value) => setLogPageSize.mutate(Number(value))}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {[5, 10, 20, 50, 100, 200].map((n) => (
+              <SelectItem key={n} value={String(n)}>
+                {n}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-[11px] text-muted-foreground">
+          {t('settings.logPageSizeHint')}
+        </p>
+      </Field>
     </div>
   )
 }

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -1,6 +1,7 @@
 import {
   Bot,
   FileText,
+  FolderOpen,
   Image as ImageIcon,
   Loader2,
   Paperclip,
@@ -40,6 +41,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { useChangesSummary } from '@/hooks/use-changes-summary'
 import { useEngineAvailability, useFollowUpIssue } from '@/hooks/use-kanban'
 import { formatFileSize, formatModelName } from '@/lib/format'
+import { useFileBrowserStore } from '@/stores/file-browser-store'
 import type { BusyAction, EngineModel, SessionStatus } from '@/types/kanban'
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
@@ -176,6 +178,8 @@ export function ChatInput({
   const changedCount = changesSummary?.fileCount ?? 0
   const additions = changesSummary?.additions ?? 0
   const deletions = changesSummary?.deletions ?? 0
+  const changesRoot = (changesSummary as { root?: string } | null)?.root
+  const openFileBrowser = useFileBrowserStore((s) => s.open)
 
   // Fetch models for current engine
   const { data: discovery } = useEngineAvailability(!!engineType)
@@ -587,6 +591,14 @@ export function ChatInput({
                 -{deletions}
               </span>
             </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => projectId && openFileBrowser(projectId, changesRoot)}
+            className="inline-flex items-center justify-center rounded-lg px-1.5 py-1 text-muted-foreground bg-muted/40 hover:bg-muted/60 transition-all duration-200"
+            title={t('diff.openFiles')}
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
           </button>
 
           <div className="ml-auto flex items-center gap-1">

--- a/apps/frontend/src/components/issue-detail/LogEntry.tsx
+++ b/apps/frontend/src/components/issue-detail/LogEntry.tsx
@@ -307,6 +307,8 @@ export function LogEntry({
       if (entry.metadata?.subtype === 'hook_completed') return null
       if (entry.metadata?.source === 'result') return null
       if (typeof entry.metadata?.duration === 'number') return null
+      // Image metadata hints from CLI (e.g. "[Image: original 2400x312...]")
+      if (entry.content.startsWith('[Image:')) return null
       // Command output (e.g. /context, /cost): collapsed by default
       if (entry.metadata?.subtype === 'command_output') {
         const firstLine =
@@ -354,12 +356,26 @@ export function LogEntry({
         </div>
       )
 
-    case 'thinking':
+    case 'thinking': {
+      const preview =
+        entry.content.length > 80
+          ? `${entry.content.slice(0, 80)}…`
+          : entry.content
       return (
-        <div className="py-0.5 text-xs text-violet-500/70 dark:text-violet-400/70 italic">
-          Thinking: {entry.content}
+        <div className="my-0.5 animate-message-enter">
+          <details className="rounded-lg bg-violet-500/[0.04] border border-violet-300/20 dark:border-violet-500/15 transition-all duration-200 open:bg-violet-500/[0.06]">
+            <summary className="cursor-pointer list-none px-3 py-1.5 text-xs text-violet-500/70 dark:text-violet-400/70 hover:bg-violet-500/[0.06] transition-colors">
+              <span className="italic">Thinking: {preview}</span>
+            </summary>
+            <div className="px-3 pb-2 pt-1 border-t border-violet-300/15 dark:border-violet-500/10">
+              <pre className="text-xs text-violet-600/70 dark:text-violet-300/60 whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
+                {entry.content}
+              </pre>
+            </div>
+          </details>
         </div>
       )
+    }
 
     case 'loading':
       return (

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -10,7 +10,7 @@ import {
   ListTodo,
   Loader2,
 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useChatMessages } from '@/hooks/use-chat-messages'
 import { useViewModeStore } from '@/stores/view-mode-store'
@@ -52,7 +52,7 @@ function ChatMessageRow({ message }: { message: ChatMessage }) {
       return <ToolGroupMessage message={message} />
 
     case 'task-plan':
-      return null
+      return <TaskPlanMessage message={message as TaskPlanChatMessage} />
 
     case 'thinking':
     case 'system':
@@ -64,9 +64,9 @@ function ChatMessageRow({ message }: { message: ChatMessage }) {
   }
 }
 
-// ── Sticky Task Plan Status Bar ──────────────────────────
+// ── Task Plan ────────────────────────────────────────────
 
-function StickyTaskPlan({ message }: { message: TaskPlanChatMessage }) {
+function TaskPlanMessage({ message }: { message: TaskPlanChatMessage }) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const { todos, completedCount } = message
@@ -77,8 +77,8 @@ function StickyTaskPlan({ message }: { message: TaskPlanChatMessage }) {
     : null
 
   return (
-    <div className="sticky bottom-0 z-10 animate-message-enter">
-      <div className="rounded-lg border border-border/40 bg-background/95 backdrop-blur-sm shadow-sm">
+    <div className="animate-message-enter">
+      <div className="rounded-lg border border-border/40 bg-background/95 shadow-sm">
         {/* Expandable detail panel — opens upward */}
         {expanded ? (
           <div className="px-3 pt-2 pb-1 space-y-0.5 border-b border-border/20">
@@ -168,15 +168,6 @@ export function SessionMessages({
   // Transform flat entries → grouped ChatMessage[]
   const { messages, pendingMessages } = useChatMessages(logs)
 
-  const latestTaskPlan = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].type === 'task-plan') {
-        return messages[i] as TaskPlanChatMessage
-      }
-    }
-    return null
-  }, [messages])
-
   // Auto-scroll to bottom on new messages
   const nearBottomRef = useRef(true)
   useEffect(() => {
@@ -194,10 +185,16 @@ export function SessionMessages({
   useEffect(() => {
     if (initialScrollDone.current || messages.length === 0) return
     const el = scrollRef?.current
-    if (el) {
-      el.scrollTo({ top: el.scrollHeight })
-      initialScrollDone.current = true
-    }
+    if (!el) return
+    // Double-rAF ensures the lazy-loaded content has been painted before
+    // we measure scrollHeight.  A single rAF fires before the browser
+    // composites the first meaningful paint of the Suspense child.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        el.scrollTo({ top: el.scrollHeight })
+        initialScrollDone.current = true
+      })
+    })
   }, [messages.length, scrollRef])
 
   const prevLenRef = useRef(messages.length)
@@ -291,9 +288,6 @@ export function SessionMessages({
             </div>
           ))}
         </div>
-      ) : null}
-      {latestTaskPlan && latestTaskPlan.todos.length > 0 ? (
-        <StickyTaskPlan message={latestTaskPlan} />
       ) : null}
     </div>
   )

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -1,6 +1,4 @@
 import type { ToolGroupChatMessage, ToolGroupItem } from '@bkd/shared'
-import { ChevronDown, ChevronRight } from 'lucide-react'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getCommandPreview } from '@/lib/command-preview'
 import { formatFileSize } from '@/lib/format'
@@ -368,8 +366,6 @@ function getGroupSummaryLabel(
   return parts.length > 0 ? parts.join(', ') : `${count} tool calls`
 }
 
-const INITIAL_VISIBLE = 3
-
 function ToolItemRenderer({ item, idx }: { item: ToolGroupItem; idx: number }) {
   const kind = item.action.toolAction?.kind
   const toolName = getItemToolName(item)
@@ -404,60 +400,32 @@ export function ToolGroupMessage({
   message: ToolGroupChatMessage
 }) {
   const { t } = useTranslation()
-  const [expanded, setExpanded] = useState(false)
-  const [showAll, setShowAll] = useState(false)
   const { items, stats, count, description } = message
   const statsLabel = getGroupSummaryLabel(stats, count, t)
-  const hasMore = items.length > INITIAL_VISIBLE
-  const visibleItems =
-    expanded && !showAll && hasMore ? items.slice(0, INITIAL_VISIBLE) : items
-  const hiddenCount = items.length - INITIAL_VISIBLE
 
   return (
     <div className="py-0.5 animate-message-enter">
       <div className="rounded-lg border border-border/30 bg-card/50">
         {/* Header */}
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/20 rounded-lg"
-        >
-          {expanded ? (
-            <ChevronDown className="h-3 w-3 shrink-0" />
-          ) : (
-            <ChevronRight className="h-3 w-3 shrink-0" />
-          )}
+        <div className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
           <span className="truncate">{description || statsLabel}</span>
           {description ? (
             <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/50">
               {statsLabel}
             </span>
           ) : null}
-        </button>
+        </div>
 
         {/* Tree items */}
-        {expanded ? (
-          <div className="mx-3 mb-2 border-l border-border/40 pl-4 space-y-1">
-            {visibleItems.map((item, idx) => (
-              <ToolItemRenderer
-                key={item.action.messageId ?? `ti-${idx}`}
-                item={item}
-                idx={idx}
-              />
-            ))}
-            {hasMore ? (
-              <button
-                type="button"
-                onClick={() => setShowAll(!showAll)}
-                className="text-[11px] text-muted-foreground/60 hover:text-foreground transition-colors"
-              >
-                {showAll
-                  ? t('session.tool.showLess', 'Show less')
-                  : `Show ${hiddenCount} more`}
-              </button>
-            ) : null}
-          </div>
-        ) : null}
+        <div className="mx-3 mb-2 border-l border-border/40 pl-4 space-y-1">
+          {items.map((item, idx) => (
+            <ToolItemRenderer
+              key={item.action.messageId ?? `ti-${idx}`}
+              item={item}
+              idx={idx}
+            />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getCommandPreview } from '@/lib/command-preview'
+import { formatFileSize } from '@/lib/format'
 import {
   CodeBlock,
   detectCodeLanguage,
@@ -95,8 +96,7 @@ export function FileToolItem({ item }: { item: ToolGroupItem }) {
       item.result?.toolDetail?.raw?.isError === true ||
       item.result?.entryType === 'error-message'
     const lineCount = countLines(resultContent)
-    const showResultText =
-      resultContent && (isResultError || (lineCount !== null && lineCount <= 3))
+    const showResultText = resultContent && isResultError
 
     const summary = (
       <div className="flex items-center gap-2 text-xs">
@@ -117,12 +117,18 @@ export function FileToolItem({ item }: { item: ToolGroupItem }) {
       )
     }
 
+    const sizeInfo = lineCount
+      ? `Read ${lineCount} lines`
+      : resultContent
+        ? `${formatFileSize(resultContent.length)}`
+        : null
+
     return (
       <div className="py-0.5">
         {summary}
-        {lineCount ? (
+        {sizeInfo ? (
           <div className="ml-0.5 mt-0.5 text-[11px] text-muted-foreground/60">
-            Read {lineCount} lines
+            {sizeInfo}
           </div>
         ) : null}
       </div>

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -1,9 +1,4 @@
-import {
-  ChevronDown,
-  ChevronsRight,
-  GitBranch,
-  MousePointerClick,
-} from 'lucide-react'
+import { ChevronDown, ChevronsRight, MousePointerClick } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -463,11 +458,8 @@ function WorktreeToggle({
   onChange: (v: boolean) => void
 }) {
   return (
-    <div className="flex items-center gap-2 w-full">
+    <div className="flex items-center w-full">
       <Switch checked={value} onCheckedChange={onChange} className="shrink-0" />
-      <GitBranch
-        className={`h-3.5 w-3.5 shrink-0 ${value ? 'text-emerald-500' : 'text-muted-foreground'}`}
-      />
     </div>
   )
 }

--- a/apps/frontend/src/hooks/use-changes-summary.ts
+++ b/apps/frontend/src/hooks/use-changes-summary.ts
@@ -62,7 +62,8 @@ export function useChangesSummary(
       fileCount: restData.files.length,
       additions: restData.additions,
       deletions: restData.deletions,
-    } satisfies ChangesSummaryData
+      root: restData.root,
+    }
   }
 
   return null

--- a/apps/frontend/src/hooks/use-changes-summary.ts
+++ b/apps/frontend/src/hooks/use-changes-summary.ts
@@ -52,19 +52,25 @@ export function useChangesSummary(
     return unsub
   }, [issueId, projectId, queryClient])
 
-  // SSE data takes priority over REST data
-  if (sseSummary) return sseSummary
-
   // Derive summary from REST response
-  if (restData) {
+  const restSummary = restData
+    ? {
+        issueId: issueId ?? '',
+        fileCount: restData.files.length,
+        additions: restData.additions,
+        deletions: restData.deletions,
+        root: restData.root,
+      }
+    : null
+
+  // SSE data takes priority, but preserve REST root as fallback
+  // (SSE payloads don't carry root, so worktree paths would be lost)
+  if (sseSummary) {
     return {
-      issueId: issueId ?? '',
-      fileCount: restData.files.length,
-      additions: restData.additions,
-      deletions: restData.deletions,
-      root: restData.root,
+      ...sseSummary,
+      root: restSummary?.root,
     }
   }
 
-  return null
+  return restSummary
 }

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -231,7 +231,9 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       continue
     }
 
-    // task_progress: display inline but do NOT break the current tool group
+    // ── Inline entries that do NOT break the current tool group ──
+
+    // task_progress: display inline, never breaks tool groups
     if (
       entry.entryType === 'system-message' &&
       entry.metadata?.subtype === 'task_progress'
@@ -245,12 +247,53 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       continue
     }
 
-    // Non-tool entry → flush pending tool buffer + any unconsumed thinking
+    // error-message: display inline, never breaks tool groups
+    if (entry.entryType === 'error-message') {
+      messages.push({
+        type: 'error',
+        id: entryId(entry, nextId('err')),
+        entry,
+      } satisfies ErrorChatMessage)
+      continue
+    }
+
+    // thinking: defer for next tool group description, never breaks tool groups
+    if (entry.entryType === 'thinking') {
+      flushPendingThinking()
+      pendingThinking = entry.content ? { content: entry.content, entry } : null
+      if (!pendingThinking) {
+        messages.push({
+          type: 'thinking',
+          id: entryId(entry, nextId('th')),
+          entry,
+        } satisfies ThinkingChatMessage)
+      }
+      continue
+    }
+
+    // system-message (non-task_progress): display inline, never breaks tool groups
+    if (entry.entryType === 'system-message') {
+      if (consumedOutputIdx.has(i)) continue
+      messages.push({
+        type: 'system',
+        id: entryId(entry, nextId('sys')),
+        entry,
+        subtype: (entry.metadata?.subtype as string | undefined) ?? 'info',
+      } satisfies SystemChatMessage)
+      continue
+    }
+
+    // Skip non-visible entries
+    if (entry.entryType === 'token-usage' || entry.entryType === 'loading') {
+      continue
+    }
+
+    // ── Conversation messages flush the tool group ──
     flushToolBuffer()
+    flushPendingThinking()
 
     switch (entry.entryType) {
       case 'user-message': {
-        flushPendingThinking()
         const metaType = entry.metadata?.type as string | undefined
         const attachments = (entry.metadata?.attachments ?? []) as Array<{
           id: string
@@ -285,55 +328,12 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
       }
 
       case 'assistant-message':
-        flushPendingThinking()
         messages.push({
           type: 'assistant',
           id: entryId(entry, nextId('am')),
           entry,
           durationMs: turnDuration.get(entry.turnIndex ?? 0),
         } satisfies AssistantChatMessage)
-        break
-
-      case 'thinking':
-        // Defer: if the next entries are tool calls, this becomes the tool group
-        // description; otherwise it will be flushed as a standalone thinking message
-        flushPendingThinking()
-        pendingThinking = entry.content
-          ? { content: entry.content, entry }
-          : null
-        if (!pendingThinking) {
-          messages.push({
-            type: 'thinking',
-            id: entryId(entry, nextId('th')),
-            entry,
-          } satisfies ThinkingChatMessage)
-        }
-        break
-
-      case 'system-message': {
-        // Skip command_output entries consumed by command user-messages
-        if (consumedOutputIdx.has(i)) break
-        flushPendingThinking()
-        messages.push({
-          type: 'system',
-          id: entryId(entry, nextId('sys')),
-          entry,
-          subtype: (entry.metadata?.subtype as string | undefined) ?? 'info',
-        } satisfies SystemChatMessage)
-        break
-      }
-
-      case 'error-message':
-        flushPendingThinking()
-        messages.push({
-          type: 'error',
-          id: entryId(entry, nextId('err')),
-          entry,
-        } satisfies ErrorChatMessage)
-        break
-
-      case 'token-usage':
-      case 'loading':
         break
 
       default:

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -233,11 +233,13 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
 
     // ── Inline entries that do NOT break the current tool group ──
 
-    // task_progress: display inline, never breaks tool groups
+    // task_progress: flush buffered tools first to preserve chronology,
+    // then display as inline system message
     if (
       entry.entryType === 'system-message' &&
       entry.metadata?.subtype === 'task_progress'
     ) {
+      flushToolBuffer()
       messages.push({
         type: 'system',
         id: entryId(entry, nextId('sys')),
@@ -274,6 +276,7 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
     // system-message (non-task_progress): display inline, never breaks tool groups
     if (entry.entryType === 'system-message') {
       if (consumedOutputIdx.has(i)) continue
+      flushPendingThinking()
       messages.push({
         type: 'system',
         id: entryId(entry, nextId('sys')),

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -136,9 +136,12 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
         item.action.toolDetail?.kind ?? item.action.toolAction?.kind ?? 'other'
       stats[kind] = (stats[kind] ?? 0) + 1
     }
+    // Stable ID from first action's messageId — prevents React key changes
+    // when new tool entries arrive and the message list is rebuilt.
+    const stableId = items[0]?.action.messageId ?? nextId('tg')
     return {
       type: 'tool-group',
-      id: nextId('tg'),
+      id: `tg-${stableId}`,
       items,
       stats,
       count: items.length,
@@ -225,6 +228,20 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
         if (result) pairedResultCallIds.add(callId)
       }
       toolBuffer.push({ action: entry, result })
+      continue
+    }
+
+    // task_progress: display inline but do NOT break the current tool group
+    if (
+      entry.entryType === 'system-message' &&
+      entry.metadata?.subtype === 'task_progress'
+    ) {
+      messages.push({
+        type: 'system',
+        id: entryId(entry, nextId('sys')),
+        entry,
+        subtype: 'task_progress',
+      } satisfies SystemChatMessage)
       continue
     }
 

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -51,6 +51,7 @@ export const queryKeys = {
     ['projects', projectId, 'processes'] as const,
   projectWorktrees: (projectId: string) =>
     ['projects', projectId, 'worktrees'] as const,
+  logPageSize: () => ['settings', 'logPageSize'] as const,
   worktreeAutoCleanup: () => ['settings', 'worktreeAutoCleanup'] as const,
   upgradeVersion: () => ['upgrade', 'version'] as const,
   upgradeEnabled: () => ['upgrade', 'enabled'] as const,
@@ -510,6 +511,27 @@ export function useUpdateWorkspacePath() {
 }
 
 // --- Worktree Auto-Cleanup hooks ---
+
+export function useLogPageSize(enabled = false) {
+  return useQuery({
+    queryKey: queryKeys.logPageSize(),
+    queryFn: () => kanbanApi.getLogPageSize(),
+    enabled,
+    staleTime: Infinity,
+  })
+}
+
+export function useSetLogPageSize() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (size: number) => kanbanApi.setLogPageSize(size),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.logPageSize(),
+      })
+    },
+  })
+}
 
 export function useWorktreeAutoCleanup(enabled = false) {
   return useQuery({

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -309,6 +309,8 @@
     "packageMode": "Package",
     "fullWidthChat": "Full-width chat",
     "fullWidthChatHint": "Remove the max-width limit on the chat message area",
+    "logPageSize": "Messages per page",
+    "logPageSizeHint": "Number of conversation messages (user and assistant) to load per page",
     "worktreeAutoCleanup": "Auto-cleanup worktrees",
     "worktreeAutoCleanupHint": "Automatically remove worktrees for issues that have been done for more than 1 day",
     "upgradeEnabled": "Auto-check updates",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -309,6 +309,8 @@
     "packageMode": "包模式",
     "fullWidthChat": "全宽聊天",
     "fullWidthChatHint": "移除聊天消息区域的最大宽度限制",
+    "logPageSize": "消息加载数量",
+    "logPageSizeHint": "每次加载的对话消息数量（用户和助手消息）",
     "worktreeAutoCleanup": "自动清理工作区",
     "worktreeAutoCleanupHint": "自动清理已完成超过 1 天的工作区",
     "upgradeEnabled": "自动检查更新",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -284,6 +284,9 @@ export const kanbanApi = {
   getWorkspacePath: () => get<{ path: string }>('/api/settings/workspace-path'),
   updateWorkspacePath: (path: string) =>
     patch<{ path: string }>('/api/settings/workspace-path', { path }),
+  getLogPageSize: () => get<{ size: number }>('/api/settings/log-page-size'),
+  setLogPageSize: (size: number) =>
+    patch<{ size: number }>('/api/settings/log-page-size', { size }),
   getWorktreeAutoCleanup: () =>
     get<{ enabled: boolean }>('/api/settings/worktree-auto-cleanup'),
   setWorktreeAutoCleanup: (enabled: boolean) =>


### PR DESCRIPTION
## Summary
- Use stable tool group IDs (based on first message ID) to prevent flickering during SSE updates
- task_progress system messages no longer break tool groups, rendered inline instead
- TaskPlan (TodoWrite) rendered inline in the message flow instead of sticky at the bottom
- Non-devMode visibility kept to user and assistant messages only
- Read tool shows only file path and line count, no binary content
- Thinking messages use collapsible panels, collapsed by default showing only summary

## Test plan
- [ ] Enable devMode and verify full tool groups and system messages are visible
- [ ] Disable devMode and confirm only user and assistant messages are shown
- [ ] Confirm tool groups do not flicker during real-time SSE updates
- [ ] Confirm TaskPlan renders inline in the message flow
- [ ] Confirm task_progress messages do not split tool groups