### PR TITLE
feat: add macOS Intel (x64) launcher build support

### DIFF
--- a/.github/workflows/launcher.yml
+++ b/.github/workflows/launcher.yml
@@ -31,6 +31,10 @@ jobs:
             runner: macos-latest
             label: darwin-arm64
             suffix: darwin-arm64
+          - target: bun-darwin-x64
+            runner: macos-13
+            label: darwin-x64
+            suffix: darwin-x64
 
     steps:
       - uses: actions/checkout@v4
@@ -81,6 +85,7 @@ jobs:
           cp artifacts/bkd-launcher-linux-x64/bkd-* release/
           cp artifacts/bkd-launcher-linux-arm64/bkd-* release/
           cp artifacts/bkd-launcher-darwin-arm64/bkd-* release/
+          cp artifacts/bkd-launcher-darwin-x64/bkd-* release/
           for f in release/bkd-launcher-*; do
             chmod +x "$f"
           done

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ chmod +x bkd-launcher-darwin-arm64
 ./bkd-launcher-darwin-arm64
 ```
 
+**macOS (Intel)**
+
+```bash
+curl -LO https://github.com/bkhq/bkd/releases/download/launcher-v1/bkd-launcher-darwin-x64
+chmod +x bkd-launcher-darwin-x64
+./bkd-launcher-darwin-x64
+```
+
 The launcher stays fixed across versions — only the lightweight app package gets updated. Open http://localhost:3000 after starting.
 
 ## System Requirements

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,6 +39,14 @@ chmod +x bkd-launcher-darwin-arm64
 ./bkd-launcher-darwin-arm64
 ```
 
+**macOS (Intel)**
+
+```bash
+curl -LO https://github.com/bkhq/bkd/releases/download/launcher-v1/bkd-launcher-darwin-x64
+chmod +x bkd-launcher-darwin-x64
+./bkd-launcher-darwin-x64
+```
+
 启动器跨版本保持不变，只有轻量级的应用包会被更新。启动后打开 http://localhost:3000。
 
 ## 系统要求


### PR DESCRIPTION
## Summary
- Add `bun-darwin-x64` target to the launcher CI matrix using `macos-13` runner (last Intel macOS runner available on GitHub Actions)
- Add artifact copy step for the new `darwin-x64` binary in the release job
- Document macOS Intel download instructions in both `README.md` and `README.zh-CN.md`

## Test plan
- [ ] Trigger launcher workflow and verify `darwin-x64` binary builds successfully
- [ ] Verify the release job includes the new binary in the GitHub release assets