### PR TITLE
refactor: migrate drag-and-drop from @dnd-kit to @atlaskit/pragmatic-drag-and-drop

### DIFF
--- a/apps/api/src/db/helpers.ts
+++ b/apps/api/src/db/helpers.ts
@@ -1,4 +1,5 @@
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
+import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { cacheDel, cacheGet, cacheGetOrSet, cacheSet } from '@/cache'
 import { db } from '.'
 import {
@@ -222,6 +223,69 @@ export async function ensureServerInfoDefaults(): Promise<void> {
     const existing = await getAppSetting(SERVER_URL_KEY)
     if (!existing) {
       await setAppSetting(SERVER_URL_KEY, envUrl)
+    }
+  }
+}
+
+// --- Sort order backfill ---
+
+/**
+ * On startup: assign sequential sortOrders to projects and issues
+ * that still have the default 'a0', preserving their current DB order
+ * (createdAt ASC). Only runs once — skips if any row already has a
+ * non-default sortOrder.
+ */
+export async function backfillSortOrders(): Promise<void> {
+  // Backfill projects
+  const allProjects = await db
+    .select({ id: projectsTable.id, sortOrder: projectsTable.sortOrder })
+    .from(projectsTable)
+    .where(eq(projectsTable.isDeleted, false))
+    .orderBy(asc(projectsTable.createdAt))
+
+  const projectsNeedBackfill = allProjects.length > 1
+    && allProjects.every(p => p.sortOrder === 'a0')
+
+  if (projectsNeedBackfill) {
+    let cursor: string | null = null
+    for (const project of allProjects) {
+      const key = generateKeyBetween(cursor, null)
+      cursor = key
+      await db.update(projectsTable)
+        .set({ sortOrder: key })
+        .where(eq(projectsTable.id, project.id))
+    }
+  }
+
+  // Backfill issues per project
+  const projectIds = allProjects.map(p => p.id)
+  for (const projectId of projectIds) {
+    const issues = await db
+      .select({ id: issuesTable.id, sortOrder: issuesTable.sortOrder, statusId: issuesTable.statusId })
+      .from(issuesTable)
+      .where(and(eq(issuesTable.projectId, projectId), eq(issuesTable.isDeleted, false)))
+      .orderBy(asc(issuesTable.createdAt))
+
+    const needsBackfill = issues.length > 1
+      && issues.every(i => i.sortOrder === 'a0')
+
+    if (!needsBackfill) continue
+
+    // Group by status column, assign within each group
+    const byStatus: Record<string, typeof issues> = {}
+    for (const issue of issues) {
+      ;(byStatus[issue.statusId] ??= []).push(issue)
+    }
+
+    for (const group of Object.values(byStatus)) {
+      let cursor: string | null = null
+      for (const issue of group) {
+        const key = generateKeyBetween(cursor, null)
+        cursor = key
+        await db.update(issuesTable)
+          .set({ sortOrder: key })
+          .where(eq(issuesTable.id, issue.id))
+      }
     }
   }
 }

