### PR TITLE
feat: engine binary path, description in settings UI

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -31,33 +31,38 @@ const ISSUE_LOG_DIR = join(ROOT_DIR, 'data', 'logs', 'issues')
  * Falls back to npx for environments without a standalone binary.
  * Result is cached after first call.
  */
-let _cachedBaseCommand: string | undefined
-function getBaseCommand(): string {
-  if (_cachedBaseCommand) return _cachedBaseCommand
-  // 1. Check PATH
+let _cachedBaseCmd: string | undefined
+function resolveBaseCmd(): string {
+  if (_cachedBaseCmd) return _cachedBaseCmd
+  // 1. Check /work/bin first (container / custom deploy)
+  if (existsSync('/work/bin/claude')) {
+    _cachedBaseCmd = '/work/bin/claude'
+    return _cachedBaseCmd
+  }
+  // 2. Check PATH
   const fromPath = resolveCommand('claude')
   if (fromPath) {
-    _cachedBaseCommand = fromPath
-    return _cachedBaseCommand
+    _cachedBaseCmd = fromPath
+    return _cachedBaseCmd
   }
-  // 2. Check HOME-relative install locations
+  // 3. Check HOME-relative install locations
   const home = process.env.HOME ?? ''
   if (home) {
     const homeCandidates = [join(home, '.local/bin/claude'), join(home, '.bun/bin/claude')]
     const found = homeCandidates.find(p => existsSync(p))
     if (found) {
-      _cachedBaseCommand = found
-      return _cachedBaseCommand
+      _cachedBaseCmd = found
+      return _cachedBaseCmd
     }
   }
-  // 3. Check absolute paths independent of HOME
+  // 4. Check absolute paths independent of HOME
   if (existsSync('/usr/local/bin/claude')) {
-    _cachedBaseCommand = '/usr/local/bin/claude'
-    return _cachedBaseCommand
+    _cachedBaseCmd = '/usr/local/bin/claude'
+    return _cachedBaseCmd
   }
-  // 4. Fall back to npx
-  _cachedBaseCommand = NPX_FALLBACK
-  return _cachedBaseCommand
+  // 5. Fall back to npx
+  _cachedBaseCmd = NPX_FALLBACK
+  return _cachedBaseCmd
 }
 
 // Known Claude models — Claude Code CLI has no `models` subcommand
@@ -125,7 +130,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
 
   async getAvailability(): Promise<EngineAvailability> {
     try {
-      const resolved = await CommandBuilder.create(getBaseCommand())
+      const resolved = await CommandBuilder.create(resolveBaseCmd())
         .param('--version')
         .env('NPM_CONFIG_LOGLEVEL', 'error')
         .resolve()
@@ -208,7 +213,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
    * `discover_available_command_and_plugins`.
    */
   async discoverSlashCommandsAndAgents(workingDir: string): Promise<DiscoveryResult> {
-    const resolved = await CommandBuilder.create(getBaseCommand())
+    const resolved = await CommandBuilder.create(resolveBaseCmd())
       .params(['-p', '--verbose', '--output-format=stream-json'])
       .param('--max-turns', '1')
       .params(['--', '/'])
@@ -330,7 +335,7 @@ export class ClaudeCodeExecutor implements EngineExecutor {
     const permissionMode = options.permissionMode ?? 'auto'
     const isPlanMode = permissionMode === 'plan'
 
-    const builder = CommandBuilder.create(getBaseCommand())
+    const builder = CommandBuilder.create(resolveBaseCmd())
       .params(['-p', '--output-format=stream-json', '--verbose', '--no-chrome'])
       .param('--input-format', 'stream-json')
       // Enable SDK-based permission handling via stdin/stdout control protocol

--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -27,30 +27,34 @@ const NPX_FALLBACK = ['npx', '-y', '@openai/codex']
  * Falls back to npx for environments without a standalone binary.
  * Result is cached after first call.
  */
-let _cachedCodexCmd: string[] | undefined
-function getCodexCmd(): string[] {
-  if (_cachedCodexCmd) return _cachedCodexCmd
-  // 1. Check PATH
+let _cachedBaseCmd: string[] | undefined
+function resolveBaseCmd(): string[] {
+  if (_cachedBaseCmd) return _cachedBaseCmd
+  // 1. Check /work/bin first (container / custom deploy)
+  if (existsSync('/work/bin/codex')) {
+    _cachedBaseCmd = ['/work/bin/codex']
+    return _cachedBaseCmd
+  }
+  // 2. Check PATH
   const fromPath = resolveCommand('codex')
   if (fromPath) {
-    _cachedCodexCmd = [fromPath]
-    return _cachedCodexCmd
+    _cachedBaseCmd = [fromPath]
+    return _cachedBaseCmd
   }
-  // 2. Check common install locations
+  // 3. Check common install locations
   const home = process.env.HOME ?? ''
   const candidates = [
     ...(home ? [join(home, '.local/bin/codex'), join(home, '.bun/bin/codex')] : []),
     '/usr/local/bin/codex',
-    '/work/bin/codex',
   ]
   const found = candidates.find(p => existsSync(p))
   if (found) {
-    _cachedCodexCmd = [found]
-    return _cachedCodexCmd
+    _cachedBaseCmd = [found]
+    return _cachedBaseCmd
   }
-  // 3. Fall back to npx
-  _cachedCodexCmd = NPX_FALLBACK
-  return _cachedCodexCmd
+  // 4. Fall back to npx
+  _cachedBaseCmd = NPX_FALLBACK
+  return _cachedBaseCmd
 }
 const JSONRPC_TIMEOUT = 15000
 
@@ -208,9 +212,9 @@ interface CodexModelListResponse {
  * then paginate through model/list. Returns flattened EngineModel[].
  */
 async function queryCodexModels(): Promise<EngineModel[]> {
-  logger.debug({ cmd: [...getCodexCmd(), 'app-server'].join(' ') }, 'codex_models_start')
+  logger.debug({ cmd: [...resolveBaseCmd(), 'app-server'].join(' ') }, 'codex_models_start')
 
-  const proc = spawnNode([...getCodexCmd(), 'app-server'], {
+  const proc = spawnNode([...resolveBaseCmd(), 'app-server'], {
     stdin: 'pipe',
     stdout: 'pipe',
     stderr: 'pipe',
@@ -316,7 +320,7 @@ export class CodexExecutor implements EngineExecutor {
   ]
 
   async spawn(options: SpawnOptions, env: ExecutionEnv): Promise<SpawnedProcess> {
-    const cmd = [...getCodexCmd(), 'app-server']
+    const cmd = [...resolveBaseCmd(), 'app-server']
 
     const proc = spawnNode(cmd, {
       cwd: options.workingDir,
@@ -390,7 +394,7 @@ export class CodexExecutor implements EngineExecutor {
   }
 
   async spawnFollowUp(options: FollowUpOptions, env: ExecutionEnv): Promise<SpawnedProcess> {
-    const cmd = [...getCodexCmd(), 'app-server']
+    const cmd = [...resolveBaseCmd(), 'app-server']
 
     const proc = spawnNode(cmd, {
       cwd: options.workingDir,
@@ -482,7 +486,7 @@ export class CodexExecutor implements EngineExecutor {
 
   async getAvailability(): Promise<EngineAvailability> {
     try {
-      const { code: exitCode, stdout } = await runCommand([...getCodexCmd(), '--version'], {
+      const { code: exitCode, stdout } = await runCommand([...resolveBaseCmd(), '--version'], {
         timeout: 10000,
         stderr: 'pipe',
       })
@@ -506,10 +510,12 @@ export class CodexExecutor implements EngineExecutor {
         }
       }
 
+      const cmd = resolveBaseCmd()
       return {
         engineType: 'codex',
         installed: true,
         version,
+        binaryPath: cmd.join(' '),
         authStatus,
       }
     } catch (error) {

--- a/apps/api/src/engines/executors/gemini/executor.ts
+++ b/apps/api/src/engines/executors/gemini/executor.ts
@@ -92,6 +92,7 @@ export class GeminiExecutor implements EngineExecutor {
         installed: true,
         executable: false, // spawn not yet implemented
         version,
+        binaryPath: 'npx -y @google/gemini-cli',
         authStatus,
       }
     } catch (error) {

--- a/apps/api/src/engines/types.ts
+++ b/apps/api/src/engines/types.ts
@@ -242,7 +242,7 @@ export const BUILT_IN_PROFILES: Record<EngineType, EngineProfile> = {
   },
   'echo': {
     engineType: 'echo',
-    name: 'Echo',
+    name: 'Echo (Mock)',
     baseCommand: 'echo',
     protocol: 'stream-json',
     capabilities: ['session-fork'],

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -1332,6 +1332,14 @@ function EngineCard({
             )}
           </div>
           <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground">
+            {t(`createIssue.engineDesc.${engine.engineType}`, '') ?
+                (
+                  <>
+                    <span className="truncate">{t(`createIssue.engineDesc.${engine.engineType}`)}</span>
+                    {(selectedModelName || hasModels) && <span className="text-muted-foreground/50">·</span>}
+                  </>
+                ) :
+              null}
             {selectedModelName ? <span className="truncate">{selectedModelName}</span> : null}
             {selectedModelName && hasModels ?
                 (
@@ -1344,6 +1352,11 @@ function EngineCard({
                 ) :
               null}
           </div>
+          {engine.binaryPath && (
+            <div className="mt-0.5 truncate text-[11px] font-mono text-muted-foreground/60">
+              {engine.binaryPath}
+            </div>
+          )}
         </div>
         <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
           {engine.installed ?
@@ -1405,6 +1418,11 @@ function EngineCard({
                   </button>
                 )
               })}
+              {engine.binaryPath && (
+                <div className="mt-1 truncate border-t pt-1.5 text-[10px] font-mono text-muted-foreground/50">
+                  {engine.binaryPath}
+                </div>
+              )}
             </div>
           ) :
         null}

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -396,6 +396,13 @@ function EngineSelect({
                 className="h-3.5 w-3.5 text-muted-foreground shrink-0"
               />
               <span className="font-medium">{profile?.name ?? a.engineType}</span>
+              {t(`createIssue.engineDesc.${a.engineType}`, '') ?
+                  (
+                    <span className="text-[10px] text-muted-foreground ml-1">
+                      {t(`createIssue.engineDesc.${a.engineType}`)}
+                    </span>
+                  ) :
+                null}
             </DropdownMenuItem>
           )
         })}

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronsRight, MousePointerClick } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -9,8 +9,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
@@ -30,8 +28,8 @@ import type { EngineAvailability, EngineModel, EngineProfile } from '@/types/kan
 // ── Data ──────────────────────────────────────────────
 
 const PERMISSIONS = [
-  { id: 'auto', icon: ChevronsRight },
-  { id: 'ask', icon: MousePointerClick },
+  { id: 'auto' },
+  { id: 'ask' },
 ] as const
 type PermissionId = (typeof PERMISSIONS)[number]['id']
 
@@ -488,7 +486,6 @@ function PermissionSelect({
 }) {
   const { t } = useTranslation()
   const current = PERMISSIONS.find(p => p.id === value) ?? PERMISSIONS[0]
-  const Icon = current.icon
 
   return (
     <DropdownMenu>
@@ -500,28 +497,19 @@ function PermissionSelect({
           />
         )}
       >
-        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="truncate">{t(`createIssue.perm.${current.id}`)}</span>
         <ChevronDown className="h-3 w-3 text-muted-foreground ml-auto shrink-0" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[140px]">
-        <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground">
-          {t('createIssue.permission')}
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {PERMISSIONS.map((perm) => {
-          const PermIcon = perm.icon
-          return (
-            <DropdownMenuItem
-              key={perm.id}
-              onSelect={() => onChange(perm.id)}
-              className={perm.id === value ? 'bg-accent/50' : ''}
-            >
-              <PermIcon className="h-4 w-4 text-muted-foreground shrink-0" />
-              <span className="font-medium">{t(`createIssue.perm.${perm.id}`)}</span>
-            </DropdownMenuItem>
-          )
-        })}
+        {PERMISSIONS.map(perm => (
+          <DropdownMenuItem
+            key={perm.id}
+            onSelect={() => onChange(perm.id)}
+            className={perm.id === value ? 'bg-accent/50' : ''}
+          >
+            <span className="font-medium">{t(`createIssue.perm.${perm.id}`)}</span>
+          </DropdownMenuItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -9,8 +9,6 @@ import {
   Clock,
   FileText,
   Loader2,
-  RotateCcw,
-  Skull,
   Square,
   Terminal,
 } from 'lucide-react'
@@ -19,7 +17,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { useCancelIssue, useRestartIssue, useTerminateProcess } from '@/hooks/use-kanban'
+import { useTerminateProcess } from '@/hooks/use-kanban'
 import type { ProcessInfo } from '@/types/kanban'
 
 function StatusIcon({ status }: { status: string | null }) {
@@ -72,8 +70,6 @@ function isIdle(proc: ProcessInfo): boolean {
 function ProcessCard({ proc, projectId }: { proc: ProcessInfo, projectId: string }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const cancelMutation = useCancelIssue(projectId)
-  const restartMutation = useRestartIssue(projectId)
   const terminateMutation = useTerminateProcess(projectId)
   const [showCommand, setShowCommand] = useState(false)
   const idle = isIdle(proc)
@@ -178,44 +174,15 @@ function ProcessCard({ proc, projectId }: { proc: ProcessInfo, projectId: string
 
       {/* Actions */}
       <div className="flex items-center gap-1.5 pt-1">
-        {(proc.processState === 'running' || proc.processState === 'spawning') && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-6 text-[10px] gap-1"
-            disabled={cancelMutation.isPending}
-            onClick={() => cancelMutation.mutate(proc.issueId)}
-          >
-            <Square className="h-3 w-3" />
-            {cancelMutation.isPending ? t('processManager.cancelling') : t('processManager.cancel')}
-          </Button>
-        )}
-        {(proc.processState === 'failed' || proc.processState === 'cancelled') && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-6 text-[10px] gap-1"
-            disabled={restartMutation.isPending}
-            onClick={() => restartMutation.mutate(proc.issueId)}
-          >
-            <RotateCcw className="h-3 w-3" />
-            {restartMutation.isPending ?
-                t('processManager.restarting') :
-                t('processManager.restart')}
-          </Button>
-        )}
-        {/* Terminate — always available, force-kills process regardless of state */}
         <Button
           variant="outline"
           size="sm"
-          className="h-6 text-[10px] gap-1 text-destructive hover:text-destructive"
+          className="h-6 text-[10px] gap-1"
           disabled={terminateMutation.isPending}
           onClick={() => terminateMutation.mutate(proc.issueId)}
         >
-          <Skull className="h-3 w-3" />
-          {terminateMutation.isPending ?
-              t('processManager.terminating') :
-              t('processManager.terminate')}
+          <Square className="h-3 w-3" />
+          {terminateMutation.isPending ? t('processManager.terminating') : t('processManager.terminate')}
         </Button>
       </div>
     </div>

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -132,7 +132,7 @@
       "planner": "Plan tasks",
       "reviewer": "Review code",
       "researcher": "Research",
-      "echo": "Mock engine"
+      "echo": "Mock engine, does nothing"
     },
     "modelDesc": {
       "opus": "Most capable",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -132,7 +132,7 @@
       "planner": "规划任务",
       "reviewer": "审查代码",
       "researcher": "调研分析",
-      "echo": "模拟引擎"
+      "echo": "模拟模型，不做任何工作"
     },
     "modelDesc": {
       "opus": "最强大",


### PR DESCRIPTION
## Summary
- Prioritize `/work/bin` for claude and codex binary resolution (highest priority)
- Standardize naming: `getBaseCommand`/`getCodexCmd` → `resolveBaseCmd` in both executors
- Return `binaryPath` from codex and gemini `getAvailability()`
- Display `engineDesc` i18n descriptions in settings engine cards and create issue dialog
- Show resolved `binaryPath` in engine cards (collapsed view + expanded model list)
- Rename Echo profile to "Echo (Mock)" with updated descriptions

## Test plan
- [ ] Re-probe engines in settings — all engines show binary path
- [ ] Engine descriptions visible under engine name in settings
- [ ] Engine descriptions visible in create issue engine dropdown
- [ ] Place binary in `/work/bin/claude` or `/work/bin/codex` — verify it's picked up first