### PR TITLE
fix: persist terminal session across page refresh

### DIFF
--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -6,11 +6,29 @@ import { ProcessManager } from '@/engines/process-manager'
 import { spawnNodeSync } from '@/engines/spawn'
 import { logger } from '@/logger'
 
-// Server-internal secrets that must never be forwarded to terminal PTY processes
+// App-specific env vars that must not leak into terminal PTY processes.
+// HOST/PORT would override zsh's %m prompt (e.g. HOST=0.0.0.0 → "0").
 const TERMINAL_STRIP_KEYS = new Set([
+  // Server
+  'HOST',
+  'PORT',
+  'ROOT_DIR',
+  'SERVER_NAME',
+  'SERVER_URL',
+  // Security
   'API_SECRET',
-  'DB_PATH',
   'ALLOWED_ORIGIN',
+  // Database
+  'DB_PATH',
+  'BKD_DATA_DIR',
+  // Logging
+  'LOG_LEVEL',
+  'SERVICE_NAME',
+  'LOG_EXECUTOR_IO',
+  // Engine
+  'MAX_CONCURRENT_EXECUTIONS',
+  'WORKTREE_DIR',
+  // Debug
   'ENABLE_RUNTIME_ENDPOINT',
 ])
 
@@ -112,6 +130,18 @@ if (typeof expiryTimer === 'object' && 'unref' in expiryTimer) {
 
 const app = new Hono()
 
+// GET /terminal/:id — Check if a terminal session is alive
+// NOTE: /terminal/ws/:id below has a static 'ws' segment that Hono's trie router
+// matches before this :id param, so there is no conflict.
+app.get('/terminal/:id', (c) => {
+  const id = c.req.param('id')
+  const entry = terminalPM.get(id)
+  if (!entry) {
+    return c.json({ success: false, error: 'Session not found' }, 404)
+  }
+  return c.json({ success: true, data: { id } })
+})
+
 // POST /terminal — Create a new terminal session (spawn PTY)
 app.post('/terminal', (c) => {
   const id = crypto.randomUUID()
@@ -176,6 +206,8 @@ app.get(
   },
   upgradeWebSocket((c) => {
     const id = c.req.param('id')
+    // Capture the raw WS ref so onClose can detect stale sockets
+    let myWsRaw: WsLike | null = null
 
     return {
       onOpen(_evt, ws) {
@@ -191,8 +223,17 @@ app.get(
           entry.meta.graceTimer = null
         }
 
-        // Detach previous WS (if any)
-        entry.meta.wsRaw = ws.raw as WsLike
+        // Close previous WS if another client is still connected
+        if (entry.meta.wsRaw && entry.meta.wsRaw !== ws.raw) {
+          try {
+            entry.meta.wsRaw.close?.(4000, 'Replaced by new connection')
+          } catch {
+            /* already closed */
+          }
+        }
+
+        myWsRaw = ws.raw as WsLike
+        entry.meta.wsRaw = myWsRaw
 
         logger.info({ id, pid: entry.subprocess.pid }, 'terminal_ws_attached')
       },
@@ -231,6 +272,9 @@ app.get(
         const entry = terminalPM.get(id)
         if (!entry) return
 
+        // Ignore stale socket close — a new WS has already taken over
+        if (entry.meta.wsRaw !== myWsRaw) return
+
         entry.meta.wsRaw = null
         logger.info({ id }, 'terminal_ws_detached')
 
@@ -248,7 +292,21 @@ app.get(
         logger.error({ id, error: String(evt) }, 'terminal_ws_error')
         const entry = terminalPM.get(id)
         if (!entry) return
-        entry.meta.wsRaw = null
+        // Only act if this is still the active socket
+        if (entry.meta.wsRaw === myWsRaw) {
+          entry.meta.wsRaw = null
+          // Start grace timer here — onClose compares entry.meta.wsRaw (now null)
+          // against myWsRaw, sees them differ, and exits early
+          if (!entry.meta.graceTimer) {
+            entry.meta.graceTimer = setTimeout(() => {
+              entry.meta.graceTimer = null
+              if (!entry.meta.wsRaw) {
+                logger.info({ id }, 'terminal_grace_expired')
+                killSession(id)
+              }
+            }, GRACE_PERIOD_MS)
+          }
+        }
       },
     }
   }),

--- a/apps/frontend/src/components/terminal/TerminalView.tsx
+++ b/apps/frontend/src/components/terminal/TerminalView.tsx
@@ -86,6 +86,34 @@ function encodeResize(cols: number, rows: number): ArrayBuffer {
   return buf
 }
 
+// --- Session persistence ---
+
+const SESSION_STORAGE_KEY = 'bkd-terminal-session-id'
+
+function saveSessionId(id: string): void {
+  try {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, id)
+  } catch {
+    /* quota */
+  }
+}
+
+function loadSessionId(): string | null {
+  try {
+    return sessionStorage.getItem(SESSION_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function clearSessionId(): void {
+  try {
+    sessionStorage.removeItem(SESSION_STORAGE_KEY)
+  } catch {
+    /* */
+  }
+}
+
 // --- API helpers ---
 
 async function createSession(): Promise<string> {
@@ -95,7 +123,18 @@ async function createSession(): Promise<string> {
   return json.data.id as string
 }
 
+async function checkSession(id: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/terminal/${id}`)
+    const json = await res.json()
+    return json.success === true
+  } catch {
+    return false
+  }
+}
+
 function deleteSession(sessionId: string): void {
+  clearSessionId()
   void fetch(`/api/terminal/${sessionId}`, { method: 'DELETE' })
 }
 
@@ -153,6 +192,8 @@ function tryLoadWebgl(terminal: Terminal): void {
   }
 }
 
+let wsRetryCount = 0
+
 function connectWs(sessionId: string, terminal: Terminal, fitAddon: FitAddon): void {
   const state = store.getState()
   if (state.disposed) return
@@ -168,6 +209,7 @@ function connectWs(sessionId: string, terminal: Terminal, fitAddon: FitAddon): v
   store.getState().set({ ws })
 
   ws.addEventListener('open', () => {
+    wsRetryCount = 0
     fitAddon.fit()
     const { cols, rows } = terminal
     ws.send(encodeResize(cols, rows))
@@ -182,8 +224,17 @@ function connectWs(sessionId: string, terminal: Terminal, fitAddon: FitAddon): v
   ws.addEventListener('close', (evt) => {
     store.getState().set({ ws: null })
 
-    // PTY exited — session is gone, start fresh on reconnect
-    if (evt.reason === 'PTY exited') {
+    // Replaced by another tab/connection — stop reconnecting
+    if (evt.code === 4000) {
+      clearSessionId()
+      store.getState().set({ sessionId: null })
+      terminal.writeln('\r\n\x1B[90m[session taken over by another tab]\x1B[0m')
+      return
+    }
+
+    // Session is gone (PTY exited or server rejected) — start fresh
+    if (evt.reason === 'PTY exited' || evt.code === 1008) {
+      clearSessionId()
       store.getState().set({ sessionId: null })
       if (!store.getState().disposed) {
         terminal.writeln('\r\n\x1B[90m[session ended, reconnecting...]\x1B[0m')
@@ -199,6 +250,19 @@ function connectWs(sessionId: string, terminal: Terminal, fitAddon: FitAddon): v
     // WS disconnected but session may still be alive — reconnect to same session
     const currentState = store.getState()
     if (!currentState.disposed && currentState.sessionId) {
+      wsRetryCount++
+      // Too many retries — session is likely dead, start fresh
+      if (wsRetryCount >= 3) {
+        wsRetryCount = 0
+        clearSessionId()
+        store.getState().set({ sessionId: null })
+        const timer = setTimeout(() => {
+          store.getState().set({ reconnectTimer: null })
+          void initConnection(terminal, fitAddon)
+        }, 1500)
+        store.getState().set({ reconnectTimer: timer })
+        return
+      }
       const timer = setTimeout(() => {
         store.getState().set({ reconnectTimer: null })
         const s = store.getState()
@@ -236,8 +300,16 @@ async function initConnection(terminal: Terminal, fitAddon: FitAddon): Promise<v
 
   const connectingPromise = (async () => {
     try {
-      // Create session via REST (works through Vite proxy)
-      const sessionId = await createSession()
+      // Try to reconnect to a persisted session first
+      const savedId = loadSessionId()
+      let sessionId: string
+      if (savedId && await checkSession(savedId)) {
+        sessionId = savedId
+        terminal.writeln('\r\n\x1B[90m[reconnected to existing session]\x1B[0m')
+      } else {
+        sessionId = await createSession()
+      }
+      saveSessionId(sessionId)
       store.getState().set({ sessionId })
 
       // Connect WS for bidirectional I/O
@@ -345,6 +417,7 @@ export function TerminalView({ className }: { className?: string }) {
 
 /** Explicitly kill the terminal session and clean up all resources */
 export function disposeTerminal(): void {
+  wsRetryCount = 0
   const state = store.getState()
   store.getState().set({ disposed: true, connecting: null })
   if (state.reconnectTimer) {


### PR DESCRIPTION
## Summary
- **Terminal session survives page refresh**: session ID is persisted to `sessionStorage`. On reload, the client checks if the session is still alive via `GET /terminal/:id` and reconnects the WebSocket instead of spawning a new PTY.
- **Fix hostname showing "0" in terminal prompt**: strip all app-specific env vars (`HOST`, `PORT`, `ROOT_DIR`, `DB_PATH`, etc.) from the PTY environment. Previously `HOST=0.0.0.0` leaked into zsh, causing `%m` prompt to display "0" instead of the real hostname.
- **New endpoint `GET /terminal/:id`**: returns 200 if the session is alive, 404 otherwise. Used by the frontend to validate saved sessions before reconnecting.

## Test plan
- [ ] Open terminal, note the session works normally
- [ ] Refresh the page — terminal should reconnect to the same session (shows `[reconnected to existing session]`)
- [ ] Verify terminal prompt shows correct hostname (e.g. `station`) instead of `0`
- [ ] Manually close terminal (delete button) — refreshing should create a new session
- [ ] Wait >60s after closing the tab, then reopen — should create a new session (grace period expired)