### PR TITLE
fix: deduplicate Codex turn_complete messages and simplify file read UI

### DIFF
--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -705,14 +705,16 @@ export class CodexLogNormalizer {
 
       // --- Turn complete (v2 codex/event) ---
       // Schema type discriminant is "task_complete" in EventMsg but "turn_complete" in our events
+      // Note: last_agent_message is NOT used as content because the same text was already
+      // streamed via agent_message_delta / agent_message events as assistant-message entries.
+      // Using it here would produce a duplicate system-message with identical content.
       case 'turn_complete':
       case 'task_complete': {
         this.resetStreamingState()
         const turnId = msg.turn_id as string | undefined
-        const lastMessage = msg.last_agent_message as string | null | undefined
         return {
           entryType: 'system-message',
-          content: lastMessage || 'Turn completed',
+          content: 'Turn completed',
           timestamp: now,
           metadata: {
             turnCompleted: true,

--- a/apps/api/test/codex-normalize-log.test.ts
+++ b/apps/api/test/codex-normalize-log.test.ts
@@ -795,13 +795,14 @@ describe('CodexLogNormalizer (codex/event/*)', () => {
       expect(r!.metadata?.turnCompleted).toBe(true)
     })
 
-    test('extracts turn_id and last_agent_message', () => {
+    test('extracts turn_id and ignores last_agent_message (already streamed)', () => {
       const n = new CodexLogNormalizer()
       const r = n.parse(codexEvent('turn_complete', {
         turn_id: 'turn-42',
         last_agent_message: 'Done!',
       }))
-      expect(r!.content).toBe('Done!')
+      // last_agent_message is NOT used — the same text was already streamed via agent_message_delta
+      expect(r!.content).toBe('Turn completed')
       expect(r!.metadata?.turnId).toBe('turn-42')
     })
 

--- a/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
+++ b/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
@@ -215,10 +215,12 @@ export function ShikiPatchDiff({ patch }: { patch: string }) {
 export function ToolPanel({
   summary,
   children,
+  actions,
   collapsible = false,
 }: {
   summary: React.ReactNode
   children: React.ReactNode
+  actions?: React.ReactNode
   collapsible?: boolean
 }) {
   if (collapsible) {
@@ -226,6 +228,7 @@ export function ToolPanel({
       <details className="group/panel transition-all duration-200">
         <summary className="flex items-center cursor-pointer list-none px-3 py-1.5 transition-colors hover:bg-muted/10">
           <div className="flex-1 min-w-0">{summary}</div>
+          {actions ? <div className="shrink-0 ml-1">{actions}</div> : null}
           <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/40 transition-transform group-open/panel:rotate-90 ml-1" />
         </summary>
         <div className="border-t border-border">{children}</div>
@@ -234,8 +237,11 @@ export function ToolPanel({
   }
   return (
     <div>
-      <div className="px-3 py-1.5">{summary}</div>
-      <div className="border-t border-border">{children}</div>
+      <div className="flex items-center px-3 py-1.5">
+        <div className="flex-1 min-w-0">{summary}</div>
+        {actions ? <div className="shrink-0 ml-1">{actions}</div> : null}
+      </div>
+      {children ? <div className="border-t border-border">{children}</div> : null}
     </div>
   )
 }

--- a/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
+++ b/apps/frontend/src/components/issue-detail/CodeRenderers.tsx
@@ -185,11 +185,11 @@ export function ShikiPatchDiff({ patch }: { patch: string }) {
   return (
     <div className="overflow-x-auto rounded-md border border-border/40">
       <Suspense
-        fallback={
+        fallback={(
           <pre className="px-2.5 py-2 text-[12px] font-mono overflow-x-auto whitespace-pre-wrap">
             {patch}
           </pre>
-        }
+        )}
       >
         <LazyPatchDiff
           patch={patch}

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -88,7 +88,7 @@ function CopyPathButton({ path }: { path: string }) {
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(path)
     setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
+    setTimeout(setCopied, 1500, false)
   }, [path])
   const Icon = copied ? Check : Copy
   return (

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -1,5 +1,6 @@
 import type { ToolGroupChatMessage, ToolGroupItem } from '@bkd/shared'
 import {
+  Check,
   ChevronRight,
   Copy,
   FileEdit,
@@ -9,9 +10,9 @@ import {
   Users,
   Wrench,
 } from 'lucide-react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getCommandPreview } from '@/lib/command-preview'
-import { formatFileSize } from '@/lib/format'
 import {
   CodeBlock,
   detectCodeLanguage,
@@ -27,11 +28,6 @@ function getItemToolName(item: ToolGroupItem): string | undefined {
     item.action.toolDetail?.toolName
     ?? (typeof item.action.metadata?.toolName === 'string' ? item.action.metadata.toolName : undefined)
   )
-}
-
-function countLines(text: string | undefined | null): number | null {
-  if (!text) return null
-  return text.split('\n').length
 }
 
 /** Compute +added / -removed line counts from old/new strings or patch. */
@@ -84,6 +80,25 @@ function ToolLabel({ label, icon: Icon }: { label: string, icon: React.Component
 function PathBadge({ path }: { path: string }) {
   return (
     <code className="rounded bg-muted/50 px-1.5 py-0.5 text-[11px] font-mono overflow-x-auto whitespace-nowrap scrollbar-none">{path}</code>
+  )
+}
+
+function CopyPathButton({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(path)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }, [path])
+  const Icon = copied ? Check : Copy
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="shrink-0 p-0.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+    >
+      <Icon className="h-3 w-3" />
+    </button>
   )
 }
 
@@ -142,27 +157,18 @@ export function FileToolItem({ item }: { item: ToolGroupItem }) {
   if (!isEdit) {
     const resultContent = item.result?.content
     const hasError = isItemError(item)
-    const lineCount = countLines(resultContent)
     const showResultText = resultContent && hasError
 
-    const summary = (
-      <div className="flex items-center gap-2 min-w-0">
-        <ToolLabel label="Read" icon={FileText} />
-        <PathBadge path={filePath} />
-      </div>
-    )
-
-    const sizeInfo = lineCount
-      ? `${lineCount} lines`
-      : resultContent
-        ? formatFileSize(resultContent.length)
-        : null
-
     return (
-      <ToolPanel collapsible summary={summary}>
-        {sizeInfo
-          ? <div className="text-[11px] text-muted-foreground/50">{sizeInfo}</div>
-          : null}
+      <ToolPanel
+        summary={(
+          <div className="flex items-center gap-2 min-w-0">
+            <ToolLabel label="Read" icon={FileText} />
+            <PathBadge path={filePath} />
+          </div>
+        )}
+        actions={<CopyPathButton path={filePath} />}
+      >
         {showResultText
           ? (
               <div className="text-[11px] font-mono whitespace-pre-wrap text-red-600 dark:text-red-400">


### PR DESCRIPTION
## Summary
- **Fix duplicate Codex messages**: `turn_complete` / `task_complete` events no longer use `last_agent_message` as content (it duplicated text already streamed via `agent_message_delta`). Now always outputs "Turn completed" as a system message.
- **Simplify File Read tool UI**: Removed line count and file size display, switched to non-collapsible panel for cleaner appearance.
- **Add copy-path button**: File Read tool now has a copy-to-clipboard button for the file path, with visual feedback (checkmark icon).
- **Extend ToolPanel**: Added optional `actions` prop to render additional action buttons alongside the summary.

## Test plan
- [x] Updated `codex-normalize-log.test.ts` to verify `turn_complete` outputs "Turn completed" instead of duplicating assistant message
- [ ] Verify Codex execution no longer shows duplicate messages in the chat UI
- [ ] Verify File Read tool displays as non-collapsible panel with copy-path button
- [ ] Verify copy-path button copies correct path and shows checkmark feedback