### PR TITLE
fix: pending messages not shown for todo issues, UI improvements

### DIFF
--- a/apps/frontend/src/components/files/FileBreadcrumb.tsx
+++ b/apps/frontend/src/components/files/FileBreadcrumb.tsx
@@ -3,13 +3,15 @@ import { useTranslation } from 'react-i18next'
 
 interface FileBreadcrumbProps {
   projectName: string
+  rootPath?: string
   path: string
   onNavigate: (path: string) => void
 }
 
-export function FileBreadcrumb({ projectName, path, onNavigate }: FileBreadcrumbProps) {
+export function FileBreadcrumb({ projectName, rootPath, path, onNavigate }: FileBreadcrumbProps) {
   const { t } = useTranslation()
   const segments = path && path !== '.' ? path.split('/') : []
+  const displayRoot = rootPath ?? projectName
 
   return (
     <nav
@@ -22,7 +24,7 @@ export function FileBreadcrumb({ projectName, path, onNavigate }: FileBreadcrumb
         className="flex items-center gap-1 px-1.5 py-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shrink-0"
       >
         <Home className="h-3.5 w-3.5" />
-        <span className="font-medium">{projectName}</span>
+        <span className="font-medium font-mono text-xs">{displayRoot}</span>
       </button>
 
       {segments.map((segment, i) => {

--- a/apps/frontend/src/components/files/FileBrowserContent.tsx
+++ b/apps/frontend/src/components/files/FileBrowserContent.tsx
@@ -39,10 +39,11 @@ export function FileBrowserContent({
   const effectiveRoot = rootPath ?? project?.directory ?? null
 
   const handleCopyPath = useCallback(() => {
-    navigator.clipboard.writeText(currentPath === '.' ? '/' : currentPath)
+    const fullPath = currentPath === '.' ? (effectiveRoot ?? '/') : (effectiveRoot ? `${effectiveRoot}/${currentPath}` : currentPath)
+    navigator.clipboard.writeText(fullPath)
     setCopied(true)
     setTimeout(setCopied, 1500, false)
-  }, [currentPath])
+  }, [currentPath, effectiveRoot])
 
   const handleDownload = useCallback(() => {
     if (!effectiveRoot || currentPath === '.') return
@@ -81,9 +82,8 @@ export function FileBrowserContent({
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          <span className="text-xs font-medium text-muted-foreground truncate">
-            {project?.name ?? t('fileBrowser.title')}
-            {rootPath ? ` (${rootPath.split('/').pop()})` : ''}
+          <span className="text-xs font-medium text-muted-foreground truncate font-mono">
+            {effectiveRoot ?? project?.name ?? t('fileBrowser.title')}
           </span>
         </div>
         <div className="flex items-center gap-1">
@@ -130,6 +130,7 @@ export function FileBrowserContent({
       <div className="px-3 py-2 border-b border-border shrink-0">
         <FileBreadcrumb
           projectName={project?.name ?? ''}
+          rootPath={effectiveRoot ?? undefined}
           path={currentPath}
           onNavigate={navigateTo}
         />

--- a/apps/frontend/src/components/files/FileBrowserDrawer.tsx
+++ b/apps/frontend/src/components/files/FileBrowserDrawer.tsx
@@ -15,6 +15,7 @@ export function FileBrowserDrawer() {
     isOpen,
     isFullscreen,
     inlineMode,
+    forceDrawer,
     width,
     projectId,
     close,
@@ -25,8 +26,9 @@ export function FileBrowserDrawer() {
   const isMobile = useIsMobile()
   const dragRef = useRef<{ startX: number, startWidth: number } | null>(null)
 
-  // Skip rendering when an inline panel handles the file browser (issue/review pages)
-  if (!isOpen || !projectId || inlineMode) return null
+  // Skip rendering when an inline panel handles the file browser,
+  // unless forceDrawer is set (opened explicitly from header)
+  if (!isOpen || !projectId || (inlineMode && !forceDrawer)) return null
 
   const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth
   const maxWidth = Math.round(viewportWidth * FILE_BROWSER_MAX_WIDTH_RATIO)

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -166,7 +166,7 @@ export function ChatInput({
   const additions = changesSummary?.additions ?? 0
   const deletions = changesSummary?.deletions ?? 0
   const changesRoot = (changesSummary as { root?: string } | null)?.root
-  const openFileBrowser = useFileBrowserStore(s => s.open)
+  const openFileBrowser = useFileBrowserStore(s => s.toggleDrawer)
 
   // Fetch models for current engine
   const { data: discovery } = useEngineAvailability(!!engineType)

--- a/apps/frontend/src/components/issue-detail/DiffPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/DiffPanel.tsx
@@ -1,9 +1,8 @@
-import { ChevronRight, Copy, FolderOpen, X } from 'lucide-react'
+import { ChevronRight, Copy, X } from 'lucide-react'
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useIssueChanges, useIssueFilePatch } from '@/hooks/use-kanban'
 import { useTheme } from '@/hooks/use-theme'
-import { useFileBrowserStore } from '@/stores/file-browser-store'
 import type { IssueChangedFile } from '@/types/kanban'
 import { DIFF_MIN_WIDTH } from './diff-constants'
 
@@ -75,8 +74,6 @@ export function DiffPanel({
   const { t } = useTranslation()
   const changesQuery = useIssueChanges(projectId, issueId, true)
   const files = changesQuery.data?.files ?? []
-  const changesRoot = changesQuery.data?.root
-  const openFileBrowser = useFileBrowserStore(s => s.open)
 
   return (
     <div
@@ -92,14 +89,6 @@ export function DiffPanel({
       <div className="flex flex-col h-full min-h-0">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/60 shrink-0 min-h-[45px] bg-background/80 backdrop-blur-sm">
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => openFileBrowser(projectId, changesRoot)}
-              className="flex items-center justify-center h-7 w-7 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-all duration-150"
-              title={t('diff.openFiles')}
-            >
-              <FolderOpen className="h-4 w-4" />
-            </button>
             <span className="text-sm font-semibold tracking-tight">{t('diff.changes')}</span>
             <span className="text-[11px] font-medium text-muted-foreground/60 bg-muted/50 rounded-full px-1.5 py-0.5 tabular-nums">
               {files.length}

--- a/apps/frontend/src/components/issue-detail/LogEntry.tsx
+++ b/apps/frontend/src/components/issue-detail/LogEntry.tsx
@@ -178,8 +178,10 @@ export function LogEntry({
       const isPending = entry.metadata?.type === 'pending'
       const isDone = entry.metadata?.type === 'done'
       const messageAttachments = (entry.metadata?.attachments ?? []) as AttachmentMeta[]
+      // Strip "--- Attached files ---" block from display (already shown as chips)
+      const displayContent = entry.content.replace(/\n*--- Attached files ---\n(?:\[Attached file:.*\]\n?)*/g, '').trim()
       // Skip empty user messages (no text, no attachments, not pending/done)
-      if (!entry.content.trim() && messageAttachments.length === 0 && !isPending && !isDone)
+      if (!displayContent && messageAttachments.length === 0 && !isPending && !isDone)
         return null
       const barColor = isPending ?
         'border-amber-400 bg-amber-500/[0.06]' :
@@ -189,10 +191,10 @@ export function LogEntry({
       return (
         <div className="group py-2 animate-message-enter">
           <div className={`bg-muted/70 px-3 py-2.5 border border-l-[3px] ${barColor}`}>
-            {entry.content.trim() ?
+            {displayContent ?
                 (
                   <div className="text-[15px] whitespace-pre-wrap break-words text-foreground leading-[1.75]">
-                    {entry.content}
+                    {displayContent}
                   </div>
                 ) :
               null}

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -175,7 +175,7 @@ export function SessionMessages({
 
   const initialScrollDone = useRef(false)
   useEffect(() => {
-    if (initialScrollDone.current || messages.length === 0) return
+    if (initialScrollDone.current || (messages.length === 0 && pendingMessages.length === 0)) return
     const el = scrollRef?.current
     if (!el) return
     // Double-rAF ensures the lazy-loaded content has been painted before
@@ -187,7 +187,7 @@ export function SessionMessages({
         initialScrollDone.current = true
       })
     })
-  }, [messages.length, scrollRef])
+  }, [messages.length, pendingMessages.length, scrollRef])
 
   const prevLenRef = useRef(messages.length)
   const prevFirstIdRef = useRef(messages[0]?.id)
@@ -215,7 +215,7 @@ export function SessionMessages({
     prevFirstIdRef.current = firstId
   }, [messages.length, isRunning, scrollRef])
 
-  if (messages.length === 0 && !isRunning) return null
+  if (messages.length === 0 && pendingMessages.length === 0 && !isRunning) return null
 
   return (
     <div className={`flex flex-col py-2 px-5${fullWidthChat ? '' : ' max-w-4xl'}`}>

--- a/apps/frontend/src/components/kanban/KanbanHeader.tsx
+++ b/apps/frontend/src/components/kanban/KanbanHeader.tsx
@@ -25,7 +25,7 @@ export function KanbanHeader({
 }) {
   const { t } = useTranslation()
   const openCreateDialog = usePanelStore(s => s.openCreateDialog)
-  const toggleFileBrowser = useFileBrowserStore(s => s.toggle)
+  const toggleFileBrowser = useFileBrowserStore(s => s.toggleDrawer)
   const toggleProcessManager = useProcessManagerStore(s => s.toggle)
   const [showSettings, setShowSettings] = useState(false)
 
@@ -48,7 +48,7 @@ export function KanbanHeader({
           {project.directory && (
             <button
               type="button"
-              onClick={() => toggleFileBrowser(project.alias)}
+              onClick={() => toggleFileBrowser(project.alias, project.directory ?? undefined)}
               className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.07] transition-colors shrink-0"
               aria-label={t('viewMode.files')}
               title={t('viewMode.files')}

--- a/apps/frontend/src/stores/file-browser-store.ts
+++ b/apps/frontend/src/stores/file-browser-store.ts
@@ -14,6 +14,11 @@ function clampWidth(w: number): number {
   return Math.max(min, Math.min(w, max))
 }
 
+/** Build a cache key for per-context path persistence. */
+function contextKey(projectId: string, rootPath: string | null): string {
+  return rootPath ? `${projectId}:${rootPath}` : projectId
+}
+
 interface FileBrowserStore {
   isOpen: boolean
   isMinimized: boolean
@@ -27,6 +32,8 @@ interface FileBrowserStore {
   rootPath: string | null
   currentPath: string
   hideIgnored: boolean
+  /** Per-context path cache so switching contexts restores the last position. */
+  pathCache: Map<string, string>
   open: (projectId: string, rootPath?: string) => void
   openFullscreen: (projectId: string, rootPath?: string) => void
   close: () => void
@@ -45,6 +52,31 @@ interface FileBrowserStore {
 export { MIN_WIDTH as FILE_BROWSER_MIN_WIDTH }
 export const FILE_BROWSER_MAX_WIDTH_RATIO = MAX_WIDTH_RATIO
 
+/**
+ * Save current path to cache and resolve the path for a new context.
+ * Returns the cached path or '.' if the context is new.
+ */
+function switchContext(
+  s: FileBrowserStore,
+  projectId: string,
+  rootPath: string | null,
+): { currentPath: string, pathCache: Map<string, string> } {
+  const newKey = contextKey(projectId, rootPath)
+  const oldKey = s.projectId ? contextKey(s.projectId, s.rootPath) : null
+
+  // Same context — keep current path, no cache update needed
+  if (oldKey === newKey) {
+    return { currentPath: s.currentPath, pathCache: s.pathCache }
+  }
+
+  // Save current path for the old context
+  const cache = new Map(s.pathCache)
+  if (oldKey) cache.set(oldKey, s.currentPath)
+
+  // Restore cached path for the new context
+  return { currentPath: cache.get(newKey) ?? '.', pathCache: cache }
+}
+
 export const useFileBrowserStore = create<FileBrowserStore>(set => ({
   isOpen: false,
   isMinimized: false,
@@ -56,46 +88,54 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
   rootPath: null,
   currentPath: '.',
   hideIgnored: false,
+  pathCache: new Map(),
 
   open: (projectId, rootPath) =>
-    set(s => ({
-      isOpen: true,
-      isMinimized: false,
-      projectId,
-      rootPath: rootPath ?? null,
-      currentPath:
-        s.projectId === projectId && s.rootPath === (rootPath ?? null) ? s.currentPath : '.',
-    })),
+    set((s) => {
+      const ctx = switchContext(s, projectId, rootPath ?? null)
+      return {
+        isOpen: true,
+        isMinimized: false,
+        projectId,
+        rootPath: rootPath ?? null,
+        ...ctx,
+      }
+    }),
   openFullscreen: (projectId, rootPath) =>
-    set(s => ({
-      isOpen: true,
-      isMinimized: false,
-      isFullscreen: true,
-      projectId,
-      rootPath: rootPath ?? null,
-      currentPath:
-        s.projectId === projectId && s.rootPath === (rootPath ?? null) ? s.currentPath : '.',
-    })),
+    set((s) => {
+      const ctx = switchContext(s, projectId, rootPath ?? null)
+      return {
+        isOpen: true,
+        isMinimized: false,
+        isFullscreen: true,
+        projectId,
+        rootPath: rootPath ?? null,
+        ...ctx,
+      }
+    }),
   close: () => set({ isOpen: false, forceDrawer: false }),
   toggle: projectId =>
     set((s) => {
       if (s.isMinimized) {
+        const ctx = switchContext(s, projectId, s.projectId === projectId ? s.rootPath : null)
         return {
           isOpen: true,
           isMinimized: false,
           projectId,
           rootPath: s.projectId === projectId ? s.rootPath : null,
-          currentPath: s.projectId === projectId ? s.currentPath : '.',
+          ...ctx,
         }
       }
       if (s.isOpen && s.projectId === projectId) {
         return { isOpen: false }
       }
+      const newRoot = s.projectId === projectId ? s.rootPath : null
+      const ctx = switchContext(s, projectId, newRoot)
       return {
         isOpen: true,
         projectId,
-        rootPath: s.projectId === projectId ? s.rootPath : null,
-        currentPath: s.projectId === projectId ? s.currentPath : '.',
+        rootPath: newRoot,
+        ...ctx,
       }
     }),
   toggleDrawer: (projectId, rootPath) =>
@@ -103,13 +143,15 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
       if (s.isOpen && s.forceDrawer && s.projectId === projectId) {
         return { isOpen: false, forceDrawer: false }
       }
+      const effectiveRoot = rootPath ?? (s.projectId === projectId ? s.rootPath : null)
+      const ctx = switchContext(s, projectId, effectiveRoot)
       return {
         isOpen: true,
         isMinimized: false,
         forceDrawer: true,
         projectId,
-        rootPath: rootPath ?? (s.projectId === projectId ? s.rootPath : null),
-        currentPath: s.projectId === projectId && s.rootPath === (rootPath ?? null) ? s.currentPath : '.',
+        rootPath: effectiveRoot,
+        ...ctx,
       }
     }),
   minimize: () => set({ isOpen: false, isMinimized: true, isFullscreen: false }),

--- a/apps/frontend/src/stores/file-browser-store.ts
+++ b/apps/frontend/src/stores/file-browser-store.ts
@@ -20,6 +20,8 @@ interface FileBrowserStore {
   isFullscreen: boolean
   /** When true, an inline panel handles rendering (suppresses the global drawer) */
   inlineMode: boolean
+  /** When true, force drawer rendering even if inlineMode is on */
+  forceDrawer: boolean
   width: number
   projectId: string | null
   rootPath: string | null
@@ -29,6 +31,8 @@ interface FileBrowserStore {
   openFullscreen: (projectId: string, rootPath?: string) => void
   close: () => void
   toggle: (projectId: string) => void
+  /** Toggle as drawer, overriding inlineMode so the global drawer renders. */
+  toggleDrawer: (projectId: string, rootPath?: string) => void
   minimize: () => void
   restore: () => void
   toggleFullscreen: () => void
@@ -46,6 +50,7 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
   isMinimized: false,
   isFullscreen: false,
   inlineMode: false,
+  forceDrawer: false,
   width: Math.round(getViewportWidth() * DEFAULT_WIDTH_RATIO),
   projectId: null,
   rootPath: null,
@@ -71,7 +76,7 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
       currentPath:
         s.projectId === projectId && s.rootPath === (rootPath ?? null) ? s.currentPath : '.',
     })),
-  close: () => set({ isOpen: false }),
+  close: () => set({ isOpen: false, forceDrawer: false }),
   toggle: projectId =>
     set((s) => {
       if (s.isMinimized) {
@@ -91,6 +96,20 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
         projectId,
         rootPath: s.projectId === projectId ? s.rootPath : null,
         currentPath: s.projectId === projectId ? s.currentPath : '.',
+      }
+    }),
+  toggleDrawer: (projectId, rootPath) =>
+    set((s) => {
+      if (s.isOpen && s.forceDrawer && s.projectId === projectId) {
+        return { isOpen: false, forceDrawer: false }
+      }
+      return {
+        isOpen: true,
+        isMinimized: false,
+        forceDrawer: true,
+        projectId,
+        rootPath: rootPath ?? (s.projectId === projectId ? s.rootPath : null),
+        currentPath: s.projectId === projectId && s.rootPath === (rootPath ?? null) ? s.currentPath : '.',
       }
     }),
   minimize: () => set({ isOpen: false, isMinimized: true, isFullscreen: false }),

--- a/docs/task/BUG-006.md
+++ b/docs/task/BUG-006.md
@@ -1,0 +1,31 @@
+# BUG-006 Pending messages not displayed for todo issues
+
+- **status**: completed
+- **priority**: P1
+- **owner**: claude
+
+## Problem
+
+When an issue's status is "todo", sending a message creates a pending message that is correctly stored and categorized, but the chat UI does not display it.
+
+### Root Cause
+
+`SessionMessages.tsx` line 218 has an early return:
+```ts
+if (messages.length === 0 && !isRunning) return null
+```
+
+Pending messages are extracted into a separate `pendingMessages` array by `useChatMessages()`. When there are no non-pending messages (common for "todo" issues), the `messages` array is empty, `isRunning` is false, and the component returns null before reaching the pending messages rendering section.
+
+Additionally, the "--- Attached files ---" block appended to message content by the backend was displayed as raw text, despite attachments already being shown as metadata chips.
+
+## Fix
+
+1. Changed early return guard to also check `pendingMessages.length`
+2. Updated initial scroll effect dependency to include `pendingMessages.length`
+3. Strip "--- Attached files ---" block from displayed content in `LogEntry`
+
+## Files Changed
+
+- `apps/frontend/src/components/issue-detail/SessionMessages.tsx`
+- `apps/frontend/src/components/issue-detail/LogEntry.tsx`

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -88,3 +88,4 @@
 - [x] **BUG-003 升级不要自动下载，只提示新版本** `P1` - file: `docs/task/BUG-003.md`
 - [x] **BUG-004 非 dev 模式不应返回 tool-use 消息** `P1` - owner: claude - file: `docs/task/BUG-004.md`
 - [x] **BUG-005 File browser rejects valid worktree root paths** `P1` - owner: claude - file: `docs/task/BUG-005.md`
+- [x] **BUG-006 Pending messages not displayed for todo issues** `P1` - owner: claude - file: `docs/task/BUG-006.md`


### PR DESCRIPTION
## Summary

- Fix pending messages not displaying for todo issues after page refresh, issue switch, or initial load
- ChatInput file button now opens as drawer (works on issue detail pages)
- File browser shows full absolute path in breadcrumb and copies full path
- File browser caches browsed position per project/worktree context
- Remove folder icon from diff panel Changes header
- Strip raw "--- Attached files ---" block from displayed message content

## Changes

**SessionMessages.tsx** — Early return guard now checks `pendingMessages.length`, fixing the root cause where pending-only views returned null

**LogEntry.tsx** — Strip `--- Attached files ---` block from displayed content (already shown as attachment chips)

**DiffPanel.tsx** — Remove FolderOpen button from Changes header

**FileBreadcrumb.tsx / FileBrowserContent.tsx** — Show full absolute path, copy full path

**ChatInput.tsx** — Use `toggleDrawer` instead of `open` for file browser button

**KanbanHeader.tsx** — Use `toggleDrawer` with `project.directory` for header file browser button

**FileBrowserDrawer.tsx** — Render when `forceDrawer` is set, even if `inlineMode` is active

**file-browser-store.ts** — Add `forceDrawer` flag, `toggleDrawer` action, and per-context `pathCache` for position persistence

## Test plan

- [ ] Create a todo issue, send a message — pending message should display immediately
- [ ] Refresh the page — pending message should still be visible at the bottom
- [ ] Switch to another issue and back — pending message should persist
- [ ] Click file browser icon in kanban header on issue detail page — should open as drawer
- [ ] Click file browser icon in ChatInput area — should open as drawer with worktree path
- [ ] Browse files in one context, switch to another, switch back — position should be restored
- [ ] Verify diff panel Changes header has no folder icon
- [ ] Verify file browser breadcrumb shows full absolute path