### PR TITLE
feat: validate git repo before worktree creation and base on main branch

### DIFF
--- a/apps/api/src/engines/issue/utils/worktree.ts
+++ b/apps/api/src/engines/issue/utils/worktree.ts
@@ -4,6 +4,7 @@ import { WORKTREE_DIR } from '@/engines/issue/constants'
 import { runCommand } from '@/engines/spawn'
 import { logger } from '@/logger'
 import { ROOT_DIR } from '@/root'
+import { isGitRepoFresh } from '@/utils/git'
 
 /** Resolve WORKTREE_DIR — absolute paths used as-is, relative resolved from ROOT_DIR */
 export const WORKTREE_BASE = WORKTREE_DIR.startsWith('/') ?
@@ -22,18 +23,45 @@ export function resolveWorktreePath(projectId: string, issueId: string): string 
   return join(WORKTREE_BASE, projectId, issueId)
 }
 
+/**
+ * Resolve the main branch start point for worktree creation.
+ * Priority: origin/main > origin/master > local main > local master.
+ * Throws if no main branch is found — refuses to use HEAD which may
+ * point to an arbitrary feature branch with uncommitted state.
+ */
+async function resolveMainBranch(baseDir: string): Promise<string> {
+  const candidates = ['origin/main', 'origin/master', 'main', 'master']
+  for (const ref of candidates) {
+    const { code } = await runCommand(
+      ['git', 'rev-parse', '--verify', '--quiet', ref],
+      { cwd: baseDir, stderr: 'pipe' },
+    )
+    if (code === 0) return ref
+  }
+  throw new Error(
+    `Cannot resolve main branch in ${baseDir}: none of ${candidates.join(', ')} exist`,
+  )
+}
+
 export async function createWorktree(
   baseDir: string,
   projectId: string,
   issueId: string,
 ): Promise<string> {
+  // Guard: baseDir must be inside a git work tree
+  if (!(await isGitRepoFresh(baseDir))) {
+    throw new Error(`Cannot create worktree: ${baseDir} is not a git repository`)
+  }
+
   const branchName = `bkd/${issueId}`
   const worktreeDir = resolveWorktreePath(projectId, issueId)
   await mkdir(join(WORKTREE_BASE, projectId), { recursive: true })
 
-  // Create worktree with a new branch off HEAD
+  const startPoint = await resolveMainBranch(baseDir)
+
+  // Create worktree with a new branch off the resolved main branch
   const result = await runCommand(
-    ['git', 'worktree', 'add', '-b', branchName, worktreeDir],
+    ['git', 'worktree', 'add', '-b', branchName, worktreeDir, startPoint],
     { cwd: baseDir, stderr: 'pipe' },
   )
   if (result.code !== 0) {
@@ -46,7 +74,7 @@ export async function createWorktree(
       throw new Error(`Failed to create worktree: ${result.stderr.trim()} / ${retry.stderr.trim()}`)
     }
   }
-  logger.debug({ issueId, worktreeDir, branchName }, 'worktree_created')
+  logger.debug({ issueId, worktreeDir, branchName, startPoint }, 'worktree_created')
   return worktreeDir
 }
 

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -2,9 +2,9 @@ import { stat } from 'node:fs/promises'
 import { resolve, sep } from 'node:path'
 import { runCommand } from '@/engines/spawn'
 import { Hono } from 'hono'
-import { cacheGetOrSet } from '@/cache'
 import { findProject } from '@/db/helpers'
 import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
+import { isGitRepo } from '@/utils/git'
 import { getProjectOwnedIssue } from './_shared'
 
 // ---------- Types ----------
