### PR TITLE
fix: UI tweaks for status bar and bash command display

### DIFF
--- a/apps/frontend/src/components/issue-detail/IssueDetail.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueDetail.tsx
@@ -50,6 +50,24 @@ export function IssueDetail({
       {/* Status — editable */}
       <StatusSelect status={status} onChange={id => onUpdate?.({ statusId: id })} />
 
+      {/* Delete */}
+      {onDelete ?
+          (
+            <Button
+              type="button"
+              onClick={onDelete}
+              size="sm"
+              variant="outline"
+              disabled={isDeleting}
+              className={`${badgeButtonBase} cursor-pointer border-border/50 bg-muted/20 text-muted-foreground/60 hover:text-destructive hover:border-destructive/30 hover:bg-destructive/10`}
+              title={t('issue.delete')}
+            >
+              <Trash2 className="h-3 w-3" />
+              <span>{isDeleting ? t('issue.deleting') : t('issue.delete')}</span>
+            </Button>
+          ) :
+        null}
+
       {/* Tags — editable (comma-separated) */}
       {editingTag ?
           (
@@ -99,24 +117,6 @@ export function IssueDetail({
               {issue.tags && issue.tags.length > 0 ? issue.tags.join(', ') : t('issue.tag')}
             </button>
           )}
-
-      {/* Delete */}
-      {onDelete ?
-          (
-            <Button
-              type="button"
-              onClick={onDelete}
-              size="sm"
-              variant="outline"
-              disabled={isDeleting}
-              className={`${badgeButtonBase} cursor-pointer border-border/50 bg-muted/20 text-muted-foreground/60 hover:text-destructive hover:border-destructive/30 hover:bg-destructive/10`}
-              title={t('issue.delete')}
-            >
-              <Trash2 className="h-3 w-3" />
-              <span>{isDeleting ? t('issue.deleting') : t('issue.delete')}</span>
-            </Button>
-          ) :
-        null}
 
       {/* Worktree (right side) */}
       <div className="ml-auto flex items-center gap-1.5">

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -256,11 +256,26 @@ export function CommandToolItem({ item }: { item: ToolGroupItem }) {
               </div>
             )
           : null}
-        <CodeBlock
-          content={item.result?.content || item.action.content || '(empty)'}
-          collapsible={false}
-          language={hasError ? 'text' : undefined}
-        />
+        {(() => {
+          const resultContent = item.result?.content || item.action.content || '(empty)'
+          return (
+            <div className="relative group/result">
+              <CodeBlock
+                content={resultContent}
+                collapsible={false}
+                language={hasError ? 'text' : undefined}
+              />
+              <button
+                type="button"
+                className="absolute top-1.5 right-1.5 p-1 rounded opacity-0 group-hover/result:opacity-100 hover:bg-muted/50 text-muted-foreground/50 hover:text-muted-foreground transition-all"
+                title={t('common.copy')}
+                onClick={() => navigator.clipboard.writeText(resultContent)}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )
+        })()}
       </div>
     </ToolPanel>
   )

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -1,6 +1,7 @@
 import type { ToolGroupChatMessage, ToolGroupItem } from '@bkd/shared'
 import {
   ChevronRight,
+  Copy,
   FileEdit,
   FileText,
   Search,
@@ -240,11 +241,18 @@ export function CommandToolItem({ item }: { item: ToolGroupItem }) {
       <div className="space-y-2">
         {preview.isTruncated || fullCommand.includes('\n')
           ? (
-              <div className="rounded-md border border-border/30 bg-muted/10 p-2 space-y-1">
-                <div className="px-0.5 text-[11px] text-muted-foreground">
-                  {t('session.tool.fullCommand')}
+              <div className="rounded-md border border-border/30 bg-muted/10 p-2">
+                <div className="flex items-start gap-2">
+                  <pre className="flex-1 text-[12px] font-mono whitespace-pre-wrap break-all leading-[1.5]">{fullCommand}</pre>
+                  <button
+                    type="button"
+                    className="shrink-0 p-1 rounded hover:bg-muted/50 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+                    title={t('common.copy')}
+                    onClick={() => navigator.clipboard.writeText(fullCommand)}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </button>
                 </div>
-                <CodeBlock content={fullCommand} language="shell" collapsible={false} />
               </div>
             )
           : null}

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -4,7 +4,8 @@
     "loading": "Loading...",
     "search": "Search...",
     "select": "Select",
-    "edit": "Edit"
+    "edit": "Edit",
+    "copy": "Copy"
   },
   "project": {
     "projects": "Projects",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -4,7 +4,8 @@
     "loading": "加载中...",
     "search": "搜索...",
     "select": "选择",
-    "edit": "编辑"
+    "edit": "编辑",
+    "copy": "复制"
   },
   "project": {
     "projects": "项目",


### PR DESCRIPTION
## Summary
- Reorder issue status bar layout: status → delete → tags (previously status → tags → delete)
- Replace bash tool "完整命令" label with plain preformatted command text + copy button
- Add `common.copy` i18n key for en/zh

## Test plan
- [ ] Open an issue detail page, verify status bar shows: status, delete, then tags
- [ ] Expand a Bash tool call with a long/multiline command, verify full command displays without label and has a working copy button