### PR TITLE
feat: render Codex file edits with PatchDiff component

### DIFF
--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -261,7 +261,8 @@ export class CodexLogNormalizer {
         const callId = msg.call_id as string | undefined
         if (!changes) return null
         const entries: NormalizedLogEntry[] = []
-        for (const path of Object.keys(changes)) {
+        for (const [path, patchValue] of Object.entries(changes)) {
+          const patch = typeof patchValue === 'string' ? patchValue : undefined
           const toolAction: ToolAction = {
             kind: 'file-edit',
             path,
@@ -274,7 +275,7 @@ export class CodexLogNormalizer {
               toolName: 'Edit',
               toolCallId: callId,
               path,
-              input: { file_path: path },
+              input: { file_path: path, ...(patch ? { patch } : {}) },
             },
             toolAction,
           })
@@ -330,7 +331,8 @@ export class CodexLogNormalizer {
         const callId = msg.call_id as string | undefined
         if (!changes) return null
         const entries: NormalizedLogEntry[] = []
-        for (const path of Object.keys(changes)) {
+        for (const [path, patchValue] of Object.entries(changes)) {
+          const patch = typeof patchValue === 'string' ? patchValue : undefined
           entries.push({
             entryType: 'tool-use',
             content: `Tool: Edit`,
@@ -339,7 +341,7 @@ export class CodexLogNormalizer {
               toolName: 'Edit',
               toolCallId: callId,
               path,
-              input: { file_path: path },
+              input: { file_path: path, ...(patch ? { patch } : {}) },
             },
             toolAction: { kind: 'file-edit', path },
           })

--- a/apps/frontend/src/components/files/FileBrowserContent.tsx
+++ b/apps/frontend/src/components/files/FileBrowserContent.tsx
@@ -128,7 +128,7 @@ export function FileBrowserContent({
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto min-h-0 p-4 flex flex-col">
+      <div className="flex-1 overflow-auto min-h-0 px-4 pb-4 pt-2 flex flex-col">
         {!effectiveRoot
           ? (
               <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">

--- a/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
+++ b/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
@@ -9,6 +9,10 @@ const LazyMultiFileDiff = lazy(() =>
   import('@pierre/diffs/react').then(m => ({ default: m.MultiFileDiff })),
 )
 
+const LazyPatchDiff = lazy(() =>
+  import('@pierre/diffs/react').then(m => ({ default: m.PatchDiff })),
+)
+
 // ── Shared helpers ───────────────────────────────────────
 
 export function stringifyPretty(input: unknown): string {
@@ -26,6 +30,7 @@ export interface ParsedFileToolInput {
   content?: string
   oldString?: string
   newString?: string
+  patch?: string
   hasOnlyFilePath: boolean
   raw: string
 }
@@ -43,6 +48,7 @@ export function parseFileToolInput(input: unknown): ParsedFileToolInput {
     content: typeof obj.content === 'string' ? obj.content : undefined,
     oldString: typeof obj.old_string === 'string' ? obj.old_string : undefined,
     newString: typeof obj.new_string === 'string' ? obj.new_string : undefined,
+    patch: typeof obj.patch === 'string' ? obj.patch : undefined,
     hasOnlyFilePath,
     raw,
   }
@@ -155,6 +161,40 @@ export function ShikiUnifiedDiff({
             diffIndicators: 'bars',
             expandUnchanged: false,
             hunkSeparators: 'line-info',
+            disableLineNumbers: false,
+            overflow: 'wrap',
+            theme: {
+              light: 'github-light-default',
+              dark: 'github-dark-default',
+            },
+            themeType,
+            disableFileHeader: true,
+          }}
+        />
+      </Suspense>
+    </div>
+  )
+}
+
+export function ShikiPatchDiff({ patch }: { patch: string }) {
+  const { resolved } = useTheme()
+  const themeType = resolved === 'dark' ? 'dark' : 'light'
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-border/40">
+      <Suspense
+        fallback={
+          <pre className="px-2.5 py-2 text-[12px] font-mono overflow-x-auto whitespace-pre-wrap">
+            {patch}
+          </pre>
+        }
+      >
+        <LazyPatchDiff
+          patch={patch}
+          options={{
+            diffStyle: 'unified',
+            diffIndicators: 'bars',
+            expandUnchanged: true,
             disableLineNumbers: false,
             overflow: 'wrap',
             theme: {

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -15,6 +15,7 @@ import {
   CodeBlock,
   detectCodeLanguage,
   parseFileToolInput,
+  ShikiPatchDiff,
   ShikiUnifiedDiff,
   ToolPanel,
 } from './CodeRenderers'
@@ -32,12 +33,23 @@ function countLines(text: string | undefined | null): number | null {
   return text.split('\n').length
 }
 
-/** Compute +added / -removed line counts from old/new strings. */
+/** Compute +added / -removed line counts from old/new strings or patch. */
 function diffStats(
   oldStr: string | undefined,
   newStr: string | undefined,
+  patch?: string | undefined,
 ): { added: number, removed: number } | null {
-  if (oldStr === undefined && newStr === undefined) return null
+  if (oldStr === undefined && newStr === undefined && patch === undefined) return null
+  // Parse unified diff patch for line counts
+  if (patch !== undefined && oldStr === undefined && newStr === undefined) {
+    let added = 0
+    let removed = 0
+    for (const line of patch.split('\n')) {
+      if (line.startsWith('+') && !line.startsWith('+++')) added++
+      else if (line.startsWith('-') && !line.startsWith('---')) removed++
+    }
+    return (added > 0 || removed > 0) ? { added, removed } : null
+  }
   const oldLines = oldStr ? oldStr.split('\n').length : 0
   const newLines = newStr ? newStr.split('\n').length : 0
   if (oldStr !== undefined && newStr !== undefined) {
@@ -123,6 +135,7 @@ export function FileToolItem({ item }: { item: ToolGroupItem }) {
   const hasContent = parsed.content !== undefined
   const hasOldString = parsed.oldString !== undefined
   const hasNewString = parsed.newString !== undefined
+  const hasPatch = parsed.patch !== undefined
 
   if (!isEdit) {
     const resultContent = item.result?.content
@@ -160,7 +173,7 @@ export function FileToolItem({ item }: { item: ToolGroupItem }) {
   }
 
   // File edit / write
-  const stats = diffStats(parsed.oldString, parsed.newString ?? parsed.content)
+  const stats = diffStats(parsed.oldString, parsed.newString ?? parsed.content, parsed.patch)
 
   return (
     <ToolPanel
@@ -202,7 +215,11 @@ export function FileToolItem({ item }: { item: ToolGroupItem }) {
           ? <CodeBlock content={parsed.newString || ''} language={codeLanguage} collapsible={false} />
           : null}
 
-        {!hasContent && !hasOldString && !hasNewString && !parsed.hasOnlyFilePath
+        {!hasOldString && !hasNewString && hasPatch
+          ? <ShikiPatchDiff patch={parsed.patch!} />
+          : null}
+
+        {!hasContent && !hasOldString && !hasNewString && !hasPatch && !parsed.hasOnlyFilePath
           ? <CodeBlock content={parsed.raw || '(empty)'} language="json" collapsible={false} />
           : null}
       </div>


### PR DESCRIPTION
## Summary
- Codex file edit tool actions now render with `@pierre/diffs` PatchDiff component instead of raw diff text
- Extract diff patch content from Codex `changes` values in normalizer (`patch_apply_begin` / `apply_patch_approval_request`)
- Add `ShikiPatchDiff` component with syntax highlighting and unified diff view
- Reduce file browser top padding to close gap between header and directory listing

## Test plan
- [ ] Verify Codex file edit patches render with syntax-highlighted diff view
- [ ] Verify Claude Code file edits still render correctly with ShikiUnifiedDiff
- [ ] Verify file browser directory listing has reduced gap from header
- [ ] Verify dark/light theme switching works for PatchDiff