### PR TITLE
fix: replace Bun.spawn with node:child_process for Claude executor

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { CommandBuilder } from '@/engines/command'
 import { safeEnv } from '@/engines/safe-env'
+import { spawnNode } from '@/engines/spawn'
 import type {
   EngineAvailability,
   EngineCapability,
@@ -129,7 +130,8 @@ export class ClaudeCodeExecutor implements EngineExecutor {
         .env('NPM_CONFIG_LOGLEVEL', 'error')
         .resolve()
 
-      const proc = Bun.spawn([resolved.resolvedPath, ...resolved.args], {
+      const proc = spawnNode([resolved.resolvedPath, ...resolved.args], {
+        stdin: 'ignore',
         stdout: 'pipe',
         stderr: 'pipe',
         env: safeEnv(resolved.env),
@@ -214,7 +216,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       .cwd(workingDir)
       .resolve()
 
-    const proc = Bun.spawn([resolved.resolvedPath, ...resolved.args], {
+    const proc = spawnNode([resolved.resolvedPath, ...resolved.args], {
       cwd: resolved.cwd ?? workingDir,
       stdin: 'ignore',
       stdout: 'pipe',
@@ -405,7 +407,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       `claude_${mode}_command`,
     )
 
-    const proc = Bun.spawn([resolved.resolvedPath, ...resolved.args], {
+    const proc = spawnNode([resolved.resolvedPath, ...resolved.args], {
       cwd: resolved.cwd ?? options.workingDir,
       stdin: 'pipe',
       stdout: 'pipe',
@@ -426,7 +428,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
     logger.debug(
       {
         issueId: env.issueId,
-        pid: (proc as { pid?: number }).pid,
+        pid: proc.pid,
         mode,
         promptChars: options.prompt.length,
         permissionMode: options.permissionMode ?? 'auto',
@@ -435,12 +437,12 @@ export class ClaudeCodeExecutor implements EngineExecutor {
     )
 
     // Wrap stdout to intercept control_request messages
-    const filteredStdout = handler.wrapStdout(proc.stdout as ReadableStream<Uint8Array>)
+    const filteredStdout = handler.wrapStdout(proc.stdout)
 
     return {
-      subprocess: proc,
+      subprocess: proc as unknown as SpawnedProcess['subprocess'],
       stdout: filteredStdout,
-      stderr: proc.stderr as ReadableStream<Uint8Array>,
+      stderr: proc.stderr,
       cancel: () => handler.interrupt(),
       protocolHandler: handler,
       spawnCommand: [resolved.resolvedPath, ...resolved.args].join(' '),

--- a/apps/api/src/engines/executors/claude/protocol.ts
+++ b/apps/api/src/engines/executors/claude/protocol.ts
@@ -1,5 +1,5 @@
-import type { FileSink } from 'bun'
 import { ulid } from 'ulid'
+import type { StdinWriter } from '@/engines/spawn'
 import type { PermissionPolicy } from '@/engines/types'
 import { logger } from '@/logger'
 
@@ -89,7 +89,7 @@ interface ControlRequest {
  * normal log entries.
  */
 export class ClaudeProtocolHandler {
-  private stdin: FileSink
+  private stdin: StdinWriter
   private closed = false
   /**
    * Called when ANY stdout data is received from the process, signaling it is alive.
@@ -101,7 +101,7 @@ export class ClaudeProtocolHandler {
   /** Called when a Result message is received, signaling turn completion. */
   onResult?: (data: unknown) => void
 
-  constructor(stdin: FileSink) {
+  constructor(stdin: StdinWriter) {
     this.stdin = stdin
   }
 

--- a/apps/api/src/engines/spawn.ts
+++ b/apps/api/src/engines/spawn.ts
@@ -6,9 +6,9 @@ import { Readable } from 'node:stream'
  * Used by ClaudeProtocolHandler to write JSON to stdin.
  */
 export interface StdinWriter {
-  write(data: string | Uint8Array): void
-  end(): void
-  flush?(): void
+  write: (data: string | Uint8Array) => void
+  end: () => void
+  flush?: () => void
 }
 
 interface SpawnResult {
@@ -17,7 +17,7 @@ interface SpawnResult {
   stdout: ReadableStream<Uint8Array>
   stderr: ReadableStream<Uint8Array>
   exited: Promise<number>
-  kill(signal?: number): void
+  kill: (signal?: number) => void
 }
 
 interface SpawnOptions {
@@ -79,10 +79,20 @@ export function spawnNode(
     ? nodeReadableToWebStream(child.stderr)
     : emptyReadableStream()
 
-  // Create exited promise from exit event
+  // Create exited promise from exit event.
+  // Preserve signal exit codes (128 + signal) for compatibility with
+  // completion-monitor.ts which derives signal info from exitCode > 128.
   const exited = new Promise<number>((resolve, reject) => {
-    child.on('exit', (code) => {
-      resolve(code ?? 1)
+    child.on('exit', (code, signal) => {
+      if (code !== null) {
+        resolve(code)
+      } else if (signal) {
+        // Match Bun convention: signal-terminated → 128 + signal number
+        const sigNum = SIGNAL_NUMBERS[signal] ?? 15
+        resolve(128 + sigNum)
+      } else {
+        resolve(1)
+      }
     })
     child.on('error', (err) => {
       reject(err)
@@ -103,6 +113,14 @@ export function spawnNode(
       }
     },
   }
+}
+
+const SIGNAL_NUMBERS: Record<string, number> = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGKILL: 9,
+  SIGTERM: 15,
 }
 
 function nodeReadableToWebStream(readable: Readable): ReadableStream<Uint8Array> {

--- a/apps/api/src/engines/spawn.ts
+++ b/apps/api/src/engines/spawn.ts
@@ -1,0 +1,118 @@
+import { spawn as nodeSpawn } from 'node:child_process'
+import { Readable } from 'node:stream'
+
+/**
+ * Writable interface compatible with Bun's FileSink.
+ * Used by ClaudeProtocolHandler to write JSON to stdin.
+ */
+export interface StdinWriter {
+  write(data: string | Uint8Array): void
+  end(): void
+  flush?(): void
+}
+
+interface SpawnResult {
+  pid: number | undefined
+  stdin: StdinWriter
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+  kill(signal?: number): void
+}
+
+interface SpawnOptions {
+  cwd?: string
+  stdin?: 'pipe' | 'ignore'
+  stdout?: 'pipe' | 'ignore'
+  stderr?: 'pipe' | 'ignore'
+  env?: Record<string, string | undefined>
+}
+
+/**
+ * Spawn a child process using node:child_process instead of Bun.spawn.
+ *
+ * Returns an object compatible with Bun's Subprocess interface so that
+ * ProcessManager and other consumers work without changes.
+ *
+ * Motivation: Bun.spawn has a known stdout pipe breakage bug where the
+ * pipe closes prematurely while the process is still alive. Node's
+ * child_process.spawn uses battle-tested pipe handling.
+ */
+export function spawnNode(
+  cmd: string[],
+  options?: SpawnOptions,
+): SpawnResult {
+  const [program, ...args] = cmd
+  const child = nodeSpawn(program, args, {
+    cwd: options?.cwd,
+    stdio: [
+      options?.stdin ?? 'pipe',
+      options?.stdout ?? 'pipe',
+      options?.stderr ?? 'pipe',
+    ],
+    env: options?.env as NodeJS.ProcessEnv,
+  })
+
+  // Wrap stdin as StdinWriter (compatible with Bun FileSink interface)
+  const stdin: StdinWriter = {
+    write(data: string | Uint8Array) {
+      if (child.stdin && !child.stdin.destroyed) {
+        child.stdin.write(data)
+      }
+    },
+    end() {
+      if (child.stdin && !child.stdin.destroyed) {
+        child.stdin.end()
+      }
+    },
+    flush() {
+      // Node streams auto-flush; no-op for compatibility
+    },
+  }
+
+  // Convert Node Readable to Web ReadableStream
+  const stdout = child.stdout
+    ? nodeReadableToWebStream(child.stdout)
+    : emptyReadableStream()
+
+  const stderr = child.stderr
+    ? nodeReadableToWebStream(child.stderr)
+    : emptyReadableStream()
+
+  // Create exited promise from exit event
+  const exited = new Promise<number>((resolve, reject) => {
+    child.on('exit', (code) => {
+      resolve(code ?? 1)
+    })
+    child.on('error', (err) => {
+      reject(err)
+    })
+  })
+
+  return {
+    pid: child.pid,
+    stdin,
+    stdout,
+    stderr,
+    exited,
+    kill(signal?: number) {
+      try {
+        child.kill(signal)
+      } catch {
+        // already dead
+      }
+    },
+  }
+}
+
+function nodeReadableToWebStream(readable: Readable): ReadableStream<Uint8Array> {
+  return Readable.toWeb(readable) as unknown as ReadableStream<Uint8Array>
+}
+
+function emptyReadableStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close()
+    },
+  })
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-03-09 05:00 [BUG-P0]
+
+PIPE-001: Replace Bun.spawn with node:child_process for Claude executor
+
+- Root cause: Bun.spawn stdout pipe breaks prematurely while process still alive
+- Process stays alive (stdin open) → subprocess.exited never resolves → no settlement → frontend stuck in "thinking"
+- Created `engines/spawn.ts` — node:child_process wrapper with Bun Subprocess-compatible interface
+- Updated `ClaudeProtocolHandler` stdin type from Bun `FileSink` to generic `StdinWriter`
+- Replaced all 3 Bun.spawn calls in claude executor with `spawnNode()`
+- Other executors (codex, gemini, echo) unchanged — only claude-code affected
+
 ## 2026-03-09 04:00 [progress]
 
 UI-003: Remove devMode feature entirely

--- a/docs/task/PIPE-001.md
+++ b/docs/task/PIPE-001.md
@@ -1,0 +1,24 @@
+# PIPE-001 Claude executor 替换 Bun.spawn 为 node:child_process
+
+- **status**: completed
+- **priority**: P0
+- **owner**: claude
+- **created**: 2026-03-09
+
+## Context
+
+Bun.spawn 的 stdout pipe 在某些情况下会意外断裂（Bun pipe bug），导致：
+1. 进程仍在运行（stdin 保持打开），但 BKD 无法读取 stdout
+2. Transcript fallback 接管但无法检测 turn 完成（10 分钟后超时）
+3. `subprocess.exited` 永远不 resolve → 不触发 settlement → 前端卡在 "thinking"
+4. 用户发的 follow-up 消息以 `followup_queued_during_active_turn` 排队，无法执行
+
+## Solution
+
+混合方案：仅 claude executor 替换为 node:child_process.spawn，其他 executor 保持 Bun.spawn。
+
+## Files
+
+- `apps/api/src/engines/spawn.ts` — 新文件，node:child_process 包装器
+- `apps/api/src/engines/executors/claude/executor.ts` — 使用包装器
+- `apps/api/src/engines/executors/claude/protocol.ts` — stdin 类型适配

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -81,6 +81,10 @@
 - [x] **UI-002 Suppress queue-operation/progress raw text in chat** `P2` - owner: claude - file: `docs/task/UI-002.md`
 - [x] **UI-003 Remove devMode feature entirely** `P2` - owner: claude - file: `docs/task/UI-003.md`
 
+## Pipe Reliability
+
+- [x] **PIPE-001 Claude executor 替换 Bun.spawn 为 node:child_process** `P0` - owner: claude - file: `docs/task/PIPE-001.md`
+
 ## Bug Fix
 
 - [x] **BUG-001 未指定 root 目录时以自身所在目录为 root** `P1` - file: `docs/task/BUG-001.md`


### PR DESCRIPTION
## Summary

- Bun.spawn has a stdout pipe breakage bug where the pipe closes prematurely while the process is still alive
- This causes `subprocess.exited` to never resolve, blocking settlement and leaving the frontend stuck in "thinking" state
- Switch Claude executor to `node:child_process.spawn` which has battle-tested pipe handling
- Other executors (codex, gemini, echo) remain on Bun.spawn as they are unaffected

## Changes

- Add `engines/spawn.ts` — `spawnNode()` wrapper with Bun Subprocess-compatible interface (`StdinWriter`, Web ReadableStream conversion, `exited` Promise)
- Update `ClaudeProtocolHandler` stdin type from Bun `FileSink` to generic `StdinWriter`
- Replace all 3 `Bun.spawn` calls in Claude executor (`spawnProcess`, `getAvailability`, `discoverSlashCommandsAndAgents`)

## Test plan

- [x] TypeScript compilation passes (no new errors)
- [x] API tests pass (357 pass, 7 pre-existing failures unrelated to this change)
- [ ] Manual test: execute a Claude issue and verify stdout stream works end-to-end
- [ ] Manual test: verify settlement triggers correctly after process exits