### PR TITLE
fix: improve engine availability detection and auth verification

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -26,6 +26,33 @@ const NPX_FALLBACK = 'npx -y @anthropic-ai/claude-code'
 /** Base directory for per-issue debug logs */
 const ISSUE_LOG_DIR = join(ROOT_DIR, 'data', 'logs', 'issues')
 
+/** Timeout for the lightweight auth verification probe */
+const AUTH_VERIFY_TIMEOUT_MS = 15_000
+
+/**
+ * Find the `claude` binary in well-known locations WITHOUT falling back to npx.
+ * Used by getAvailability() to determine if the engine is truly installed.
+ * Returns null if no binary is found.
+ */
+function resolveBinaryOnly(): string | null {
+  // 1. Check /work/bin first (container / custom deploy)
+  if (existsSync('/work/bin/claude')) return '/work/bin/claude'
+  // 2. Check PATH
+  const fromPath = resolveCommand('claude')
+  if (fromPath) return fromPath
+  // 3. Check HOME-relative install locations
+  const home = process.env.HOME ?? ''
+  if (home) {
+    const homeCandidates = [join(home, '.local/bin/claude'), join(home, '.bun/bin/claude')]
+    const found = homeCandidates.find(p => existsSync(p))
+    if (found) return found
+  }
+  // 4. Check absolute paths independent of HOME
+  if (existsSync('/usr/local/bin/claude')) return '/usr/local/bin/claude'
+  // No npx fallback — not installed
+  return null
+}
+
 /**
  * Find the `claude` binary, checking PATH and common install locations.
  * Falls back to npx for environments without a standalone binary.
@@ -34,33 +61,12 @@ const ISSUE_LOG_DIR = join(ROOT_DIR, 'data', 'logs', 'issues')
 let _cachedBaseCmd: string | undefined
 function resolveBaseCmd(): string {
   if (_cachedBaseCmd) return _cachedBaseCmd
-  // 1. Check /work/bin first (container / custom deploy)
-  if (existsSync('/work/bin/claude')) {
-    _cachedBaseCmd = '/work/bin/claude'
+  const binary = resolveBinaryOnly()
+  if (binary) {
+    _cachedBaseCmd = binary
     return _cachedBaseCmd
   }
-  // 2. Check PATH
-  const fromPath = resolveCommand('claude')
-  if (fromPath) {
-    _cachedBaseCmd = fromPath
-    return _cachedBaseCmd
-  }
-  // 3. Check HOME-relative install locations
-  const home = process.env.HOME ?? ''
-  if (home) {
-    const homeCandidates = [join(home, '.local/bin/claude'), join(home, '.bun/bin/claude')]
-    const found = homeCandidates.find(p => existsSync(p))
-    if (found) {
-      _cachedBaseCmd = found
-      return _cachedBaseCmd
-    }
-  }
-  // 4. Check absolute paths independent of HOME
-  if (existsSync('/usr/local/bin/claude')) {
-    _cachedBaseCmd = '/usr/local/bin/claude'
-    return _cachedBaseCmd
-  }
-  // 5. Fall back to npx
+  // Fall back to npx (for execution only, not availability detection)
   _cachedBaseCmd = NPX_FALLBACK
   return _cachedBaseCmd
 }
@@ -130,7 +136,17 @@ export class ClaudeCodeExecutor implements EngineExecutor {
 
   async getAvailability(): Promise<EngineAvailability> {
     try {
-      const resolved = await CommandBuilder.create(resolveBaseCmd())
+      // Only check real binary paths — do not fall back to npx
+      const binaryPath = resolveBinaryOnly()
+      if (!binaryPath) {
+        return {
+          engineType: 'claude-code',
+          installed: false,
+          authStatus: 'unknown',
+        }
+      }
+
+      const resolved = await CommandBuilder.create(binaryPath)
         .param('--version')
         .env('NPM_CONFIG_LOGLEVEL', 'error')
         .resolve()
@@ -158,25 +174,14 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       const versionMatch = stdout.match(/(\d+\.\d+\.\d[\w.-]*)/)
       const version = versionMatch?.[1]
 
-      // Check auth - look for ANTHROPIC_API_KEY or ~/.claude.json
-      let authStatus: EngineAvailability['authStatus'] = 'unknown'
-      if (process.env.ANTHROPIC_API_KEY) {
-        authStatus = 'authenticated'
-      } else {
-        const home = process.env.HOME ?? '/root'
-        const configFile = Bun.file(`${home}/.claude.json`)
-        if (await configFile.exists()) {
-          authStatus = 'authenticated'
-        } else {
-          authStatus = 'unauthenticated'
-        }
-      }
+      // Verify auth by running a minimal test session
+      const authStatus = await this.verifyAuth(binaryPath)
 
       return {
         engineType: 'claude-code',
         installed: true,
         version,
-        binaryPath: resolved.resolvedPath,
+        binaryPath,
         authStatus,
       }
     } catch (error) {
@@ -325,6 +330,55 @@ export class ClaudeCodeExecutor implements EngineExecutor {
   }
 
   // ---------- Private ----------
+
+  /**
+   * Verify authentication by running a minimal test session.
+   * Spawns `claude -p "hi" --max-turns 1 --output-format text` and checks
+   * if the process succeeds (authenticated) or prints a login prompt.
+   */
+  private async verifyAuth(binaryPath: string): Promise<EngineAvailability['authStatus']> {
+    try {
+      const resolved = await CommandBuilder.create(binaryPath)
+        .params(['-p', '--output-format', 'text', '--max-turns', '1', '--no-chrome'])
+        .params(['--', 'hi'])
+        .env('NPM_CONFIG_LOGLEVEL', 'error')
+        .resolve()
+
+      const proc = spawnNode([resolved.resolvedPath, ...resolved.args], {
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: safeEnv(resolved.env),
+      })
+
+      const timer = setTimeout(() => proc.kill(), AUTH_VERIFY_TIMEOUT_MS)
+
+      const [stdoutText, stderrText] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ])
+      const exitCode = await proc.exited
+      clearTimeout(timer)
+
+      // Claude prints login prompts as plain text on stdout/stderr and exits non-zero
+      const combined = `${stdoutText}\n${stderrText}`
+      if (/not logged in|please run \/login|login required/i.test(combined)) {
+        return 'unauthenticated'
+      }
+      if (/auth|unauthorized|401|forbidden|403|invalid.*key/i.test(combined)) {
+        return 'unauthenticated'
+      }
+
+      // Exit 0 with any text output → auth works
+      return exitCode === 0 ? 'authenticated' : 'unauthenticated'
+    } catch (err) {
+      logger.debug(
+        { error: err instanceof Error ? err.message : String(err) },
+        'claude_auth_verify_failed',
+      )
+      return 'unknown'
+    }
+  }
 
   /**
    * Build the common CommandBuilder shared by spawn and spawnFollowUp.

--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -554,25 +554,28 @@ export class CodexExecutor implements EngineExecutor {
       )
       session.notify('initialized', {})
 
-      const account = (await session.call('account/read', {}, 1)) as {
-        requiresOpenaiAuth?: boolean
-        account?: unknown
-      }
+      const account = (await session.call('account/read', {}, 1)) as Record<string, unknown>
 
-      if (account.requiresOpenaiAuth && !account.account) {
+      // Handle both camelCase and snake_case response shapes
+      const requiresAuth = account.requiresOpenaiAuth ?? account.requires_openai_auth
+      if (requiresAuth && !account.account) {
         return 'unauthenticated'
       }
       return 'authenticated'
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       logger.debug({ error: msg }, 'codex_auth_verify_failed')
-      // If account/read is not supported, fall back to env/config check
-      if (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY) {
-        return 'authenticated'
-      }
-      const home = process.env.HOME ?? '/root'
-      if (existsSync(`${home}/.codex/config.toml`)) {
-        return 'authenticated'
+      // Only fall back to env/config heuristics if the method is unsupported
+      // (i.e. older Codex version). For other errors (auth failure, timeout)
+      // report unknown rather than masking the real status.
+      if (/method not found|not supported|unknown method/i.test(msg)) {
+        if (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY) {
+          return 'authenticated'
+        }
+        const home = process.env.HOME ?? '/root'
+        if (existsSync(`${home}/.codex/config.toml`)) {
+          return 'authenticated'
+        }
       }
       return 'unknown'
     } finally {

--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -23,6 +23,26 @@ import { CodexProtocolHandler } from './protocol'
 const NPX_FALLBACK = ['npx', '-y', '@openai/codex']
 
 /**
+ * Find the `codex` binary in well-known locations WITHOUT falling back to npx.
+ * Used by getAvailability() to determine if the engine is truly installed.
+ * Returns null if no binary is found.
+ */
+function resolveBinaryOnly(): string | null {
+  // 1. Check /work/bin first (container / custom deploy)
+  if (existsSync('/work/bin/codex')) return '/work/bin/codex'
+  // 2. Check PATH
+  const fromPath = resolveCommand('codex')
+  if (fromPath) return fromPath
+  // 3. Check common install locations
+  const home = process.env.HOME ?? ''
+  const candidates = [
+    ...(home ? [join(home, '.local/bin/codex'), join(home, '.bun/bin/codex')] : []),
+    '/usr/local/bin/codex',
+  ]
+  return candidates.find(p => existsSync(p)) ?? null
+}
+
+/**
  * Find the `codex` binary, checking PATH and common install locations.
  * Falls back to npx for environments without a standalone binary.
  * Result is cached after first call.
@@ -30,29 +50,12 @@ const NPX_FALLBACK = ['npx', '-y', '@openai/codex']
 let _cachedBaseCmd: string[] | undefined
 function resolveBaseCmd(): string[] {
   if (_cachedBaseCmd) return _cachedBaseCmd
-  // 1. Check /work/bin first (container / custom deploy)
-  if (existsSync('/work/bin/codex')) {
-    _cachedBaseCmd = ['/work/bin/codex']
+  const binary = resolveBinaryOnly()
+  if (binary) {
+    _cachedBaseCmd = [binary]
     return _cachedBaseCmd
   }
-  // 2. Check PATH
-  const fromPath = resolveCommand('codex')
-  if (fromPath) {
-    _cachedBaseCmd = [fromPath]
-    return _cachedBaseCmd
-  }
-  // 3. Check common install locations
-  const home = process.env.HOME ?? ''
-  const candidates = [
-    ...(home ? [join(home, '.local/bin/codex'), join(home, '.bun/bin/codex')] : []),
-    '/usr/local/bin/codex',
-  ]
-  const found = candidates.find(p => existsSync(p))
-  if (found) {
-    _cachedBaseCmd = [found]
-    return _cachedBaseCmd
-  }
-  // 4. Fall back to npx
+  // Fall back to npx (for execution only, not availability detection)
   _cachedBaseCmd = NPX_FALLBACK
   return _cachedBaseCmd
 }
@@ -486,7 +489,13 @@ export class CodexExecutor implements EngineExecutor {
 
   async getAvailability(): Promise<EngineAvailability> {
     try {
-      const { code: exitCode, stdout } = await runCommand([...resolveBaseCmd(), '--version'], {
+      // Only check real binary paths — do not fall back to npx
+      const binaryPath = resolveBinaryOnly()
+      if (!binaryPath) {
+        return { engineType: 'codex', installed: false, authStatus: 'unknown' }
+      }
+
+      const { code: exitCode, stdout } = await runCommand([binaryPath, '--version'], {
         timeout: 10000,
         stderr: 'pipe',
       })
@@ -498,24 +507,14 @@ export class CodexExecutor implements EngineExecutor {
       const versionMatch = stdout.match(/(\d+\.\d+\.\d[\w.-]*)/)
       const version = versionMatch?.[1]
 
-      let authStatus: EngineAvailability['authStatus'] = 'unknown'
-      if (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY) {
-        authStatus = 'authenticated'
-      } else {
-        const home = process.env.HOME ?? '/root'
-        if (existsSync(`${home}/.codex/config.toml`)) {
-          authStatus = 'authenticated'
-        } else {
-          authStatus = 'unauthenticated'
-        }
-      }
+      // Verify auth via app-server account/read RPC
+      const authStatus = await this.verifyAuth(binaryPath)
 
-      const cmd = resolveBaseCmd()
       return {
         engineType: 'codex',
         installed: true,
         version,
-        binaryPath: cmd.join(' '),
+        binaryPath,
         authStatus,
       }
     } catch (error) {
@@ -525,6 +524,61 @@ export class CodexExecutor implements EngineExecutor {
         authStatus: 'unknown',
         error: error instanceof Error ? error.message : 'Unknown error',
       }
+    }
+  }
+
+  /**
+   * Verify authentication by starting a short-lived app-server and calling
+   * account/read. This checks if the API key / OAuth session is valid.
+   */
+  private async verifyAuth(binaryPath: string): Promise<EngineAvailability['authStatus']> {
+    const proc = spawnNode([binaryPath, 'app-server'], {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: safeEnv({ NPM_CONFIG_LOGLEVEL: 'error' }),
+      detached: false,
+    })
+
+    const killTimer = setTimeout(() => proc.kill(), JSONRPC_TIMEOUT + 5000)
+    const session = new JsonRpcSession(proc)
+
+    try {
+      await session.call(
+        'initialize',
+        {
+          clientInfo: { name: 'bkd', title: 'BKD', version: '0.1.0' },
+          capabilities: { experimental_api: true },
+        },
+        0,
+      )
+      session.notify('initialized', {})
+
+      const account = (await session.call('account/read', {}, 1)) as {
+        requiresOpenaiAuth?: boolean
+        account?: unknown
+      }
+
+      if (account.requiresOpenaiAuth && !account.account) {
+        return 'unauthenticated'
+      }
+      return 'authenticated'
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      logger.debug({ error: msg }, 'codex_auth_verify_failed')
+      // If account/read is not supported, fall back to env/config check
+      if (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY) {
+        return 'authenticated'
+      }
+      const home = process.env.HOME ?? '/root'
+      if (existsSync(`${home}/.codex/config.toml`)) {
+        return 'authenticated'
+      }
+      return 'unknown'
+    } finally {
+      session.destroy()
+      clearTimeout(killTimer)
+      proc.kill()
     }
   }
 

