### PR TITLE
feat: make max concurrent executions configurable via settings

### DIFF
--- a/apps/api/src/engines/issue/engine.ts
+++ b/apps/api/src/engines/issue/engine.ts
@@ -195,6 +195,23 @@ export class IssueEngine {
     return terminateProcess(this.ctx, issueId)
   }
 
+  // ---- Concurrency config ----
+
+  setMaxConcurrent(n: number): void {
+    this.ctx.pm.setMaxConcurrent(n)
+  }
+
+  async initMaxConcurrent(): Promise<void> {
+    const { getAppSetting } = await import('@/db/helpers')
+    const value = await getAppSetting('engine:maxConcurrentExecutions')
+    if (value) {
+      const n = Number(value)
+      if (Number.isFinite(n) && n >= 1) {
+        this.ctx.pm.setMaxConcurrent(n)
+      }
+    }
+  }
+
   // ---- Error tracking ----
 
   getLastError(issueId: string): string | undefined {

--- a/apps/api/src/engines/process-manager.ts
+++ b/apps/api/src/engines/process-manager.ts
@@ -60,7 +60,7 @@ export class ProcessManager<TMeta> {
   private exitHandlers = new Map<number, ProcessExitHandler<TMeta>>()
   private nextHandlerId = 0
 
-  private readonly maxConcurrent: number
+  private maxConcurrent: number
   private readonly autoCleanupDelayMs: number
   private readonly killTimeoutMs: number
   private readonly log: ProcessManagerLogger
@@ -88,6 +88,10 @@ export class ProcessManager<TMeta> {
         ;(this.gcTimer as NodeJS.Timeout).unref()
       }
     }
+  }
+
+  setMaxConcurrent(n: number): void {
+    this.maxConcurrent = n
   }
 
   // ---- Registration & State Transitions ----

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -44,6 +44,11 @@ void migrateSlashCommandsKey()
     logger.error({ err }, 'slash_commands_cache_load_failed')
   })
 
