### PR TITLE
feat: file browser drawer/inline separation and UI improvements

### DIFF
--- a/apps/frontend/src/components/files/FileBreadcrumb.tsx
+++ b/apps/frontend/src/components/files/FileBreadcrumb.tsx
@@ -1,30 +1,26 @@
-import { ChevronRight, Home } from 'lucide-react'
+import { Home } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 interface FileBreadcrumbProps {
-  projectName: string
-  rootPath?: string
   path: string
   onNavigate: (path: string) => void
 }
 
-export function FileBreadcrumb({ projectName, rootPath, path, onNavigate }: FileBreadcrumbProps) {
+export function FileBreadcrumb({ path, onNavigate }: FileBreadcrumbProps) {
   const { t } = useTranslation()
   const segments = path && path !== '.' ? path.split('/') : []
-  const displayRoot = rootPath ?? projectName
 
   return (
     <nav
       aria-label={t('fileBrowser.breadcrumb')}
-      className="flex items-center gap-1 text-sm overflow-x-auto"
+      className="flex items-center gap-1.5 text-sm overflow-x-auto"
     >
       <button
         type="button"
         onClick={() => onNavigate('.')}
-        className="flex items-center gap-1 px-1.5 py-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shrink-0"
+        className="text-primary hover:text-primary/80 shrink-0 flex items-center gap-1"
       >
         <Home className="h-3.5 w-3.5" />
-        <span className="font-medium font-mono text-xs">{displayRoot}</span>
       </button>
 
       {segments.map((segment, i) => {
@@ -32,17 +28,17 @@ export function FileBreadcrumb({ projectName, rootPath, path, onNavigate }: File
         const isLast = i === segments.length - 1
 
         return (
-          <span key={segmentPath} className="flex items-center gap-1 shrink-0">
-            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50" />
-            {isLast ?
-                (
-                  <span className="px-1.5 py-0.5 font-semibold text-foreground">{segment}</span>
-                ) :
-                (
+          <span key={segmentPath} className="flex items-center gap-1.5 shrink-0 text-xs">
+            <span className="text-muted-foreground/40">/</span>
+            {isLast
+              ? (
+                  <span className="font-semibold text-foreground">{segment}</span>
+                )
+              : (
                   <button
                     type="button"
                     onClick={() => onNavigate(segmentPath)}
-                    className="px-1.5 py-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                    className="text-primary hover:underline underline-offset-2"
                   >
                     {segment}
                   </button>

--- a/apps/frontend/src/components/files/FileBrowserContent.tsx
+++ b/apps/frontend/src/components/files/FileBrowserContent.tsx
@@ -78,15 +78,16 @@ export function FileBrowserContent({
 
   return (
     <>
+      {/* Header + Breadcrumb */}
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0">
-        <div className="flex items-center gap-2 min-w-0">
-          <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          <span className="text-xs font-medium text-muted-foreground truncate font-mono">
-            {effectiveRoot ?? project?.name ?? t('fileBrowser.title')}
+      <div className="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-border shrink-0">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <FolderOpen className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+          <span className="text-xs font-medium text-muted-foreground truncate font-mono" title={effectiveRoot ?? undefined}>
+            {effectiveRoot ?? t('fileBrowser.title')}
           </span>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 shrink-0">
           <button
             type="button"
             onClick={handleCopyPath}
@@ -126,16 +127,6 @@ export function FileBrowserContent({
         </div>
       </div>
 
-      {/* Breadcrumb */}
-      <div className="px-3 py-2 border-b border-border shrink-0">
-        <FileBreadcrumb
-          projectName={project?.name ?? ''}
-          rootPath={effectiveRoot ?? undefined}
-          path={currentPath}
-          onNavigate={navigateTo}
-        />
-      </div>
-
       {/* Content */}
       <div className="flex-1 overflow-auto min-h-0 p-4 flex flex-col">
         {!effectiveRoot
@@ -158,9 +149,21 @@ export function FileBrowserContent({
                   </div>
                 )
               : listing?.type === 'file'
-                ? <FileViewer file={listing} onBack={handleFileBack} />
+                ? (
+                    <FileViewer
+                      file={listing}
+                      onBack={handleFileBack}
+                      breadcrumb={<FileBreadcrumb path={currentPath} onNavigate={navigateTo} />}
+                    />
+                  )
                 : listing?.type === 'directory'
-                  ? <FileList entries={listing.entries} onNavigate={handleEntryClick} />
+                  ? (
+                      <FileList
+                        entries={listing.entries}
+                        onNavigate={handleEntryClick}
+                        breadcrumb={<FileBreadcrumb path={currentPath} onNavigate={navigateTo} />}
+                      />
+                    )
                   : null}
       </div>
     </>

--- a/apps/frontend/src/components/files/FileBrowserDrawer.tsx
+++ b/apps/frontend/src/components/files/FileBrowserDrawer.tsx
@@ -14,8 +14,7 @@ export function FileBrowserDrawer() {
   const {
     isOpen,
     isFullscreen,
-    inlineMode,
-    forceDrawer,
+    isDrawer,
     width,
     projectId,
     close,
@@ -26,9 +25,7 @@ export function FileBrowserDrawer() {
   const isMobile = useIsMobile()
   const dragRef = useRef<{ startX: number, startWidth: number } | null>(null)
 
-  // Skip rendering when an inline panel handles the file browser,
-  // unless forceDrawer is set (opened explicitly from header)
-  if (!isOpen || !projectId || (inlineMode && !forceDrawer)) return null
+  if (!isOpen || !projectId || !isDrawer) return null
 
   const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth
   const maxWidth = Math.round(viewportWidth * FILE_BROWSER_MAX_WIDTH_RATIO)

--- a/apps/frontend/src/components/files/FileList.tsx
+++ b/apps/frontend/src/components/files/FileList.tsx
@@ -33,9 +33,10 @@ function formatDate(iso: string): string {
 interface FileListProps {
   entries: FileEntry[]
   onNavigate: (name: string, type: 'file' | 'directory') => void
+  breadcrumb?: React.ReactNode
 }
 
-export function FileList({ entries, onNavigate }: FileListProps) {
+export function FileList({ entries, onNavigate, breadcrumb }: FileListProps) {
   const { t } = useTranslation()
 
   if (entries.length === 0) {
@@ -48,8 +49,13 @@ export function FileList({ entries, onNavigate }: FileListProps) {
 
   return (
     <div className="border border-border rounded-lg overflow-auto flex-1 min-h-0">
+      {breadcrumb && (
+        <div className="sticky top-0 z-[2] bg-muted/50 border-b border-border px-4 py-1.5">
+          {breadcrumb}
+        </div>
+      )}
       <table className="w-full text-sm">
-        <thead className="sticky top-0 z-[1]">
+        <thead className={`sticky ${breadcrumb ? 'top-[33px]' : 'top-0'} z-[1]`}>
           <tr className="bg-muted/50 border-b border-border">
             <th className="text-left font-medium text-muted-foreground px-4 py-2">
               {t('fileBrowser.name')}

--- a/apps/frontend/src/components/files/FileList.tsx
+++ b/apps/frontend/src/components/files/FileList.tsx
@@ -41,8 +41,15 @@ export function FileList({ entries, onNavigate, breadcrumb }: FileListProps) {
 
   if (entries.length === 0) {
     return (
-      <div className="flex items-center justify-center py-16 text-muted-foreground text-sm">
-        {t('fileBrowser.emptyDirectory')}
+      <div className="border border-border rounded-lg overflow-auto flex-1 min-h-0">
+        {breadcrumb && (
+          <div className="sticky top-0 z-[2] bg-muted/50 border-b border-border px-4 py-1.5">
+            {breadcrumb}
+          </div>
+        )}
+        <div className="flex items-center justify-center py-16 text-muted-foreground text-sm">
+          {t('fileBrowser.emptyDirectory')}
+        </div>
       </div>
     )
   }

--- a/apps/frontend/src/components/files/FileViewer.tsx
+++ b/apps/frontend/src/components/files/FileViewer.tsx
@@ -56,9 +56,10 @@ function formatSize(bytes: number): string {
 interface FileViewerProps {
   file: FileContent
   onBack: () => void
+  breadcrumb?: React.ReactNode
 }
 
-export function FileViewer({ file, onBack }: FileViewerProps) {
+export function FileViewer({ file, onBack, breadcrumb }: FileViewerProps) {
   const { t } = useTranslation()
   const [html, setHtml] = useState<string>('')
   const [loading, setLoading] = useState(true)
@@ -104,6 +105,11 @@ export function FileViewer({ file, onBack }: FileViewerProps) {
   if (file.isBinary) {
     return (
       <div className="border border-border rounded-lg overflow-hidden">
+        {breadcrumb && (
+          <div className="bg-muted/50 border-b border-border px-4 py-1.5">
+            {breadcrumb}
+          </div>
+        )}
         <div className="flex items-center justify-between px-4 py-2 bg-muted/50 border-b border-border">
           <div className="flex items-center gap-2">
             <button
@@ -128,6 +134,11 @@ export function FileViewer({ file, onBack }: FileViewerProps) {
 
   return (
     <div className="flex flex-col h-full border border-border rounded-lg overflow-hidden">
+      {breadcrumb && (
+        <div className="bg-muted/50 border-b border-border px-4 py-1.5 shrink-0">
+          {breadcrumb}
+        </div>
+      )}
       <div className="flex items-center justify-between px-4 py-2 bg-muted/50 border-b border-border shrink-0">
         <div className="flex items-center gap-2">
           <button

--- a/apps/frontend/src/components/issue-detail/ChatArea.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatArea.tsx
@@ -47,15 +47,8 @@ export function ChatArea({
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState('')
   const isMobile = useIsMobile()
-  const showFileBrowser = useFileBrowserStore(s => s.isOpen)
+  const showFileBrowser = useFileBrowserStore(s => s.isOpen && !s.isDrawer)
   const closeFileBrowser = useFileBrowserStore(s => s.close)
-  const setInlineMode = useFileBrowserStore(s => s.setInlineMode)
-
-  // Suppress the global drawer while this inline panel is mounted
-  useEffect(() => {
-    setInlineMode(true)
-    return () => setInlineMode(false)
-  }, [setInlineMode])
 
   const updateIssue = useUpdateIssue(projectId)
   const autoTitle = useAutoTitleIssue(projectId)

--- a/apps/frontend/src/components/issue-detail/ChatArea.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatArea.tsx
@@ -47,7 +47,7 @@ export function ChatArea({
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState('')
   const isMobile = useIsMobile()
-  const showFileBrowser = useFileBrowserStore(s => s.isOpen && !s.isDrawer)
+  const showFileBrowser = useFileBrowserStore(s => s.isOpen && !s.isDrawer && s.issueId === issueId)
   const closeFileBrowser = useFileBrowserStore(s => s.close)
 
   const updateIssue = useUpdateIssue(projectId)

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -166,7 +166,7 @@ export function ChatInput({
   const additions = changesSummary?.additions ?? 0
   const deletions = changesSummary?.deletions ?? 0
   const changesRoot = (changesSummary as { root?: string } | null)?.root
-  const openFileBrowser = useFileBrowserStore(s => s.toggleDrawer)
+  const openFileBrowser = useFileBrowserStore(s => s.openForIssue)
 
   // Fetch models for current engine
   const { data: discovery } = useEngineAvailability(!!engineType)
@@ -542,6 +542,14 @@ export function ChatInput({
         <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border/30">
           <button
             type="button"
+            onClick={() => projectId && issueId && openFileBrowser(projectId, issueId, changesRoot)}
+            className="inline-flex items-center justify-center rounded-lg px-1.5 py-1 text-muted-foreground bg-muted/40 hover:bg-muted/60 transition-all duration-200"
+            title={t('diff.openFiles')}
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
             onClick={onToggleDiff}
             className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs transition-all duration-200 ${
               diffOpen ?
@@ -561,15 +569,6 @@ export function ChatInput({
               </span>
             </span>
           </button>
-          <button
-            type="button"
-            onClick={() => projectId && openFileBrowser(projectId, changesRoot)}
-            className="inline-flex items-center justify-center rounded-lg px-1.5 py-1 text-muted-foreground bg-muted/40 hover:bg-muted/60 transition-all duration-200"
-            title={t('diff.openFiles')}
-          >
-            <FolderOpen className="h-3.5 w-3.5" />
-          </button>
-
           <div className="ml-auto flex items-center gap-1">
             {isSessionActive && !isThinking ?
                 (

--- a/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
@@ -41,7 +41,7 @@ export function IssueListPanel({
   const { data: issues } = useIssues(projectId)
   const { data: project } = useProject(projectId)
   const openCreateDialog = usePanelStore(s => s.openCreateDialog)
-  const toggleFileBrowser = useFileBrowserStore(s => s.toggle)
+  const toggleFileBrowser = useFileBrowserStore(s => s.toggleDrawer)
   const toggleProcessManager = useProcessManagerStore(s => s.toggle)
   const [search, setSearch] = useState('')
   const [showSettings, setShowSettings] = useState(false)
@@ -121,7 +121,7 @@ export function IssueListPanel({
               variant="ghost"
               size="icon"
               className="h-7 w-7 text-muted-foreground hover:text-foreground"
-              onClick={() => toggleFileBrowser(projectId)}
+              onClick={() => toggleFileBrowser(projectId, project?.directory ?? undefined)}
               aria-label={t('viewMode.files')}
               title={t('viewMode.files')}
             >

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -430,7 +430,7 @@
     "lines": "lines",
     "truncated": "Truncated",
     "back": "Back",
-    "title": "Files",
+    "title": "File Manager",
     "close": "Close file browser",
     "resizePanel": "Resize file browser",
     "viewSource": "Source",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -430,7 +430,7 @@
     "lines": "行",
     "truncated": "已截断",
     "back": "返回",
-    "title": "文件",
+    "title": "文件管理器",
     "close": "关闭文件管理",
     "resizePanel": "调整文件管理面板大小",
     "viewSource": "源码",

--- a/apps/frontend/src/stores/file-browser-store.ts
+++ b/apps/frontend/src/stores/file-browser-store.ts
@@ -15,7 +15,8 @@ function clampWidth(w: number): number {
 }
 
 /** Build a cache key for per-context path persistence. */
-function contextKey(projectId: string, rootPath: string | null): string {
+function contextKey(projectId: string, rootPath: string | null, issueId?: string | null): string {
+  if (issueId) return `${projectId}:issue:${issueId}`
   return rootPath ? `${projectId}:${rootPath}` : projectId
 }
 
@@ -23,28 +24,28 @@ interface FileBrowserStore {
   isOpen: boolean
   isMinimized: boolean
   isFullscreen: boolean
-  /** When true, an inline panel handles rendering (suppresses the global drawer) */
-  inlineMode: boolean
-  /** When true, force drawer rendering even if inlineMode is on */
-  forceDrawer: boolean
+  /** Whether the current view is a drawer (true) or inline panel (false). */
+  isDrawer: boolean
   width: number
   projectId: string | null
+  issueId: string | null
   rootPath: string | null
   currentPath: string
   hideIgnored: boolean
   /** Per-context path cache so switching contexts restores the last position. */
   pathCache: Map<string, string>
   open: (projectId: string, rootPath?: string) => void
+  /** Open for a specific issue — tracks path per issue, opens as inline panel. */
+  openForIssue: (projectId: string, issueId: string, rootPath?: string) => void
   openFullscreen: (projectId: string, rootPath?: string) => void
   close: () => void
   toggle: (projectId: string) => void
-  /** Toggle as drawer, overriding inlineMode so the global drawer renders. */
+  /** Toggle as drawer (global overlay). */
   toggleDrawer: (projectId: string, rootPath?: string) => void
   minimize: () => void
   restore: () => void
   toggleFullscreen: () => void
   setWidth: (w: number) => void
-  setInlineMode: (inline: boolean) => void
   navigateTo: (path: string) => void
   toggleHideIgnored: () => void
 }
@@ -60,9 +61,10 @@ function switchContext(
   s: FileBrowserStore,
   projectId: string,
   rootPath: string | null,
+  issueId?: string | null,
 ): { currentPath: string, pathCache: Map<string, string> } {
-  const newKey = contextKey(projectId, rootPath)
-  const oldKey = s.projectId ? contextKey(s.projectId, s.rootPath) : null
+  const newKey = contextKey(projectId, rootPath, issueId)
+  const oldKey = s.projectId ? contextKey(s.projectId, s.rootPath, s.issueId) : null
 
   // Same context — keep current path, no cache update needed
   if (oldKey === newKey) {
@@ -81,10 +83,10 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
   isOpen: false,
   isMinimized: false,
   isFullscreen: false,
-  inlineMode: false,
-  forceDrawer: false,
+  isDrawer: true,
   width: Math.round(getViewportWidth() * DEFAULT_WIDTH_RATIO),
   projectId: null,
+  issueId: null,
   rootPath: null,
   currentPath: '.',
   hideIgnored: false,
@@ -96,7 +98,26 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
       return {
         isOpen: true,
         isMinimized: false,
+        isDrawer: true,
         projectId,
+        issueId: null,
+        rootPath: rootPath ?? null,
+        ...ctx,
+      }
+    }),
+  openForIssue: (projectId, issueId, rootPath) =>
+    set((s) => {
+      // Toggle off if already open as inline for the same issue
+      if (s.isOpen && !s.isDrawer && s.issueId === issueId) {
+        return { isOpen: false }
+      }
+      const ctx = switchContext(s, projectId, rootPath ?? null, issueId)
+      return {
+        isOpen: true,
+        isMinimized: false,
+        isDrawer: false,
+        projectId,
+        issueId,
         rootPath: rootPath ?? null,
         ...ctx,
       }
@@ -108,12 +129,14 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
         isOpen: true,
         isMinimized: false,
         isFullscreen: true,
+        isDrawer: true,
         projectId,
+        issueId: null,
         rootPath: rootPath ?? null,
         ...ctx,
       }
     }),
-  close: () => set({ isOpen: false, forceDrawer: false }),
+  close: () => set({ isOpen: false }),
   toggle: projectId =>
     set((s) => {
       if (s.isMinimized) {
@@ -121,7 +144,9 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
         return {
           isOpen: true,
           isMinimized: false,
+          isDrawer: true,
           projectId,
+          issueId: null,
           rootPath: s.projectId === projectId ? s.rootPath : null,
           ...ctx,
         }
@@ -133,22 +158,25 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
       const ctx = switchContext(s, projectId, newRoot)
       return {
         isOpen: true,
+        isDrawer: true,
         projectId,
+        issueId: null,
         rootPath: newRoot,
         ...ctx,
       }
     }),
   toggleDrawer: (projectId, rootPath) =>
     set((s) => {
-      if (s.isOpen && s.forceDrawer && s.projectId === projectId) {
-        return { isOpen: false, forceDrawer: false }
+      if (s.isOpen && s.isDrawer && s.projectId === projectId) {
+        return { isOpen: false }
       }
       const effectiveRoot = rootPath ?? (s.projectId === projectId ? s.rootPath : null)
       const ctx = switchContext(s, projectId, effectiveRoot)
       return {
         isOpen: true,
         isMinimized: false,
-        forceDrawer: true,
+        isDrawer: true,
+        issueId: null,
         projectId,
         rootPath: effectiveRoot,
         ...ctx,
@@ -158,7 +186,6 @@ export const useFileBrowserStore = create<FileBrowserStore>(set => ({
   restore: () => set({ isOpen: true, isMinimized: false }),
   toggleFullscreen: () => set(s => ({ isFullscreen: !s.isFullscreen })),
   setWidth: w => set({ width: clampWidth(w) }),
-  setInlineMode: inline => set({ inlineMode: inline }),
   navigateTo: path => set({ currentPath: path }),
   toggleHideIgnored: () => set(s => ({ hideIgnored: !s.hideIgnored })),
 }))


### PR DESCRIPTION
## Summary
- Separate file browser into **drawer mode** (project-level, opened from IssueListPanel/KanbanHeader) and **inline mode** (per-issue workspace, opened from ChatInput) using a simple `isDrawer` flag
- Replace `inlineMode` + `forceDrawer` with single `isDrawer` boolean — mode is determined at open time, no registration effects needed
- Add per-issue path tracking via `issueId` in store context keys
- Redesign breadcrumb to GitHub style: Home icon, `/` separators, blue clickable links, bold last segment
- Move breadcrumb into content area (above table header in FileList, above file header in FileViewer)
- Add FolderOpen icon in file browser header as visual identifier

## Test plan
- [ ] Click file browser button in IssueListPanel header → opens as drawer overlay showing project directory
- [ ] Click file browser button in ChatInput → opens as inline panel showing issue workspace
- [ ] Opening drawer while inline is open → only drawer shows (no duplicate)
- [ ] Opening inline while drawer is open → only inline shows
- [ ] Breadcrumb navigation works in both drawer and inline modes
- [ ] Per-issue path is remembered when switching between issues
- [ ] File viewer shows breadcrumb above the file header