### PR TITLE
fix: prevent dual-instance corruption and engine settlement races

### DIFF
--- a/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
+++ b/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
@@ -79,6 +79,19 @@ export function monitorCompletion(
         { event: 'process_exited', pid, exitCode, signal },
       )
 
+      // Wait for stdout stream to finish draining all buffered data before
+      // settling. Without this, subprocess.exited resolves while consumeStream
+      // is still processing remaining output, causing the status to move to
+      // "review" while logs are still being emitted to the frontend.
+      if (managed.stdoutDone) {
+        try {
+          await managed.stdoutDone
+        } catch {
+          // Stream error already handled by consumeStream's catch handler
+        }
+        managed.debugLog?.event('stdout_drained_before_settle')
+      }
+
       // If the issue was already settled by handleTurnCompleted (conversational
       // engines where the process stays alive between turns), just clean up.
       if (managed.turnSettled) {

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -18,6 +18,11 @@ export function handleTurnCompleted(
 ): void {
   const managed = ctx.pm.get(executionId)?.meta
   if (!managed || managed.state !== 'running') return
+  // Guard: if turnInFlight is already false, this is a duplicate turn-completion
+  // entry from the stream (e.g. Claude emits a result entry followed by a system
+  // stop entry, or the stream continues producing result entries after settlement).
+  // Without this guard, each entry would trigger a new settlement cycle.
+  if (!managed.turnInFlight) return
   dispatch(managed, { type: 'TURN_COMPLETED' })
   logger.debug(
     { issueId, executionId, queued: managed.pendingInputs.length },

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -123,7 +123,7 @@ export function register(
   const stdoutStream = teeStreamToDebug(process.stdout, debugLog, 'stdout')
   const stderrStream = teeStreamToDebug(process.stderr, debugLog, 'stderr')
 
-  void consumeStream(executionId, issueId, stdoutStream, logParser, stdoutCallbacks)
+  managed.stdoutDone = consumeStream(executionId, issueId, stdoutStream, logParser, stdoutCallbacks)
     .then(() => {
       debugLog.event('stdout_stream_ended')
       logger.debug({ issueId, executionId }, 'consume_stream_promise_resolved')

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -88,4 +88,10 @@ export interface ManagedProcess {
   spawnCwd?: string
   /** External session ID (Claude CLI session UUID). */
   externalSessionId?: string
+  /**
+   * Promise that resolves when the stdout stream consumer finishes draining
+   * all buffered data. monitorCompletion awaits this before settling the issue
+   * to prevent the race where status moves to "review" while logs are still streaming.
+   */
+  stdoutDone?: Promise<void>
 }

--- a/apps/api/src/engines/reconciler.ts
+++ b/apps/api/src/engines/reconciler.ts
@@ -62,10 +62,23 @@ export async function reconcileStaleWorkingIssues(): Promise<number> {
 
   if (reconciledIssues.length === 0) return 0
 
+  // Re-check hasActiveProcess right before UPDATE to close the TOCTOU race:
+  // between the SELECT above and now, executeIssue may have registered a new
+  // process. Without this re-check, the reconciler would overwrite the freshly
+  // set sessionStatus='running' back to 'failed', causing the issue to flip
+  // between working and review while the process is actively executing.
+  const stillNeedsSessionFix = needsSessionFix.filter(id => !hasActiveProcess(id))
+  const stillNeedsStatusOnly = needsStatusOnly.filter(id => !hasActiveProcess(id))
+  const stillReconciledIssues = reconciledIssues.filter(
+    issue => stillNeedsSessionFix.includes(issue.id) || stillNeedsStatusOnly.includes(issue.id),
+  )
+
+  if (stillReconciledIssues.length === 0) return 0
+
   // Batch update in a single transaction
   const now = new Date()
   await db.transaction(async (tx) => {
-    if (needsSessionFix.length > 0) {
+    if (stillNeedsSessionFix.length > 0) {
       await tx
         .update(issuesTable)
         .set({
@@ -73,18 +86,18 @@ export async function reconcileStaleWorkingIssues(): Promise<number> {
           statusId: 'review',
           statusUpdatedAt: now,
         })
-        .where(inArray(issuesTable.id, needsSessionFix))
+        .where(inArray(issuesTable.id, stillNeedsSessionFix))
     }
-    if (needsStatusOnly.length > 0) {
+    if (stillNeedsStatusOnly.length > 0) {
       await tx
         .update(issuesTable)
         .set({ statusId: 'review', statusUpdatedAt: now })
-        .where(inArray(issuesTable.id, needsStatusOnly))
+        .where(inArray(issuesTable.id, stillNeedsStatusOnly))
     }
   })
 
   // Post-commit: invalidate caches and emit events
-  for (const issue of reconciledIssues) {
+  for (const issue of stillReconciledIssues) {
     await cacheDel(`issue:${issue.projectId}:${issue.id}`)
     emitIssueUpdated(issue.id, { statusId: 'review' })
     logger.info(
@@ -93,7 +106,7 @@ export async function reconcileStaleWorkingIssues(): Promise<number> {
     )
   }
 
-  return reconciledIssues.length
+  return stillReconciledIssues.length
 }
 
 // ---------- Active process check ----------

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import { startChangesSummaryWatcher, stopChangesSummaryWatcher } from './events/
 import { startUploadCleanup } from './jobs/upload-cleanup'
 import { startWorktreeCleanup } from './jobs/worktree-cleanup'
 import { logger } from './logger'
+import { acquirePidLock, releasePidLock } from './pid-lock'
 import { APP_DIR, ROOT_DIR } from './root'
 import { printStartupBanner } from './startup-banner'
 import { staticAssets } from './static-assets'
@@ -35,6 +36,18 @@ process.on('uncaughtException', (err, origin) => {
   logger.fatal({ err, origin }, 'uncaught_exception')
   // Give pino time to flush the log entry before exiting
   setTimeout(() => process.exit(1), 200)
+})
+
+// ---------- PID lock ----------
+// Prevent multiple BKD instances from running simultaneously against the
+// same data directory. Must run before any DB writes or Bun.serve().
+acquirePidLock()
+
+// Safety net: release the PID lock on any exit path (uncaughtException,
+// process.exit, SIGKILL is not catchable but stale-lock detection handles it).
+// `process.on('exit')` only allows synchronous work — releasePidLock is sync.
+process.on('exit', () => {
+  releasePidLock()
 })
 
 // Migrate legacy global slash commands key to per-engine format, then load cache
@@ -145,6 +158,7 @@ registerShutdownForUpgrade(async () => {
   stopDeliveryCleanup()
   await issueEngine.cancelAll()
   http.stop()
+  releasePidLock()
   logger.info('server_stopped_for_upgrade')
 })
 
@@ -157,8 +171,9 @@ let isShuttingDown = false
 
 async function shutdown(signal: string) {
   if (isShuttingDown) {
-    logger.warn({ signal }, 'server_shutdown_duplicate_signal_ignored')
-    return
+    // Second signal → force-exit immediately (e.g. double Ctrl+C)
+    logger.warn({ signal }, 'server_shutdown_forced')
+    process.exit(1)
   }
   isShuttingDown = true
 
@@ -186,6 +201,7 @@ async function shutdown(signal: string) {
   await issueEngine.cancelAll()
 
   http.stop()
+  releasePidLock()
   logger.info('server_stopped')
   process.exit(0)
 }

--- a/apps/api/src/pid-lock.ts
+++ b/apps/api/src/pid-lock.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { logger } from './logger'
 import { ROOT_DIR } from './root'
@@ -7,7 +7,24 @@ import { ROOT_DIR } from './root'
 
 const PID_FILE_NAME = 'bkd.pid'
 
+/**
+ * Derive the PID lock file path from the same source as the SQLite DB,
+ * so the lock always protects the correct database instance.
+ *
+ * Resolution order:
+ *   1. Sibling of DB_PATH (e.g. `data/db/bkd.pid` next to `data/db/bkd.db`)
+ *   2. BKD_DATA_DIR/bkd.pid
+ *   3. <ROOT_DIR>/data/bkd.pid
+ */
 function getPidFilePath(): string {
+  if (process.env.DB_PATH) {
+    const dbDir = dirname(
+      process.env.DB_PATH.startsWith('/')
+        ? process.env.DB_PATH
+        : resolve(ROOT_DIR, process.env.DB_PATH),
+    )
+    return resolve(dbDir, PID_FILE_NAME)
+  }
   const dataDir = process.env.BKD_DATA_DIR
     ? resolve(process.env.BKD_DATA_DIR)
     : resolve(ROOT_DIR, 'data')
@@ -29,68 +46,115 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+/**
+ * Atomically create a file with O_EXCL (fails if the file already exists).
+ * Returns true if the file was created, false if it already existed.
+ */
+function tryCreateExclusive(filePath: string, content: string): boolean {
+  try {
+    // O_WRONLY | O_CREAT | O_EXCL — atomic create, fails with EEXIST if file exists
+    const fd = openSync(filePath, 'wx')
+    try {
+      writeSync(fd, content, null, 'utf8')
+    } finally {
+      closeSync(fd)
+    }
+    return true
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false
+    throw err
+  }
+}
+
 // ---------- Public API ----------
 
 /**
  * Acquire a PID lock. If another BKD instance is already running,
  * log an error and exit immediately to prevent dual-instance corruption.
  *
+ * Uses O_EXCL for atomic file creation to prevent TOCTOU races where
+ * two processes both pass the existence check and write their PIDs.
+ *
  * Call this synchronously at the very start of server initialisation,
  * before Bun.serve() or any reconciliation logic.
  */
 export function acquirePidLock(): void {
   const pidFile = getPidFilePath()
-
-  if (existsSync(pidFile)) {
-    try {
-      const content = readFileSync(pidFile, 'utf8').trim()
-      const existingPid = Number.parseInt(content, 10)
-
-      if (!Number.isNaN(existingPid) && existingPid > 0 && isProcessAlive(existingPid)) {
-        // Allow takeover when this process was spawned by an upgrade restart.
-        // The parent set BKD_UPGRADE_FROM_PID to its own PID before spawning us;
-        // if the lock belongs to that parent, it is about to exit — safe to take over.
-        const upgradeFromPid = Number.parseInt(process.env.BKD_UPGRADE_FROM_PID ?? '', 10)
-        if (existingPid === upgradeFromPid) {
-          logger.info(
-            { existingPid, pidFile },
-            'pid_lock_takeover_from_upgrade_parent',
-          )
-          // Clear the env var so it doesn't leak to future child processes
-          delete process.env.BKD_UPGRADE_FROM_PID
-        } else {
-          logger.fatal(
-            { existingPid, pidFile },
-            'pid_lock_failed_another_instance_running',
-          )
-          // Hard exit — do not run any cleanup as this instance never owned resources
-          console.error(
-            `[bkd] Another instance is already running (PID ${existingPid}). `
-            + `If this is incorrect, remove the stale lock file: ${pidFile}`,
-          )
-          process.exit(1)
-        }
-      }
-
-      // PID file exists but the process is dead → stale lock
-      logger.warn(
-        { stalePid: existingPid, pidFile },
-        'pid_lock_stale_removed',
-      )
-    } catch (err) {
-      // Corrupt PID file — remove and proceed
-      logger.warn({ err, pidFile }, 'pid_lock_corrupt_removed')
-    }
-  }
-
-  // Write current PID
   const dir = dirname(pidFile)
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-  writeFileSync(pidFile, String(process.pid), 'utf8')
+  mkdirSync(dir, { recursive: true })
 
-  logger.info({ pid: process.pid, pidFile }, 'pid_lock_acquired')
+  // Fast path: atomically create the lock file. If it succeeds, we own the lock.
+  if (tryCreateExclusive(pidFile, String(process.pid))) {
+    logger.info({ pid: process.pid, pidFile }, 'pid_lock_acquired')
+    return
+  }
+
+  // Lock file already exists — check if the owning process is still alive.
+  let existingPid = Number.NaN
+  try {
+    const content = readFileSync(pidFile, 'utf8').trim()
+    existingPid = Number.parseInt(content, 10)
+  } catch (err) {
+    // Corrupt or unreadable PID file — remove and retry
+    logger.warn({ err, pidFile }, 'pid_lock_corrupt_removed')
+    try {
+      unlinkSync(pidFile)
+    } catch { /* best effort */ }
+    if (tryCreateExclusive(pidFile, String(process.pid))) {
+      logger.info({ pid: process.pid, pidFile }, 'pid_lock_acquired')
+      return
+    }
+    // Another process beat us to it
+    exitDuplicateInstance(pidFile, Number.NaN)
+  }
+
+  if (!Number.isNaN(existingPid) && existingPid > 0 && isProcessAlive(existingPid)) {
+    // Allow takeover when this process was spawned by an upgrade restart.
+    // The parent set BKD_UPGRADE_FROM_PID to its own PID before spawning us;
+    // if the lock belongs to that parent, it is about to exit — safe to take over.
+    const upgradeFromPid = Number.parseInt(process.env.BKD_UPGRADE_FROM_PID ?? '', 10)
+    if (existingPid === upgradeFromPid) {
+      logger.info(
+        { existingPid, pidFile },
+        'pid_lock_takeover_from_upgrade_parent',
+      )
+      // Clear the env var so it doesn't leak to future child processes
+      delete process.env.BKD_UPGRADE_FROM_PID
+    } else {
+      exitDuplicateInstance(pidFile, existingPid)
+    }
+  } else {
+    // PID file exists but the process is dead → stale lock
+    logger.warn(
+      { stalePid: existingPid, pidFile },
+      'pid_lock_stale_removed',
+    )
+  }
+
+  // Remove stale/takeover lock and write our PID
+  try {
+    unlinkSync(pidFile)
+  } catch { /* best effort */ }
+  if (tryCreateExclusive(pidFile, String(process.pid))) {
+    logger.info({ pid: process.pid, pidFile }, 'pid_lock_acquired')
+    return
+  }
+
+  // Extremely unlikely: another process created the file between unlink and open
+  exitDuplicateInstance(pidFile, Number.NaN)
+}
+
+function exitDuplicateInstance(pidFile: string, existingPid: number): never {
+  const pidMsg = existingPid > 0 ? ` (PID ${existingPid})` : ''
+  logger.fatal(
+    { existingPid: existingPid || undefined, pidFile },
+    'pid_lock_failed_another_instance_running',
+  )
+  console.error(
+    `[bkd] Another instance is already running${pidMsg}. `
+    + `If this is incorrect, remove the stale lock file: ${pidFile}`,
+  )
+  process.exit(1)
 }
 
 /**
@@ -102,9 +166,13 @@ export function releasePidLock(): void {
   const pidFile = getPidFilePath()
 
   try {
-    if (!existsSync(pidFile)) return
+    let content: string
+    try {
+      content = readFileSync(pidFile, 'utf8').trim()
+    } catch {
+      return // file doesn't exist or unreadable — nothing to release
+    }
 
-    const content = readFileSync(pidFile, 'utf8').trim()
     const filePid = Number.parseInt(content, 10)
 
     if (filePid !== process.pid) {

--- a/apps/api/src/pid-lock.ts
+++ b/apps/api/src/pid-lock.ts
@@ -1,0 +1,125 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { logger } from './logger'
+import { ROOT_DIR } from './root'
+
+// ---------- Constants ----------
+
+const PID_FILE_NAME = 'bkd.pid'
+
+function getPidFilePath(): string {
+  const dataDir = process.env.BKD_DATA_DIR
+    ? resolve(process.env.BKD_DATA_DIR)
+    : resolve(ROOT_DIR, 'data')
+  return resolve(dataDir, PID_FILE_NAME)
+}
+
+// ---------- Helpers ----------
+
+/**
+ * Check whether a process with the given PID is still alive.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    // signal 0 doesn't kill — it just checks existence
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ---------- Public API ----------
+
+/**
+ * Acquire a PID lock. If another BKD instance is already running,
+ * log an error and exit immediately to prevent dual-instance corruption.
+ *
+ * Call this synchronously at the very start of server initialisation,
+ * before Bun.serve() or any reconciliation logic.
+ */
+export function acquirePidLock(): void {
+  const pidFile = getPidFilePath()
+
+  if (existsSync(pidFile)) {
+    try {
+      const content = readFileSync(pidFile, 'utf8').trim()
+      const existingPid = Number.parseInt(content, 10)
+
+      if (!Number.isNaN(existingPid) && existingPid > 0 && isProcessAlive(existingPid)) {
+        // Allow takeover when this process was spawned by an upgrade restart.
+        // The parent set BKD_UPGRADE_FROM_PID to its own PID before spawning us;
+        // if the lock belongs to that parent, it is about to exit — safe to take over.
+        const upgradeFromPid = Number.parseInt(process.env.BKD_UPGRADE_FROM_PID ?? '', 10)
+        if (existingPid === upgradeFromPid) {
+          logger.info(
+            { existingPid, pidFile },
+            'pid_lock_takeover_from_upgrade_parent',
+          )
+          // Clear the env var so it doesn't leak to future child processes
+          delete process.env.BKD_UPGRADE_FROM_PID
+        } else {
+          logger.fatal(
+            { existingPid, pidFile },
+            'pid_lock_failed_another_instance_running',
+          )
+          // Hard exit — do not run any cleanup as this instance never owned resources
+          console.error(
+            `[bkd] Another instance is already running (PID ${existingPid}). `
+            + `If this is incorrect, remove the stale lock file: ${pidFile}`,
+          )
+          process.exit(1)
+        }
+      }
+
+      // PID file exists but the process is dead → stale lock
+      logger.warn(
+        { stalePid: existingPid, pidFile },
+        'pid_lock_stale_removed',
+      )
+    } catch (err) {
+      // Corrupt PID file — remove and proceed
+      logger.warn({ err, pidFile }, 'pid_lock_corrupt_removed')
+    }
+  }
+
+  // Write current PID
+  const dir = dirname(pidFile)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  writeFileSync(pidFile, String(process.pid), 'utf8')
+
+  logger.info({ pid: process.pid, pidFile }, 'pid_lock_acquired')
+}
+
+/**
+ * Release the PID lock. Only removes the file if it still contains
+ * the current process's PID (guards against a race where a new
+ * instance has already written its own PID).
+ */
+export function releasePidLock(): void {
+  const pidFile = getPidFilePath()
+
+  try {
+    if (!existsSync(pidFile)) return
+
+    const content = readFileSync(pidFile, 'utf8').trim()
+    const filePid = Number.parseInt(content, 10)
+
+    if (filePid !== process.pid) {
+      // Another instance already took over — don't delete their lock
+      logger.debug(
+        { filePid, currentPid: process.pid },
+        'pid_lock_skip_release_not_owner',
+      )
+      return
+    }
+
+    unlinkSync(pidFile)
+    logger.info({ pid: process.pid }, 'pid_lock_released')
+  } catch (err) {
+    // Best-effort removal — don't crash during shutdown
+    logger.warn({ err }, 'pid_lock_release_failed')
+  }
+}

--- a/apps/api/src/pid-lock.ts
+++ b/apps/api/src/pid-lock.ts
@@ -1,4 +1,5 @@
-import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from 'node:fs'
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync, writeSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
 import { dirname, resolve } from 'node:path'
 import { logger } from './logger'
 import { ROOT_DIR } from './root'
@@ -6,6 +7,7 @@ import { ROOT_DIR } from './root'
 // ---------- Constants ----------
 
 const PID_FILE_NAME = 'bkd.pid'
+const UPGRADE_TOKEN_FILE_NAME = 'bkd.upgrade-token'
 
 /**
  * Derive the PID lock file path from the same source as the SQLite DB,
@@ -16,19 +18,25 @@ const PID_FILE_NAME = 'bkd.pid'
  *   2. BKD_DATA_DIR/bkd.pid
  *   3. <ROOT_DIR>/data/bkd.pid
  */
-function getPidFilePath(): string {
+function getLockDir(): string {
   if (process.env.DB_PATH) {
-    const dbDir = dirname(
+    return dirname(
       process.env.DB_PATH.startsWith('/')
         ? process.env.DB_PATH
         : resolve(ROOT_DIR, process.env.DB_PATH),
     )
-    return resolve(dbDir, PID_FILE_NAME)
   }
-  const dataDir = process.env.BKD_DATA_DIR
+  return process.env.BKD_DATA_DIR
     ? resolve(process.env.BKD_DATA_DIR)
     : resolve(ROOT_DIR, 'data')
-  return resolve(dataDir, PID_FILE_NAME)
+}
+
+function getPidFilePath(): string {
+  return resolve(getLockDir(), PID_FILE_NAME)
+}
+
+function getUpgradeTokenPath(): string {
+  return resolve(getLockDir(), UPGRADE_TOKEN_FILE_NAME)
 }
 
 // ---------- Helpers ----------
@@ -66,7 +74,49 @@ function tryCreateExclusive(filePath: string, content: string): boolean {
   }
 }
 
+/**
+ * Verify upgrade token: the upgrading process writes a file containing
+ * its PID and a random nonce. The new process reads and validates both,
+ * then deletes the token file. This prevents external spoofing — unlike
+ * environment variables, the token file is protected by filesystem permissions.
+ */
+function isValidUpgradeToken(existingPid: number): boolean {
+  const tokenPath = getUpgradeTokenPath()
+  try {
+    const content = readFileSync(tokenPath, 'utf8').trim()
+    const [pidStr, nonce] = content.split(':')
+    const tokenPid = Number.parseInt(pidStr ?? '', 10)
+
+    if (tokenPid !== existingPid || !nonce || nonce.length < 16) {
+      return false
+    }
+
+    // Token is valid — consume it (one-time use)
+    try {
+      unlinkSync(tokenPath)
+    } catch { /* best effort */ }
+
+    return true
+  } catch {
+    return false
+  }
+}
+
 // ---------- Public API ----------
+
+/**
+ * Write an upgrade token file that authorises the new process to take
+ * over the PID lock from this process. Called by the upgrade system
+ * just before spawning the replacement process.
+ */
+export function writeUpgradeToken(): void {
+  const tokenPath = getUpgradeTokenPath()
+  const nonce = randomBytes(16).toString('hex')
+  const content = `${process.pid}:${nonce}`
+  mkdirSync(dirname(tokenPath), { recursive: true })
+  writeFileSync(tokenPath, content, 'utf8')
+  logger.debug({ tokenPath }, 'upgrade_token_written')
+}
 
 /**
  * Acquire a PID lock. If another BKD instance is already running,
@@ -109,17 +159,14 @@ export function acquirePidLock(): void {
   }
 
   if (!Number.isNaN(existingPid) && existingPid > 0 && isProcessAlive(existingPid)) {
-    // Allow takeover when this process was spawned by an upgrade restart.
-    // The parent set BKD_UPGRADE_FROM_PID to its own PID before spawning us;
-    // if the lock belongs to that parent, it is about to exit — safe to take over.
-    const upgradeFromPid = Number.parseInt(process.env.BKD_UPGRADE_FROM_PID ?? '', 10)
-    if (existingPid === upgradeFromPid) {
+    // Allow takeover when the upgrading process left a valid token file.
+    // The token contains the parent's PID + a random nonce, so it cannot
+    // be forged via environment variables or command-line arguments.
+    if (isValidUpgradeToken(existingPid)) {
       logger.info(
         { existingPid, pidFile },
         'pid_lock_takeover_from_upgrade_parent',
       )
-      // Clear the env var so it doesn't leak to future child processes
-      delete process.env.BKD_UPGRADE_FROM_PID
     } else {
       exitDuplicateInstance(pidFile, existingPid)
     }

--- a/apps/api/src/upgrade/apply.ts
+++ b/apps/api/src/upgrade/apply.ts
@@ -3,6 +3,7 @@ import { rename, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { runCommand, spawnNode } from '@/engines/spawn'
 import { logger } from '@/logger'
+import { writeUpgradeToken } from '@/pid-lock'
 import { isPathWithinDir, parseVersionFromFileName } from '@/upgrade/utils'
 import { APP_BASE, isPackageMode, UPDATES_DIR, VERSION_FILE } from './constants'
 import { getDownloadStatus } from './download'
@@ -130,9 +131,12 @@ export async function applyUpgradeAndRestart(): Promise<void> {
         logger.warn('upgrade_no_shutdown_fn_registered')
       }
 
+      // Write upgrade token so the new process can take over the PID lock
+      writeUpgradeToken()
+
       // Re-exec the launcher binary (process.execPath is the launcher)
       const child = spawnNode([process.execPath], {
-        env: { ...process.env, BKD_UPGRADE_FROM_PID: String(process.pid) } as Record<string, string>,
+        env: { ...process.env } as Record<string, string>,
         stdin: 'ignore',
         stdout: 'ignore',
         stderr: 'ignore',
@@ -159,9 +163,12 @@ export async function applyUpgradeAndRestart(): Promise<void> {
         logger.warn('upgrade_no_shutdown_fn_registered')
       }
 
+      // Write upgrade token so the new process can take over the PID lock
+      writeUpgradeToken()
+
       // Spawn the new binary as a detached process after port is released
       const child = spawnNode([upgradeBinary], {
-        env: { ...process.env, BKD_UPGRADE_FROM_PID: String(process.pid) } as Record<string, string>,
+        env: { ...process.env } as Record<string, string>,
         stdin: 'ignore',
         stdout: 'ignore',
         stderr: 'ignore',

--- a/apps/api/src/upgrade/apply.ts
+++ b/apps/api/src/upgrade/apply.ts
@@ -132,7 +132,7 @@ export async function applyUpgradeAndRestart(): Promise<void> {
 
       // Re-exec the launcher binary (process.execPath is the launcher)
       const child = spawnNode([process.execPath], {
-        env: { ...process.env } as Record<string, string>,
+        env: { ...process.env, BKD_UPGRADE_FROM_PID: String(process.pid) } as Record<string, string>,
         stdin: 'ignore',
         stdout: 'ignore',
         stderr: 'ignore',
@@ -161,7 +161,7 @@ export async function applyUpgradeAndRestart(): Promise<void> {
 
       // Spawn the new binary as a detached process after port is released
       const child = spawnNode([upgradeBinary], {
-        env: { ...process.env } as Record<string, string>,
+        env: { ...process.env, BKD_UPGRADE_FROM_PID: String(process.pid) } as Record<string, string>,
         stdin: 'ignore',
         stdout: 'ignore',
         stderr: 'ignore',


### PR DESCRIPTION
## Summary

- **Reconciler TOCTOU race**: Re-check `hasActiveProcess()` before UPDATE to prevent overwriting freshly-set `sessionStatus=running` back to `failed`
- **Duplicate turn settlement**: Guard `handleTurnCompleted` with `turnInFlight` flag to ignore duplicate turn-completion entries from Claude CLI
- **Stdout drain race**: Await `stdoutDone` promise in `monitorCompletion` before settling, so status doesn't move to `review` while logs are still streaming
- **PID lock file** (`data/bkd.pid`): Prevent multiple BKD instances from running against the same SQLite DB. Handles upgrade restarts via `BKD_UPGRADE_FROM_PID` env var, stale lock detection via `isProcessAlive`, and `process.on('exit')` safety net
- **Ctrl+C fix**: Second signal force-exits instead of being silently ignored

## Root Cause Analysis

Production logs for issue `he1m7ltv` showed the server was restarting repeatedly (likely from self-upgrade). Each restart ran `startupReconciliation` which marked the still-running Claude process's session as `failed` and moved the issue to `review` — even though the process was actively executing. The user saw the issue flipping between `working` and `review`, with "execution failed" messages while the session was still producing output.

## Test plan

- [x] Existing tests pass (7 pre-existing failures unrelated to this PR)
- [x] ESLint passes on all modified files
- [ ] Manual: start BKD, verify `data/bkd.pid` is created with correct PID
- [ ] Manual: try starting a second instance — should exit with error message
- [ ] Manual: Ctrl+C once → graceful shutdown; Ctrl+C twice → immediate exit
- [ ] Manual: trigger upgrade restart — new instance should take over lock