--- a/apps/api/src/engines/reconciler.ts
+++ b/apps/api/src/engines/reconciler.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { cacheDel } from '@/cache'
 import { db } from '@/db'
 import {
+  backfillSortOrders,
   ensureDefaultFilterRules,
   ensureServerInfoDefaults,
   ensureWorktreeAutoCleanupDefault,
@@ -116,6 +117,7 @@ export async function startupReconciliation(): Promise<void> {
   await ensureDefaultFilterRules()
   await ensureWorktreeAutoCleanupDefault()
   await ensureServerInfoDefaults()
+  await backfillSortOrders()
 
   // First, mark stale sessions (running/pending sessionStatus) as failed.
   // This was previously done by cleanupStaleSessions in db/helpers.

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { zValidator } from '@hono/zod-validator'
 import { and, asc, desc, eq, inArray, ne } from 'drizzle-orm'
 import { Hono } from 'hono'
+import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { customAlphabet } from 'nanoid'
 import * as z from 'zod'
 import { cacheDelByPrefix } from '@/cache'
@@ -178,6 +179,17 @@ projects.post(
     }
 
     const alias = await uniqueAlias(body.alias ?? generateAlias(body.name))
+
+    // Compute sortOrder: place after the last project
+    const lastProject = await db
+      .select({ sortOrder: projectsTable.sortOrder })
+      .from(projectsTable)
+      .where(eq(projectsTable.isDeleted, false))
+      .orderBy(desc(projectsTable.sortOrder))
+      .limit(1)
+      .then(rows => rows[0])
+    const sortOrder = generateKeyBetween(lastProject?.sortOrder ?? null, null)
+
     const [row] = await db
       .insert(projectsTable)
       .values({
@@ -188,6 +200,7 @@ projects.post(
         repositoryUrl: body.repositoryUrl || null,
         systemPrompt: body.systemPrompt ?? null,
         envVars: body.envVars ? JSON.stringify(body.envVars) : null,
+        sortOrder,
       })
       .returning()
 

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -389,10 +389,22 @@ export default function HomePage() {
         reordered.splice(toIndex, 0, moved)
 
         const newIdx = reordered.findIndex(p => p.id === draggedId)
-        const prev = newIdx > 0 ? reordered[newIdx - 1]!.sortOrder : null
-        const next = newIdx < reordered.length - 1 ? reordered[newIdx + 1]!.sortOrder : null
-        const newKey = generateKeyBetween(prev, next)
-        sortProjectRef.current.mutate({ id: draggedId, sortOrder: newKey })
+        const prevKey = newIdx > 0 ? (reordered[newIdx - 1]!.sortOrder || null) : null
+        const nextKey = newIdx < reordered.length - 1 ? (reordered[newIdx + 1]!.sortOrder || null) : null
+
+        // Happy path: neighbors are in proper order
+        if (prevKey === null || nextKey === null || prevKey < nextKey) {
+          const newKey = generateKeyBetween(prevKey, nextKey)
+          sortProjectRef.current.mutate({ id: draggedId, sortOrder: newKey })
+        } else {
+          // Collision: reassign all projects with sequential sort orders
+          let cursor: string | null = null
+          for (const project of reordered) {
+            const key = generateKeyBetween(cursor, null)
+            cursor = key
+            sortProjectRef.current.mutate({ id: project.id, sortOrder: key })
+          }
+        }
       },
     })
   }, [])


### PR DESCRIPTION
## Summary
- Migrate kanban board and homepage project cards from `@dnd-kit/react` to `@atlaskit/pragmatic-drag-and-drop`
- Use `draggable` + `dropTargetForElements` + `monitorForElements` pattern with closest-edge drop indicators
- Fix sortOrder collision handling: when adjacent items share the same sortOrder (e.g. all `a0`), reassign the entire column/list with sequential fractional keys
- Add startup backfill: auto-assign sequential sortOrders to existing projects/issues that still have the default `a0`
- Assign proper sortOrder when creating new projects (was using schema default `a0`)
- Remove unused `@dnd-kit` dependencies

## Changes
- **KanbanBoard**: Replace `<DragDropProvider>` with `monitorForElements` useEffect
- **KanbanCard**: Replace `useSortable` with `combine(draggable, dropTargetForElements)` + closestEdge indicator
- **KanbanColumn**: Replace `useDroppable` with `dropTargetForElements`
- **HomePage**: Migrate project card sorting to pragmatic-dnd with left/right edge indicators
- **board-store**: sortOrder ASC primary sort + collision detection/reassignment
- **db/helpers**: `backfillSortOrders()` for existing data migration
- **routes/projects**: Compute sortOrder on project creation

## Test plan
- [ ] Drag cards between kanban columns — verify drop indicator and correct placement
- [ ] Reorder cards within the same column
- [ ] Drag project cards on homepage — verify left/right indicators
- [ ] Create new project — verify it appears at the end
- [ ] Restart server with all-`a0` data — verify backfill assigns sequential keys