+// Load max concurrent executions setting from DB
+void issueEngine.initMaxConcurrent().catch((err) => {
+  logger.error({ err }, 'init_max_concurrent_failed')
+})
+
 // Run startup reconciliation: mark stale sessions as failed and move
 // orphaned working issues to review.
 void startupReconciliation().catch((err) => {

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -230,21 +230,17 @@ general.get('/max-concurrent-executions', async (c) => {
 // PATCH /api/settings/max-concurrent-executions
 general.patch(
   '/max-concurrent-executions',
-  zValidator(
-    'json',
-    z.object({ value: z.number().int().min(1).max(20) }),
-    (result, c) => {
-      if (!result.success) {
-        return c.json(
-          {
-            success: false,
-            error: result.error.issues.map((i) => i.message).join(', '),
-          },
-          400,
-        )
-      }
-    },
-  ),
+  zValidator('json', z.object({ value: z.number().int().min(1).max(20) }), (result, c) => {
+    if (!result.success) {
+      return c.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join(', '),
+        },
+        400,
+      )
+    }
+  }),
   async (c) => {
     const { value } = c.req.valid('json')
     await setAppSetting(MAX_CONCURRENT_KEY, String(value))

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -213,6 +213,50 @@ general.patch(
   },
 )
 
+// --- Max Concurrent Executions ---
+
+const MAX_CONCURRENT_KEY = 'engine:maxConcurrentExecutions'
+const DEFAULT_MAX_CONCURRENT = Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
+
+// GET /api/settings/max-concurrent-executions
+general.get('/max-concurrent-executions', async (c) => {
+  const value = await getAppSetting(MAX_CONCURRENT_KEY)
+  return c.json({
+    success: true,
+    data: { value: value ? Number(value) : DEFAULT_MAX_CONCURRENT },
+  })
+})
+
+// PATCH /api/settings/max-concurrent-executions
+general.patch(
+  '/max-concurrent-executions',
+  zValidator(
+    'json',
+    z.object({ value: z.number().int().min(1).max(20) }),
+    (result, c) => {
+      if (!result.success) {
+        return c.json(
+          {
+            success: false,
+            error: result.error.issues.map((i) => i.message).join(', '),
+          },
+          400,
+        )
+      }
+    },
+  ),
+  async (c) => {
+    const { value } = c.req.valid('json')
+    await setAppSetting(MAX_CONCURRENT_KEY, String(value))
+
+    // Apply at runtime
+    const { issueEngine } = await import('@/engines/issue')
+    issueEngine.setMaxConcurrent(value)
+
+    return c.json({ success: true, data: { value } })
+  },
+)
+
 // --- Server Info ---
 
 // GET /api/settings/server-info

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -148,6 +148,15 @@ function GeneralSection({ open }: { open: boolean }) {
   const [serverInfoLoaded, setServerInfoLoaded] = useState(false)
   const { data: maxConcurrentData } = useMaxConcurrentExecutions(open)
   const setMaxConcurrent = useSetMaxConcurrentExecutions()
+  const [maxConcurrentInput, setMaxConcurrentInput] = useState('')
+  const maxConcurrentLoaded = useRef(false)
+
+  useEffect(() => {
+    if (maxConcurrentData && !maxConcurrentLoaded.current) {
+      setMaxConcurrentInput(String(maxConcurrentData.value))
+      maxConcurrentLoaded.current = true
+    }
+  }, [maxConcurrentData])
 
   const handleSelectWorkspace = (path: string) => {
     updateWsPath.mutate(path)
@@ -163,7 +172,10 @@ function GeneralSection({ open }: { open: boolean }) {
 
   // Reset loaded flag when dialog closes
   useEffect(() => {
-    if (!open) setServerInfoLoaded(false)
+    if (!open) {
+      setServerInfoLoaded(false)
+      maxConcurrentLoaded.current = false
+    }
   }, [open])
 
   const serverInfoDirty =
@@ -312,11 +324,14 @@ function GeneralSection({ open }: { open: boolean }) {
           min={1}
           max={20}
           className="w-24"
-          value={maxConcurrentData?.value ?? 5}
-          onChange={(e) => {
-            const v = Number.parseInt(e.target.value, 10)
+          value={maxConcurrentInput}
+          onChange={(e) => setMaxConcurrentInput(e.target.value)}
+          onBlur={() => {
+            const v = Number.parseInt(maxConcurrentInput, 10)
             if (v >= 1 && v <= 20) {
               setMaxConcurrent.mutate(v)
+            } else {
+              setMaxConcurrentInput(String(maxConcurrentData?.value ?? 5))
             }
           }}
         />

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -50,12 +50,14 @@ import {
   useEngineProfiles,
   useEngineSettings,
   useLogPageSize,
+  useMaxConcurrentExecutions,
   useProbeEngines,
   useRestartWithUpgrade,
   useRestoreDeletedIssue,
   useRunCleanup,
   useServerInfo,
   useSetLogPageSize,
+  useSetMaxConcurrentExecutions,
   useSetUpgradeEnabled,
   useSetWorktreeAutoCleanup,
   useSystemInfo,
@@ -144,6 +146,8 @@ function GeneralSection({ open }: { open: boolean }) {
   const [serverName, setServerName] = useState('')
   const [serverUrl, setServerUrl] = useState('')
   const [serverInfoLoaded, setServerInfoLoaded] = useState(false)
+  const { data: maxConcurrentData } = useMaxConcurrentExecutions(open)
+  const setMaxConcurrent = useSetMaxConcurrentExecutions()
 
   const handleSelectWorkspace = (path: string) => {
     updateWsPath.mutate(path)
@@ -299,6 +303,26 @@ function GeneralSection({ open }: { open: boolean }) {
           </SelectContent>
         </Select>
         <p className="text-[11px] text-muted-foreground">{t('settings.logPageSizeHint')}</p>
+      </Field>
+
+      <Field>
+        <Label>{t('settings.maxConcurrentExecutions')}</Label>
+        <Input
+          type="number"
+          min={1}
+          max={20}
+          className="w-24"
+          value={maxConcurrentData?.value ?? 5}
+          onChange={(e) => {
+            const v = Number.parseInt(e.target.value, 10)
+            if (v >= 1 && v <= 20) {
+              setMaxConcurrent.mutate(v)
+            }
+          }}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          {t('settings.maxConcurrentExecutionsHint')}
+        </p>
       </Field>
     </div>
   )

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -28,8 +28,7 @@ export const queryKeys = {
   projectWorktrees: (projectId: string) => ['projects', projectId, 'worktrees'] as const,
   logPageSize: () => ['settings', 'logPageSize'] as const,
   worktreeAutoCleanup: () => ['settings', 'worktreeAutoCleanup'] as const,
-  maxConcurrentExecutions: () =>
-    ['settings', 'maxConcurrentExecutions'] as const,
+  maxConcurrentExecutions: () => ['settings', 'maxConcurrentExecutions'] as const,
   upgradeVersion: () => ['upgrade', 'version'] as const,
   upgradeEnabled: () => ['upgrade', 'enabled'] as const,
   upgradeCheck: () => ['upgrade', 'check'] as const,

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -28,6 +28,8 @@ export const queryKeys = {
   projectWorktrees: (projectId: string) => ['projects', projectId, 'worktrees'] as const,
   logPageSize: () => ['settings', 'logPageSize'] as const,
   worktreeAutoCleanup: () => ['settings', 'worktreeAutoCleanup'] as const,
+  maxConcurrentExecutions: () =>
+    ['settings', 'maxConcurrentExecutions'] as const,
   upgradeVersion: () => ['upgrade', 'version'] as const,
   upgradeEnabled: () => ['upgrade', 'enabled'] as const,
   upgradeCheck: () => ['upgrade', 'check'] as const,
@@ -507,6 +509,29 @@ export function useSetWorktreeAutoCleanup() {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.worktreeAutoCleanup(),
+      })
+    },
+  })
+}
+
+// --- Max Concurrent Executions hooks ---
+
+export function useMaxConcurrentExecutions(enabled = false) {
+  return useQuery({
+    queryKey: queryKeys.maxConcurrentExecutions(),
+    queryFn: () => kanbanApi.getMaxConcurrentExecutions(),
+    enabled,
+    staleTime: Infinity,
+  })
+}
+
+export function useSetMaxConcurrentExecutions() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (value: number) => kanbanApi.setMaxConcurrentExecutions(value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.maxConcurrentExecutions(),
       })
     },
   })

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -311,6 +311,8 @@
     "fullWidthChatHint": "Remove the max-width limit on the chat message area",
     "logPageSize": "Messages per page",
     "logPageSizeHint": "Number of conversation messages (user and assistant) to load per page",
+    "maxConcurrentExecutions": "Max concurrent sessions",
+    "maxConcurrentExecutionsHint": "Maximum number of AI agent sessions that can run simultaneously (1–20)",
     "worktreeAutoCleanup": "Auto-cleanup worktrees",
     "worktreeAutoCleanupHint": "Automatically remove worktrees for issues that have been done for more than 1 day",
     "upgradeEnabled": "Auto-check updates",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -311,6 +311,8 @@
     "fullWidthChatHint": "移除聊天消息区域的最大宽度限制",
     "logPageSize": "消息加载数量",
     "logPageSizeHint": "每次加载的对话消息数量（用户和助手消息）",
+    "maxConcurrentExecutions": "最大并发会话数",
+    "maxConcurrentExecutionsHint": "允许同时运行的 AI 代理会话最大数量（1–20）",
     "worktreeAutoCleanup": "自动清理工作区",
     "worktreeAutoCleanupHint": "自动清理已完成超过 1 天的工作区",
     "upgradeEnabled": "自动检查更新",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -268,6 +268,12 @@ export const kanbanApi = {
     patch<{ enabled: boolean }>('/api/settings/worktree-auto-cleanup', {
       enabled,
     }),
+  getMaxConcurrentExecutions: () =>
+    get<{ value: number }>('/api/settings/max-concurrent-executions'),
+  setMaxConcurrentExecutions: (value: number) =>
+    patch<{ value: number }>('/api/settings/max-concurrent-executions', {
+      value,
+    }),
   getCleanupStats: () =>
     get<{
       logs: { logCount: number; toolCallCount: number }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-03-09 00:05 [progress]
+
+FEAT-003：MAX_CONCURRENT_EXECUTIONS 可通过设置页面配置
+
+- `ProcessManager` — `maxConcurrent` 改为可变，新增 `setMaxConcurrent()` 方法
+- `IssueEngine` — 新增 `setMaxConcurrent()` + `initMaxConcurrent()` 启动时从 DB 读取
+- `routes/settings/general.ts` — 新增 GET/PATCH `/api/settings/max-concurrent-executions`
+- Frontend — 设置页 General 区域新增数字输入框，支持 1–20 范围
+- i18n — 新增 `maxConcurrentExecutions` / `maxConcurrentExecutionsHint` 键
+
 ## 2026-03-08 23:50 [progress]
 
 LINT-001: Migrate from Biome to ESLint + Prettier

--- a/docs/task/FEAT-003.md
+++ b/docs/task/FEAT-003.md
@@ -1,0 +1,17 @@
+# FEAT-003 MAX_CONCURRENT_EXECUTIONS 可通过设置配置
+
+- **status**: completed
+- **priority**: P2
+- **owner**: claude
+- **plan**: PLAN-006
+
+## Description
+
+将 `MAX_CONCURRENT_EXECUTIONS` 从环境变量静态常量改为通过设置页面配置、从数据库读取，支持运行时动态修改。
+
+## Acceptance Criteria
+
+- [ ] Settings UI 中可配置最大并发数
+- [ ] 值存储在 appSettings 表中
+- [ ] 运行时修改立即生效（不需重启）
+- [ ] 环境变量作为 fallback，默认值 5

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -14,6 +14,7 @@
 
 - [x] **FEAT-001 添加 server_name 和 server_url 环境变量** `P2` - file: `docs/task/FEAT-001.md`
 - [x] **FEAT-002 将 SERVER_NAME 和 SERVER_URL 从环境变量迁移到数据库** `P2` - owner: claude - file: `docs/task/FEAT-002.md`
+- [x] **FEAT-003 MAX_CONCURRENT_EXECUTIONS 可通过设置配置** `P2` - owner: claude - plan: `PLAN-006` - file: `docs/task/FEAT-003.md`
 
 ## Webhook
 


### PR DESCRIPTION
## Summary

- Move `MAX_CONCURRENT_EXECUTIONS` from a static env-var constant to a database-backed setting configurable at runtime through the settings UI
- Add `setMaxConcurrent()` method to `ProcessManager` and `IssueEngine` for runtime updates
- Add `GET/PATCH /api/settings/max-concurrent-executions` API endpoints
- Add number input (1–20 range) in the General settings section with zh/en i18n support
- Env var kept as fallback, default remains 5

## Test plan

- [x] Process manager tests pass (39/39)
- [x] Frontend tests pass (28/28)
- [x] Lint passes (no new warnings)
- [ ] Manual: open settings → General → change max concurrent sessions value → verify it persists after page reload
- [ ] Manual: verify running sessions are not affected when reducing the limit