### PR TITLE
feat: show project name in file browser breadcrumb

### DIFF
--- a/apps/api/drizzle/0011_quiet_gideon.sql
+++ b/apps/api/drizzle/0011_quiet_gideon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` ADD `sort_order` integer DEFAULT 0 NOT NULL;

--- a/apps/api/drizzle/meta/0011_snapshot.json
+++ b/apps/api/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1094 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cce81845-40e1-4bec-821d-0d41547adcb6",
+  "prevId": "9d945ab5-acfd-496c-b8dc-e49fdf07d5db",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_issue_id_idx": {
+          "name": "attachments_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "attachments_log_id_idx": {
+          "name": "attachments_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attachments_issue_id_issues_id_fk": {
+          "name": "attachments_issue_id_issues_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_log_id_issues_logs_id_fk": {
+          "name": "attachments_log_id_issues_logs_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues_logs": {
+      "name": "issues_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_index": {
+          "name": "entry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_ref_id": {
+          "name": "tool_call_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_issue_id_idx": {
+          "name": "issues_logs_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_turn_entry_idx": {
+          "name": "issues_logs_issue_id_turn_entry_idx",
+          "columns": [
+            "issue_id",
+            "turn_index",
+            "entry_index"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_visible_type_idx": {
+          "name": "issues_logs_issue_id_visible_type_idx",
+          "columns": [
+            "issue_id",
+            "visible",
+            "entry_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_issue_id_issues_id_fk": {
+          "name": "issues_logs_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues": {
+      "name": "issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent_issue_id": {
+          "name": "parent_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "engine_type": {
+          "name": "engine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_status": {
+          "name": "session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_project_id_idx": {
+          "name": "issues_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "issues_status_id_idx": {
+          "name": "issues_status_id_idx",
+          "columns": [
+            "status_id"
+          ],
+          "isUnique": false
+        },
+        "issues_parent_issue_id_idx": {
+          "name": "issues_parent_issue_id_idx",
+          "columns": [
+            "parent_issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_status_updated_at_idx": {
+          "name": "issues_project_id_status_updated_at_idx",
+          "columns": [
+            "project_id",
+            "status_updated_at"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_issue_number_uniq": {
+          "name": "issues_project_id_issue_number_uniq",
+          "columns": [
+            "project_id",
+            "issue_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_parent_issue_id_issues_id_fk": {
+          "name": "issues_parent_issue_id_issues_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "issues_status_id_check": {
+          "name": "issues_status_id_check",
+          "value": "\"issues\".\"status_id\" IN ('todo','working','review','done')"
+        }
+      }
+    },
+    "issues_logs_tools_call": {
+      "name": "issues_logs_tools_call",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_result": {
+          "name": "is_result",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_tools_call_log_id_idx": {
+          "name": "issues_logs_tools_call_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_idx": {
+          "name": "issues_logs_tools_call_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_kind_idx": {
+          "name": "issues_logs_tools_call_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_tool_name_idx": {
+          "name": "issues_logs_tools_call_tool_name_idx",
+          "columns": [
+            "tool_name"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_kind_idx": {
+          "name": "issues_logs_tools_call_issue_id_kind_idx",
+          "columns": [
+            "issue_id",
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_tools_call_log_id_issues_logs_id_fk": {
+          "name": "issues_logs_tools_call_log_id_issues_logs_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_logs_tools_call_issue_id_issues_id_fk": {
+          "name": "issues_logs_tools_call_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "projects_alias_unique": {
+          "name": "projects_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_created_at_idx": {
+          "name": "webhook_deliveries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_dedup_idx": {
+          "name": "webhook_deliveries_dedup_idx",
+          "columns": [
+            "webhook_id",
+            "dedup_key",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1773115168976,
       "tag": "0010_yielding_red_ghost",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1773177234278,
+      "tag": "0011_quiet_gideon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -37,6 +37,7 @@ export const projects = sqliteTable('projects', {
   repositoryUrl: text('repository_url'),
   systemPrompt: text('system_prompt'),
   envVars: text('env_vars'), // JSON: Record<string, string>
+  sortOrder: integer('sort_order').notNull().default(0),
   ...commonFields,
 })
 

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { zValidator } from '@hono/zod-validator'
-import { and, eq, inArray, ne } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, ne } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { customAlphabet } from 'nanoid'
 import * as z from 'zod'
@@ -37,6 +37,7 @@ const updateProjectSchema = z.object({
   repositoryUrl: z.string().url().optional().or(z.literal('')),
   systemPrompt: z.string().max(32768).optional(),
   envVars: envVarsSchema,
+  sortOrder: z.number().int().min(0).optional(),
 })
 
 type ProjectRow = typeof projectsTable.$inferSelect
@@ -51,6 +52,7 @@ function serializeProject(row: ProjectRow) {
     repositoryUrl: row.repositoryUrl ?? undefined,
     systemPrompt: row.systemPrompt ?? undefined,
     envVars: row.envVars ? (JSON.parse(row.envVars) as Record<string, string>) : undefined,
+    sortOrder: row.sortOrder,
     createdAt: toISO(row.createdAt),
     updatedAt: toISO(row.updatedAt),
   }
@@ -99,9 +101,41 @@ async function isDirectoryTaken(directory: string, excludeId?: string): Promise<
 const projects = new Hono()
 
 projects.get('/', async (c) => {
-  const rows = await db.select().from(projectsTable).where(eq(projectsTable.isDeleted, 0))
+  const rows = await db
+    .select()
+    .from(projectsTable)
+    .where(eq(projectsTable.isDeleted, 0))
+    .orderBy(asc(projectsTable.sortOrder), desc(projectsTable.updatedAt))
   return c.json({ success: true, data: rows.map(serializeProject) })
 })
+
+const sortProjectsSchema = z.object({
+  order: z.array(z.object({
+    id: z.string(),
+    sortOrder: z.number().int().min(0),
+  })).min(1).max(200),
+})
+
+projects.patch(
+  '/sort',
+  zValidator('json', sortProjectsSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, error: result.error.issues.map(i => i.message).join(', ') }, 400)
+    }
+  }),
+  async (c) => {
+    const { order } = c.req.valid('json')
+    await db.transaction(async (tx) => {
+      for (const item of order) {
+        await tx
+          .update(projectsTable)
+          .set({ sortOrder: item.sortOrder })
+          .where(eq(projectsTable.id, item.id))
+      }
+    })
+    return c.json({ success: true, data: null })
+  },
+)
 
 projects.post(
   '/',
@@ -193,6 +227,7 @@ projects.patch(
     if (body.envVars !== undefined) {
       updates.envVars = Object.keys(body.envVars).length > 0 ? JSON.stringify(body.envVars) : null
     }
+    if (body.sortOrder !== undefined) updates.sortOrder = body.sortOrder
 
     if (Object.keys(updates).length === 0) {
       return c.json({ success: true, data: serializeProject(existing) })

--- a/apps/frontend/src/components/files/FileBreadcrumb.tsx
+++ b/apps/frontend/src/components/files/FileBreadcrumb.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from 'react-i18next'
 interface FileBreadcrumbProps {
   path: string
   onNavigate: (path: string) => void
+  projectName?: string
 }
 
-export function FileBreadcrumb({ path, onNavigate }: FileBreadcrumbProps) {
+export function FileBreadcrumb({ path, onNavigate, projectName }: FileBreadcrumbProps) {
   const { t } = useTranslation()
   const segments = path && path !== '.' ? path.split('/') : []
 
@@ -22,6 +23,19 @@ export function FileBreadcrumb({ path, onNavigate }: FileBreadcrumbProps) {
       >
         <Home className="h-3.5 w-3.5" />
       </button>
+
+      {projectName && (
+        <span className="flex items-center gap-1.5 shrink-0 text-xs">
+          <span className="text-muted-foreground/40">/</span>
+          <button
+            type="button"
+            onClick={() => onNavigate('.')}
+            className={segments.length === 0 ? 'font-semibold text-foreground' : 'text-primary hover:underline underline-offset-2'}
+          >
+            {projectName}
+          </button>
+        </span>
+      )}
 
       {segments.map((segment, i) => {
         const segmentPath = segments.slice(0, i + 1).join('/')

--- a/apps/frontend/src/components/files/FileBrowserContent.tsx
+++ b/apps/frontend/src/components/files/FileBrowserContent.tsx
@@ -206,7 +206,7 @@ export function FileBrowserContent({
                 ? (
                     <FileViewer
                       file={listing}
-                      breadcrumb={<FileBreadcrumb path={currentPath} onNavigate={navigateTo} />}
+                      breadcrumb={<FileBreadcrumb path={currentPath} onNavigate={navigateTo} projectName={project?.name} />}
                       isEditing={isEditing}
                       onStartEdit={() => setIsEditing(true)}
                       onCancelEdit={() => setIsEditing(false)}
@@ -221,7 +221,7 @@ export function FileBrowserContent({
                         onNavigate={handleEntryClick}
                         onDelete={handleDeleteEntry}
                         isDeleting={deleteFileMutation.isPending}
-                        breadcrumb={<FileBreadcrumb path={currentPath} onNavigate={navigateTo} />}
+                        breadcrumb={<FileBreadcrumb path={currentPath} onNavigate={navigateTo} projectName={project?.name} />}
                       />
                     )
                   : null}

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -84,6 +84,7 @@ export function useUpdateProject() {
       repositoryUrl?: string
       systemPrompt?: string
       envVars?: Record<string, string>
+      sortOrder?: number
     }) => {
       const { id, ...rest } = data
       return kanbanApi.updateProject(id, rest)
@@ -93,6 +94,17 @@ export function useUpdateProject() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.project(variables.id),
       })
+    },
+  })
+}
+
+export function useSortProjects() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (order: Array<{ id: string, sortOrder: number }>) =>
+      kanbanApi.sortProjects(order),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects() })
     },
   })
 }

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -95,9 +95,12 @@ export const kanbanApi = {
       repositoryUrl?: string
       systemPrompt?: string
       envVars?: Record<string, string>
+      sortOrder?: number
     },
   ) => patch<Project>(`/api/projects/${id}`, data),
   deleteProject: (id: string) => del<{ id: string }>(`/api/projects/${id}`),
+  sortProjects: (order: Array<{ id: string, sortOrder: number }>) =>
+    patch<null>('/api/projects/sort', { order }),
 
   // Worktrees
   getWorktrees: (projectId: string) =>

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -1,3 +1,5 @@
+import { DragDropProvider } from '@dnd-kit/react'
+import { useSortable } from '@dnd-kit/react/sortable'
 import {
   Check,
   Copy,
@@ -10,7 +12,7 @@ import {
   StickyNote,
   TerminalSquare,
 } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { AppLogo } from '@/components/AppLogo'
@@ -22,7 +24,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { useProjects } from '@/hooks/use-kanban'
+import { useProjects, useSortProjects } from '@/hooks/use-kanban'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useProjectStats } from '@/hooks/use-project-stats'
 import { getProjectInitials } from '@/lib/format'
@@ -31,11 +33,27 @@ import { useTerminalStore } from '@/stores/terminal-store'
 import { useViewModeStore } from '@/stores/view-mode-store'
 import type { Project } from '@/types/kanban'
 
-function ProjectCard({ project, onClick }: { project: Project, onClick: () => void }) {
+function SortableProjectCard({
+  project,
+  index,
+  onClick,
+}: {
+  project: Project
+  index: number
+  onClick: () => void
+}) {
   const { t } = useTranslation()
   const stats = useProjectStats(project.id)
   const [showSettings, setShowSettings] = useState(false)
   const [copied, setCopied] = useState(false)
+
+  const { ref, isDragging } = useSortable({
+    id: project.id,
+    index,
+    group: 'projects',
+    type: 'item',
+    data: { project },
+  })
 
   const handleCopyPath = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -48,71 +66,77 @@ function ProjectCard({ project, onClick }: { project: Project, onClick: () => vo
 
   return (
     <>
-      <Card
-        className="h-full bg-card/70 hover:bg-card cursor-pointer transition-all hover:shadow-md hover:border-primary/20 group"
-        onClick={onClick}
+      <div
+        ref={ref}
+        className={`animate-card-enter ${isDragging ? 'opacity-50 scale-105 shadow-xl z-10 rotate-1' : ''}`}
+        style={{ animationDelay: `${index * 60}ms` }}
       >
-        <CardHeader>
-          <div className="flex items-start gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-xs font-bold bg-muted text-muted-foreground">
-              {getProjectInitials(project.name)}
+        <Card
+          className="h-full bg-card/70 hover:bg-card cursor-pointer transition-all hover:shadow-md hover:border-primary/20 group"
+          onClick={onClick}
+        >
+          <CardHeader>
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-xs font-bold bg-muted text-muted-foreground">
+                {getProjectInitials(project.name)}
+              </div>
+              <div className="min-w-0 flex-1">
+                <CardTitle className="flex items-baseline gap-1.5 text-base group-hover:text-primary transition-colors">
+                  <span className="truncate">{project.name}</span>
+                  <span className="shrink-0 text-[10px] font-normal font-mono text-muted-foreground/60">
+                    {project.id}
+                  </span>
+                </CardTitle>
+                {project.description && (
+                  <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
+                    {project.description}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setShowSettings(true)
+                }}
+                className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.07] transition-colors"
+                aria-label={t('project.settings')}
+                title={t('project.settings')}
+              >
+                <Settings className="h-4 w-4" />
+              </button>
             </div>
-            <div className="min-w-0 flex-1">
-              <CardTitle className="flex items-baseline gap-1.5 text-base group-hover:text-primary transition-colors">
-                <span className="truncate">{project.name}</span>
-                <span className="shrink-0 text-[10px] font-normal font-mono text-muted-foreground/60">
-                  {project.id}
-                </span>
-              </CardTitle>
-              {project.description && (
-                <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
-                  {project.description}
-                </p>
-              )}
+          </CardHeader>
+          <CardContent className="mt-auto">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {project.directory ?
+                  (
+                    <button
+                      type="button"
+                      onClick={handleCopyPath}
+                      className="group/path flex min-w-0 items-center gap-1 hover:text-foreground transition-colors text-left"
+                      title={t('project.copyPath')}
+                    >
+                      <FolderOpen className="h-3 w-3 shrink-0" />
+                      <span className="truncate font-mono">{project.directory}</span>
+                      {copied ?
+                          (
+                            <Check className="h-3 w-3 shrink-0 text-green-500" />
+                          ) :
+                          (
+                            <Copy className="h-3 w-3 shrink-0 opacity-0 group-hover/path:opacity-100 transition-opacity" />
+                          )}
+                    </button>
+                  ) :
+                null}
+              <span className="ml-auto flex shrink-0 items-center gap-1">
+                <Hash className="h-3 w-3" />
+                {stats.issueCount}
+              </span>
             </div>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                setShowSettings(true)
-              }}
-              className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.07] transition-colors"
-              aria-label={t('project.settings')}
-              title={t('project.settings')}
-            >
-              <Settings className="h-4 w-4" />
-            </button>
-          </div>
-        </CardHeader>
-        <CardContent className="mt-auto">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {project.directory ?
-                (
-                  <button
-                    type="button"
-                    onClick={handleCopyPath}
-                    className="group/path flex min-w-0 items-center gap-1 hover:text-foreground transition-colors text-left"
-                    title={t('project.copyPath')}
-                  >
-                    <FolderOpen className="h-3 w-3 shrink-0" />
-                    <span className="truncate font-mono">{project.directory}</span>
-                    {copied ?
-                        (
-                          <Check className="h-3 w-3 shrink-0 text-green-500" />
-                        ) :
-                        (
-                          <Copy className="h-3 w-3 shrink-0 opacity-0 group-hover/path:opacity-100 transition-opacity" />
-                        )}
-                  </button>
-                ) :
-              null}
-            <span className="ml-auto flex shrink-0 items-center gap-1">
-              <Hash className="h-3 w-3" />
-              {stats.issueCount}
-            </span>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
       <ProjectSettingsDialog open={showSettings} onOpenChange={setShowSettings} project={project} />
     </>
   )
@@ -291,6 +315,15 @@ export default function HomePage() {
   const [showSettings, setShowSettings] = useState(false)
   const isMobile = useIsMobile()
   const globalProjectPath = useViewModeStore(s => s.projectPath)
+  const sortProjects = useSortProjects()
+
+  // Track local order during drag for optimistic UI
+  const [localOrder, setLocalOrder] = useState<Project[] | null>(null)
+  const displayProjects = localOrder ?? projects
+
+  // Keep a ref to the latest projects for the drag callbacks
+  const projectsRef = useRef(projects)
+  projectsRef.current = projects
 
   // Mobile always uses list mode
   const projectPath = useCallback(
@@ -355,20 +388,38 @@ export default function HomePage() {
               </div>
             ) :
             (
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {projects?.map((project, index) => (
-                  <div
-                    key={project.id}
-                    className="animate-card-enter"
-                    style={{ animationDelay: `${index * 60}ms` }}
-                  >
-                    <ProjectCard
+              <DragDropProvider
+                onDragOver={(event) => {
+                  const source = projectsRef.current
+                  if (!source) return
+                  const { dragOperation } = event.operation
+                  if (!dragOperation.source || dragOperation.source.sortable == null) return
+                  const fromIdx = dragOperation.source.sortable.index
+                  const toIdx = (event.operation.target as any)?.sortable?.index
+                  if (toIdx == null || fromIdx === toIdx) return
+                  const reordered = [...(localOrder ?? source)]
+                  const [moved] = reordered.splice(fromIdx, 1)
+                  if (moved) reordered.splice(toIdx, 0, moved)
+                  setLocalOrder(reordered)
+                }}
+                onDragEnd={() => {
+                  if (!localOrder) return
+                  const order = localOrder.map((p, i) => ({ id: p.id, sortOrder: i }))
+                  sortProjects.mutate(order)
+                  setLocalOrder(null)
+                }}
+              >
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {displayProjects?.map((project, index) => (
+                    <SortableProjectCard
+                      key={project.id}
                       project={project}
+                      index={index}
                       onClick={() => navigate(projectPath(project.alias))}
                     />
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              </DragDropProvider>
             )}
       </section>
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export interface Project {
   repositoryUrl?: string
   systemPrompt?: string
   envVars?: Record<string, string>
+  sortOrder: number
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
- Add project name as the first breadcrumb segment after the home icon in the file browser
- Matches GitHub's repo name breadcrumb pattern (`HomeIcon / projectName / dir / dir`)
- Project name is bold when at root, clickable link when in subdirectories

## Test plan
- [ ] Open file browser for a project, verify project name appears after home icon
- [ ] Click project name — navigates back to root
- [ ] At root level, project name shows bold (non-link style)
- [ ] In subdirectory, project name shows as clickable link