--- a/apps/api/src/engines/executors/gemini/executor.ts
+++ b/apps/api/src/engines/executors/gemini/executor.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { safeEnv } from '@/engines/safe-env'
-import { runCommand } from '@/engines/spawn'
+import { resolveCommand, runCommand } from '@/engines/spawn'
 import type {
   EngineAvailability,
   EngineCapability,
@@ -14,9 +15,33 @@ import type {
 } from '@/engines/types'
 
 /**
+ * Find the `gemini` binary in well-known locations WITHOUT falling back to npx.
+ * Used by getAvailability() to determine if the engine is truly installed.
+ * Returns null if no binary is found.
+ */
+function resolveBinaryOnly(): string | null {
+  // 1. Check /work/bin first (container / custom deploy)
+  if (existsSync('/work/bin/gemini')) return '/work/bin/gemini'
+  // 2. Check PATH
+  const fromPath = resolveCommand('gemini')
+  if (fromPath) return fromPath
+  // 3. Check HOME-relative install locations
+  const home = process.env.HOME ?? ''
+  if (home) {
+    const candidates = [join(home, '.local/bin/gemini'), join(home, '.bun/bin/gemini')]
+    const found = candidates.find(p => existsSync(p))
+    if (found) return found
+  }
+  // 4. Check absolute paths independent of HOME
+  if (existsSync('/usr/local/bin/gemini')) return '/usr/local/bin/gemini'
+  // No npx fallback — not installed
+  return null
+}
+
+/**
  * Gemini CLI executor — uses ACP (Agent Communication Protocol).
  *
- * Launch: `npx -y @google/gemini-cli`
+ * Launch: `gemini` (or `npx -y @google/gemini-cli` for execution fallback)
  * Communication: ACP over stdin/stdout
  *
  * TODO: Implement spawn/follow-up when Gemini CLI protocol stabilizes.
@@ -58,8 +83,14 @@ export class GeminiExecutor implements EngineExecutor {
 
   async getAvailability(): Promise<EngineAvailability> {
     try {
+      // Only check real binary paths — do not fall back to npx
+      const binaryPath = resolveBinaryOnly()
+      if (!binaryPath) {
+        return { engineType: 'gemini', installed: false, executable: false, authStatus: 'unknown' }
+      }
+
       const { code: exitCode, stdout } = await runCommand(
-        ['npx', '-y', '@google/gemini-cli', '--version'],
+        [binaryPath, '--version'],
         {
           env: safeEnv({ NPM_CONFIG_LOGLEVEL: 'error' }),
           stderr: 'pipe',
@@ -68,7 +99,7 @@ export class GeminiExecutor implements EngineExecutor {
       )
 
       if (exitCode !== 0) {
-        return { engineType: 'gemini', installed: false, authStatus: 'unknown' }
+        return { engineType: 'gemini', installed: false, executable: false, authStatus: 'unknown' }
       }
 
       const versionMatch = stdout.match(/(\d+\.\d+\.\d[\w.-]*)/)
@@ -92,7 +123,7 @@ export class GeminiExecutor implements EngineExecutor {
         installed: true,
         executable: false, // spawn not yet implemented
         version,
-        binaryPath: 'npx -y @google/gemini-cli',
+        binaryPath,
         authStatus,
       }
     } catch (error) {
@@ -108,8 +139,11 @@ export class GeminiExecutor implements EngineExecutor {
 
   async getModels(): Promise<EngineModel[]> {
     try {
+      const binaryPath = resolveBinaryOnly()
+      if (!binaryPath) return []
+
       const { code: exitCode, stdout } = await runCommand(
-        ['npx', '-y', '@google/gemini-cli', '--list-models'],
+        [binaryPath, '--list-models'],
         {
           env: safeEnv({ NPM_CONFIG_LOGLEVEL: 'error' }),
           stderr: 'pipe',


### PR DESCRIPTION
## Summary

- **npx fallback no longer counts as "installed"**: Split `resolveBinaryOnly()` from `resolveBaseCmd()` in all three executors (Claude, Codex, Gemini). `getAvailability()` now only reports `installed: true` when a real binary exists on disk — having `npx` available no longer falsely indicates the engine is installed.
- **Claude auth verification**: Spawns a minimal test session (`-p "hi" --output-format text --max-turns 1`) and detects login prompts like "Not logged in · Please run /login" from stdout/stderr. Replaces the old heuristic that only checked for `~/.claude.json` or `ANTHROPIC_API_KEY`.
- **Codex auth verification**: Starts a short-lived `app-server` and calls `account/read` via JSON-RPC to check if the API key / OAuth session is valid. Falls back to env/config check if the RPC method is unsupported.
- **Gemini**: Uses `resolveBinaryOnly()` instead of `npx -y @google/gemini-cli` for both availability detection and model listing.

## Test plan

- [x] `bun test` — 9 pass, 0 fail (api-engines.test.ts)
- [ ] Verify with Claude not logged in → should show `unauthenticated`
- [ ] Verify with Claude logged in → should show `authenticated`
- [ ] Verify with Codex installed but no API key → should show `unauthenticated`
- [ ] Verify engine not installed at all → should show `installed: false`