@@ -72,13 +72,6 @@ async function runGit(
   cwd: string,
 ): Promise<{ code: number, stdout: string }> {
   return runCommand(['git', ...args], { cwd })
-}
-
-async function isGitRepo(cwd: string): Promise<boolean> {
-  return cacheGetOrSet(`gitRepo:${cwd}`, 120, async () => {
-    const { code, stdout } = await runGit(['rev-parse', '--is-inside-work-tree'], cwd)
-    return code === 0 && stdout.trim() === 'true'
-  })
 }
 
 function parsePorcelainLine(line: string): GitChangedFile | null {

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -1,3 +1,4 @@
+import { stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { zValidator } from '@hono/zod-validator'
 import { and, asc, desc, eq, inArray, ne } from 'drizzle-orm'
@@ -10,8 +11,8 @@ import { findProject, invalidateProjectCache } from '@/db/helpers'
 import { issues as issuesTable, projects as projectsTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
 import { logger } from '@/logger'
-
 import { toISO } from '@/utils/date'
+import { isGitRepoFresh } from '@/utils/git'
 
 const aliasId = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8)
 
@@ -55,6 +56,18 @@ function serializeProject(row: ProjectRow) {
     sortOrder: row.sortOrder,
     createdAt: toISO(row.createdAt),
     updatedAt: toISO(row.updatedAt),
+  }
+}
+
+async function checkProjectGitRepo(directory: string | null | undefined): Promise<boolean> {
+  if (!directory) return false
+  const dir = resolve(directory)
+  try {
+    const s = await stat(dir)
+    if (!s.isDirectory()) return false
+    return isGitRepoFresh(dir)
+  } catch {
+    return false
   }
 }
 
@@ -106,7 +119,13 @@ projects.get('/', async (c) => {
     .from(projectsTable)
     .where(eq(projectsTable.isDeleted, 0))
     .orderBy(asc(projectsTable.sortOrder), desc(projectsTable.updatedAt))
-  return c.json({ success: true, data: rows.map(serializeProject) })
+  const data = await Promise.all(
+    rows.map(async (row) => {
+      const gitRepo = await checkProjectGitRepo(row.directory)
+      return { ...serializeProject(row), isGitRepo: gitRepo }
+    }),
+  )
+  return c.json({ success: true, data })
 })
 
 const sortProjectsSchema = z.object({
@@ -181,7 +200,8 @@ projects.get('/:projectId', async (c) => {
   if (!row) {
     return c.json({ success: false, error: 'Project not found' }, 404)
   }
-  return c.json({ success: true, data: serializeProject(row) })
+  const gitRepo = await checkProjectGitRepo(row.directory)
+  return c.json({ success: true, data: { ...serializeProject(row), isGitRepo: gitRepo } })
 })
 
 projects.patch(

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -65,7 +65,7 @@ async function checkProjectGitRepo(directory: string | null | undefined): Promis
   try {
     const s = await stat(dir)
     if (!s.isDirectory()) return false
-    return isGitRepoFresh(dir)
+    return await isGitRepoFresh(dir)
   } catch {
     return false
   }

--- a/apps/api/src/utils/git.ts
+++ b/apps/api/src/utils/git.ts
@@ -1,0 +1,26 @@
+import { cacheGetOrSet } from '@/cache'
+import { runCommand } from '@/engines/spawn'
+
+async function checkGitWorkTree(cwd: string): Promise<boolean> {
+  const { code, stdout } = await runCommand(
+    ['git', 'rev-parse', '--is-inside-work-tree'],
+    { cwd },
+  )
+  return code === 0 && stdout.trim() === 'true'
+}
+
+/**
+ * Check whether `cwd` is inside a git work tree.
+ * Result is cached for 120 seconds per directory.
+ */
+export async function isGitRepo(cwd: string): Promise<boolean> {
+  return cacheGetOrSet(`gitRepo:${cwd}`, 120, () => checkGitWorkTree(cwd))
+}
+
+/**
+ * Same check without caching — always runs `git rev-parse`.
+ * Use when freshness matters (e.g. project API responses).
+ */
+export async function isGitRepoFresh(cwd: string): Promise<boolean> {
+  return checkGitWorkTree(cwd)
+}

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -18,6 +18,7 @@ import {
   useEngineAvailability,
   useEngineProfiles,
   useEngineSettings,
+  useProject,
 } from '@/hooks/use-kanban'
 import { tStatus } from '@/lib/i18n-utils'
 import type { StatusDefinition } from '@/lib/statuses'
@@ -52,6 +53,8 @@ export function CreateIssueForm({
 }) {
   const { t } = useTranslation()
   const createIssue = useCreateIssue(projectId)
+  const { data: project } = useProject(projectId)
+  const projectIsGitRepo = project?.isGitRepo ?? false
 
   // Engine discovery data
   const { data: discovery } = useEngineAvailability(true)
@@ -74,6 +77,11 @@ export function CreateIssueForm({
   const [modelId, setModelId] = useState('')
   const [permission, setPermission] = useState<PermissionId>('auto')
   const [useWorktree, setUseWorktree] = useState(true)
+
+  // Sync worktree toggle with project git repo status
+  useEffect(() => {
+    setUseWorktree(projectIsGitRepo)
+  }, [projectIsGitRepo])
 
   // Resolve the effective engine type ('' means use system default)
   const resolvedEngineType = useMemo(() => {
@@ -136,7 +144,7 @@ export function CreateIssueForm({
           setEngineType('')
           setModelId('')
           setPermission('auto')
-          setUseWorktree(true)
+          setUseWorktree(projectIsGitRepo)
           onCreated?.()
         },
       },
@@ -147,6 +155,7 @@ export function CreateIssueForm({
     statusId,
     permission,
     useWorktree,
+    projectIsGitRepo,
     parentIssueId,
     resolvedEngineType,
     modelId,
@@ -208,7 +217,7 @@ export function CreateIssueForm({
             <StatusSelect statuses={STATUSES} value={statusId} onChange={setStatusId} />
           </PropertyRow>
           <PropertyRow label={t('createIssue.worktree')}>
-            <WorktreeToggle value={useWorktree} onChange={setUseWorktree} />
+            <WorktreeToggle value={useWorktree} onChange={setUseWorktree} disabled={!projectIsGitRepo} />
           </PropertyRow>
           <PropertyRow label={t('createIssue.engine')}>
             <EngineSelect
@@ -407,10 +416,10 @@ function EngineSelect({
 // ── WorktreeToggle ────────────────────────────────────
 // Replaced manual button with shadcn Switch for better semantics & accessibility
 
-function WorktreeToggle({ value, onChange }: { value: boolean, onChange: (v: boolean) => void }) {
+function WorktreeToggle({ value, onChange, disabled }: { value: boolean, onChange: (v: boolean) => void, disabled?: boolean }) {
   return (
     <div className="flex items-center w-full">
-      <Switch checked={value} onCheckedChange={onChange} className="shrink-0" />
+      <Switch checked={value} onCheckedChange={onChange} disabled={disabled} className="shrink-0" />
     </div>
   )
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export interface Project {
   systemPrompt?: string
   envVars?: Record<string, string>
   sortOrder: number
+  isGitRepo: boolean
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
- Add `isGitRepo` field to project API responses with real-time git detection (no cache)
- Disable worktree toggle in CreateIssueDialog when the project directory is not a git repo
- Guard `createWorktree` with git repo check and resolve start point from `origin/main` > `origin/master` > `main` > `master` (refuses to fall back to HEAD)
- Extract shared `isGitRepo` / `isGitRepoFresh` utilities to `apps/api/src/utils/git.ts`

## Test plan
- [ ] Create a project with a non-git directory, verify worktree toggle is disabled and defaults to off
- [ ] Create a project with a git directory, verify worktree toggle is enabled and defaults to on
- [ ] Run `git init` in a previously non-git project directory, reopen create dialog, verify toggle becomes enabled
- [ ] Create a worktree-enabled issue, verify it branches from `origin/main` (or first available main branch)
- [ ] Create a worktree-enabled issue in a repo with no main/master branch, verify it errors gracefully