### PR TITLE
fix: correct changes-summary display accuracy in ChatInput

### DIFF
--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -91,7 +91,7 @@ async function computeAndEmit(issueId: string): Promise<void> {
     // Count changed files (working tree + staged)
     const statusLines: { path: string, isUntracked: boolean }[] = []
 
-    const { code: statusCode, stdout: statusOut } = await runGit(['status', '--porcelain=v1'], root)
+    const { code: statusCode, stdout: statusOut } = await runGit(['status', '--porcelain=v1', '-uall'], root)
     if (statusCode === 0) {
       for (const raw of statusOut.split('\n')) {
         const line = raw.trimEnd()

--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -93,23 +93,16 @@ async function computeAndEmit(issueId: string): Promise<void> {
     let deletions = 0
 
     if (fileCount > 0) {
-      // Unstaged changes (tracked files only)
-      const unstaged = await runGit(['diff', '--numstat'], root)
-      if (unstaged.code === 0) {
-        const stats = parseNumstat(unstaged.stdout)
+      // Single diff against HEAD covers both staged and unstaged changes,
+      // avoiding double-counting partially staged hunks and handling renames correctly
+      const headDiff = await runGit(['diff', 'HEAD', '-M', '--numstat'], root)
+      if (headDiff.code === 0) {
+        const stats = parseNumstat(headDiff.stdout)
         additions += stats.additions
         deletions += stats.deletions
       }
 
-      // Staged changes
-      const staged = await runGit(['diff', '--cached', '--numstat'], root)
-      if (staged.code === 0) {
-        const stats = parseNumstat(staged.stdout)
-        additions += stats.additions
-        deletions += stats.deletions
-      }
-
-      // Untracked files — count lines manually
+      // Untracked files — count lines manually (git diff HEAD ignores them)
       for (const { path, isUntracked } of statusLines) {
         if (!isUntracked) continue
         if (!isPathInsideRoot(root, path)) continue

--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -1,6 +1,7 @@
 import { stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { runCommand } from '@/engines/spawn'
+import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
 import { eq } from 'drizzle-orm'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
@@ -16,11 +17,45 @@ async function runGit(args: string[], cwd: string): Promise<{ code: number, stdo
   return runCommand(['git', ...args], { cwd, timeout: 10_000 })
 }
 
+function parseNumstat(stdout: string): { additions: number, deletions: number } {
+  let additions = 0
+  let deletions = 0
+  for (const line of stdout.split('\n').filter(Boolean)) {
+    const [a, d] = line.split('\t')
+    const add = Number(a)
+    const del = Number(d)
+    if (!Number.isNaN(add)) additions += add
+    if (!Number.isNaN(del)) deletions += del
+  }
+  return { additions, deletions }
+}
+
+/**
+ * Resolve the correct working directory for an issue, respecting worktrees.
+ */
+async function resolveIssueDir(
+  projectId: string,
+  issueId: string,
+  useWorktree: boolean,
+  projectRoot: string,
+): Promise<string> {
+  if (!useWorktree) return projectRoot
+  const wtPath = resolveWorktreePath(projectId, issueId)
+  try {
+    const s = await stat(wtPath)
+    if (s.isDirectory()) return wtPath
+  } catch {
+    // worktree dir doesn't exist — fall back
+  }
+  return projectRoot
+}
+
 async function computeAndEmit(issueId: string): Promise<void> {
   try {
     const [issue] = await db
       .select({
         projectId: issuesTable.projectId,
+        useWorktree: issuesTable.useWorktree,
       })
       .from(issuesTable)
       .where(eq(issuesTable.id, issueId))
@@ -30,13 +65,16 @@ async function computeAndEmit(issueId: string): Promise<void> {
     const project = await findProject(issue.projectId)
     if (!project) return
 
-    const root = project.directory ? resolve(project.directory) : process.cwd()
+    const projectRoot = project.directory ? resolve(project.directory) : process.cwd()
     try {
-      const s = await stat(root)
+      const s = await stat(projectRoot)
       if (!s.isDirectory()) return
     } catch {
       return
     }
+
+    // Resolve worktree path if applicable
+    const root = await resolveIssueDir(issue.projectId, issueId, issue.useWorktree, projectRoot)
 
     // Check git repo
     const gitCheck = await runGit(['rev-parse', '--is-inside-work-tree'], root)
@@ -50,33 +88,58 @@ async function computeAndEmit(issueId: string): Promise<void> {
       return
     }
 
-    // Count changed files (working tree only)
-    let filePaths: string[] = []
+    // Count changed files (working tree + staged)
+    const statusLines: { path: string, isUntracked: boolean }[] = []
 
     const { code: statusCode, stdout: statusOut } = await runGit(['status', '--porcelain=v1'], root)
     if (statusCode === 0) {
-      const lines = statusOut
-        .split('\n')
-        .map(l => l.trimEnd())
-        .filter(Boolean)
-      filePaths = lines.map(line => line.slice(3).trim().split(' -> ').at(-1)?.trim() ?? '')
+      for (const raw of statusOut.split('\n')) {
+        const line = raw.trimEnd()
+        if (!line || line.length < 3) continue
+        const xy = line.slice(0, 2)
+        const path = line.slice(3).trim().split(' -> ').at(-1)?.trim() ?? ''
+        if (path) {
+          statusLines.push({ path, isUntracked: xy === '??' })
+        }
+      }
     }
 
-    const fileCount = filePaths.length
+    const fileCount = statusLines.length
 
-    // Additions/deletions via numstat
+    // Additions/deletions: combine unstaged + staged numstat, plus count
+    // lines in untracked files (git diff ignores them entirely)
     let additions = 0
     let deletions = 0
 
     if (fileCount > 0) {
-      const { code, stdout } = await runGit(['diff', '--numstat'], root)
-      if (code === 0) {
-        for (const line of stdout.split('\n').filter(Boolean)) {
-          const [a, d] = line.split('\t')
-          const add = Number(a)
-          const del = Number(d)
-          if (!Number.isNaN(add)) additions += add
-          if (!Number.isNaN(del)) deletions += del
+      // Unstaged changes (tracked files only)
+      const unstaged = await runGit(['diff', '--numstat'], root)
+      if (unstaged.code === 0) {
+        const stats = parseNumstat(unstaged.stdout)
+        additions += stats.additions
+        deletions += stats.deletions
+      }
+
+      // Staged changes
+      const staged = await runGit(['diff', '--cached', '--numstat'], root)
+      if (staged.code === 0) {
+        const stats = parseNumstat(staged.stdout)
+        additions += stats.additions
+        deletions += stats.deletions
+      }
+
+      // Untracked files — count lines manually
+      for (const { path, isUntracked } of statusLines) {
+        if (!isUntracked) continue
+        try {
+          const content = await Bun.file(resolve(root, path)).text()
+          if (content) {
+            const normalized = content.replace(/\r\n/g, '\n')
+            const trimmed = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized
+            additions += trimmed ? trimmed.split('\n').length : 0
+          }
+        } catch {
+          // skip unreadable files
         }
       }
     }

--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -102,12 +102,19 @@ async function computeAndEmit(issueId: string): Promise<void> {
         deletions += stats.deletions
       }
 
-      // Untracked files — count lines manually (git diff HEAD ignores them)
+      // Untracked files — count lines manually (git diff HEAD ignores them).
+      // `-uall` ensures individual files are listed, but guard against
+      // directory entries and binary/unreadable files defensively.
       for (const { path, isUntracked } of statusLines) {
         if (!isUntracked) continue
         if (!isPathInsideRoot(root, path)) continue
         try {
-          const content = await Bun.file(resolve(root, path)).text()
+          const fullPath = resolve(root, path)
+          const s = await stat(fullPath)
+          if (!s.isFile()) continue
+          // Skip large files (>1 MB) — likely binary or generated
+          if (s.size > 1_048_576) continue
+          const content = await Bun.file(fullPath).text()
           additions += countTextLines(content)
         } catch {
           // skip unreadable files

--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -1,13 +1,13 @@
 import { stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { runCommand } from '@/engines/spawn'
-import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
 import { eq } from 'drizzle-orm'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
 import { appEvents } from '@/events'
 import { logger } from '@/logger'
+import { countTextLines, isPathInsideRoot, resolveIssueDir } from '@/utils/changes'
 
 export type { ChangesSummary } from '@bkd/shared'
 
@@ -17,6 +17,7 @@ async function runGit(args: string[], cwd: string): Promise<{ code: number, stdo
   return runCommand(['git', ...args], { cwd, timeout: 10_000 })
 }
 
+/** Parse `git diff --numstat` output. Binary files emit `-\t-` which NaN-guards skip. */
 function parseNumstat(stdout: string): { additions: number, deletions: number } {
   let additions = 0
   let deletions = 0
@@ -28,26 +29,6 @@ function parseNumstat(stdout: string): { additions: number, deletions: number } 
     if (!Number.isNaN(del)) deletions += del
   }
   return { additions, deletions }
-}
-
-/**
- * Resolve the correct working directory for an issue, respecting worktrees.
- */
-async function resolveIssueDir(
-  projectId: string,
-  issueId: string,
-  useWorktree: boolean,
-  projectRoot: string,
-): Promise<string> {
-  if (!useWorktree) return projectRoot
-  const wtPath = resolveWorktreePath(projectId, issueId)
-  try {
-    const s = await stat(wtPath)
-    if (s.isDirectory()) return wtPath
-  } catch {
-    // worktree dir doesn't exist — fall back
-  }
-  return projectRoot
 }
 
 async function computeAndEmit(issueId: string): Promise<void> {
@@ -131,13 +112,10 @@ async function computeAndEmit(issueId: string): Promise<void> {
       // Untracked files — count lines manually
       for (const { path, isUntracked } of statusLines) {
         if (!isUntracked) continue
+        if (!isPathInsideRoot(root, path)) continue
         try {
           const content = await Bun.file(resolve(root, path)).text()
-          if (content) {
-            const normalized = content.replace(/\r\n/g, '\n')
-            const trimmed = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized
-            additions += trimmed ? trimmed.split('\n').length : 0
-          }
+          additions += countTextLines(content)
         } catch {
           // skip unreadable files
         }

--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -112,8 +112,6 @@ async function computeAndEmit(issueId: string): Promise<void> {
           const fullPath = resolve(root, path)
           const s = await stat(fullPath)
           if (!s.isFile()) continue
-          // Skip large files (>1 MB) — likely binary or generated
-          if (s.size > 1_048_576) continue
           const content = await Bun.file(fullPath).text()
           additions += countTextLines(content)
         } catch {

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -123,26 +123,33 @@ async function summarizeFileLines(
     }
   }
 
-  try {
-    const { code, stdout } = await runGit(
-      ['diff', '--numstat', '--no-color', '--no-ext-diff', '--', file.path],
-      cwd,
-    )
-    if (code !== 0) return { additions: 0, deletions: 0 }
+  // Combine unstaged + staged stats for this file
+  let additions = 0
+  let deletions = 0
 
-    const firstLine = stdout
-      .split('\n')
-      .map(line => line.trim())
-      .find(Boolean)
-    if (!firstLine) return { additions: 0, deletions: 0 }
+  for (const extraArgs of [[], ['--cached']]) {
+    try {
+      const { code, stdout } = await runGit(
+        ['diff', ...extraArgs, '--numstat', '--no-color', '--no-ext-diff', '--', file.path],
+        cwd,
+      )
+      if (code !== 0) continue
 
-    const [addRaw, delRaw] = firstLine.split('\t')
-    const additions = Number.isNaN(Number(addRaw)) ? 0 : Number(addRaw)
-    const deletions = Number.isNaN(Number(delRaw)) ? 0 : Number(delRaw)
-    return { additions, deletions }
-  } catch {
-    return { additions: 0, deletions: 0 }
+      const firstLine = stdout
+        .split('\n')
+        .map(line => line.trim())
+        .find(Boolean)
+      if (!firstLine) continue
+
+      const [addRaw, delRaw] = firstLine.split('\t')
+      if (!Number.isNaN(Number(addRaw))) additions += Number(addRaw)
+      if (!Number.isNaN(Number(delRaw))) deletions += Number(delRaw)
+    } catch {
+      // continue to next variant
+    }
   }
+
+  return { additions, deletions }
 }
 
 // ---------- Routes ----------

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -1,9 +1,9 @@
 import { stat } from 'node:fs/promises'
-import { resolve, sep } from 'node:path'
+import { resolve } from 'node:path'
 import { runCommand } from '@/engines/spawn'
 import { Hono } from 'hono'
 import { findProject } from '@/db/helpers'
-import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
+import { countTextLines, isPathInsideRoot, resolveIssueDir } from '@/utils/changes'
 import { isGitRepo } from '@/utils/git'
 import { getProjectOwnedIssue } from './_shared'
 
@@ -24,47 +24,17 @@ interface GitChangedFile {
 
 // ---------- Git helpers ----------
 
-function isPathInsideRoot(root: string, path: string): boolean {
-  const abs = resolve(root, path)
-  const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`
-  return abs === root || abs.startsWith(rootPrefix)
-}
-
-function countTextLines(content: string): number {
-  if (!content) return 0
-  const normalized = content.replace(/\r\n/g, '\n')
-  const trimmed = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized
-  return trimmed ? trimmed.split('\n').length : 0
-}
-
 async function resolveProjectDir(projectId: string): Promise<string | null> {
   const project = await findProject(projectId)
   if (!project?.directory) return null
   const root = resolve(project.directory)
-  const s = await stat(root)
-  if (!s.isDirectory()) throw new Error(`Project directory is not a directory: ${root}`)
-  return root
-}
-
-/**
- * If the issue has a worktree and its directory exists, use it.
- * Otherwise fall back to the project root.
- */
-async function resolveChangesDir(
-  projectId: string,
-  issueId: string,
-  useWorktree: boolean,
-  projectRoot: string,
-): Promise<string> {
-  if (!useWorktree) return projectRoot
-  const wtPath = resolveWorktreePath(projectId, issueId)
   try {
-    const s = await stat(wtPath)
-    if (s.isDirectory()) return wtPath
+    const s = await stat(root)
+    if (!s.isDirectory()) return null
   } catch {
-    // worktree dir doesn't exist — fall back
+    return null
   }
-  return projectRoot
+  return root
 }
 
 async function runGit(
@@ -170,7 +140,7 @@ changes.get('/:id/changes', async (c) => {
   if (!projectRoot) {
     return c.json({ success: false, error: 'Project directory is not configured' }, 400)
   }
-  const root = await resolveChangesDir(project.id, issueId, issue.useWorktree, projectRoot)
+  const root = await resolveIssueDir(project.id, issueId, issue.useWorktree, projectRoot)
   const gitRepo = await isGitRepo(root)
   if (!gitRepo) {
     return c.json({
@@ -220,7 +190,7 @@ changes.get('/:id/changes/file', async (c) => {
   if (!projectRoot) {
     return c.json({ success: false, error: 'Project directory is not configured' }, 400)
   }
-  const root = await resolveChangesDir(project.id, issueId, issue.useWorktree, projectRoot)
+  const root = await resolveIssueDir(project.id, issueId, issue.useWorktree, projectRoot)
 
   // SEC-019: Validate path is inside working directory on ALL code paths
   if (!isPathInsideRoot(root, path)) {
@@ -262,8 +232,13 @@ changes.get('/:id/changes/file', async (c) => {
     oldText = ''
     newText = content
   } else {
-    const { stdout } = await runGit(['diff', '--no-color', '--no-ext-diff', '--', path], root)
-    patch = stdout
+    // Try unstaged diff first; fall back to staged diff if empty (fully staged files)
+    const unstaged = await runGit(['diff', '--no-color', '--no-ext-diff', '--', path], root)
+    patch = unstaged.stdout
+    if (!patch.trim()) {
+      const staged = await runGit(['diff', '--cached', '--no-color', '--no-ext-diff', '--', path], root)
+      patch = staged.stdout
+    }
 
     const oldPath = file.previousPath ?? path
     // SEC-019: Validate previousPath too

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -93,33 +93,30 @@ async function summarizeFileLines(
     }
   }
 
-  // Combine unstaged + staged stats for this file
-  let additions = 0
-  let deletions = 0
-
-  for (const extraArgs of [[], ['--cached']]) {
-    try {
-      const { code, stdout } = await runGit(
-        ['diff', ...extraArgs, '--numstat', '--no-color', '--no-ext-diff', '--', file.path],
-        cwd,
-      )
-      if (code !== 0) continue
-
+  // Single diff against HEAD: covers both staged and unstaged changes,
+  // avoids double-counting partially staged hunks, handles renames with -M
+  try {
+    const { code, stdout } = await runGit(
+      ['diff', 'HEAD', '-M', '--numstat', '--no-color', '--no-ext-diff', '--', file.path],
+      cwd,
+    )
+    if (code === 0) {
       const firstLine = stdout
         .split('\n')
         .map(line => line.trim())
         .find(Boolean)
-      if (!firstLine) continue
-
-      const [addRaw, delRaw] = firstLine.split('\t')
-      if (!Number.isNaN(Number(addRaw))) additions += Number(addRaw)
-      if (!Number.isNaN(Number(delRaw))) deletions += Number(delRaw)
-    } catch {
-      // continue to next variant
+      if (firstLine) {
+        const [addRaw, delRaw] = firstLine.split('\t')
+        const additions = Number.isNaN(Number(addRaw)) ? 0 : Number(addRaw)
+        const deletions = Number.isNaN(Number(delRaw)) ? 0 : Number(delRaw)
+        return { additions, deletions }
+      }
     }
+  } catch {
+    // fall through
   }
 
-  return { additions, deletions }
+  return { additions: 0, deletions: 0 }
 }
 
 // ---------- Routes ----------

--- a/apps/api/src/utils/changes.ts
+++ b/apps/api/src/utils/changes.ts
@@ -1,0 +1,44 @@
+import { stat } from 'node:fs/promises'
+import { resolve, sep } from 'node:path'
+import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
+
+/**
+ * Returns true when `path` (relative to `root`) resolves inside the `root` directory.
+ * Prevents path-traversal reads outside the git working tree.
+ */
+export function isPathInsideRoot(root: string, path: string): boolean {
+  const abs = resolve(root, path)
+  const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`
+  return abs === root || abs.startsWith(rootPrefix)
+}
+
+/**
+ * Count non-empty lines in a text string, normalising CRLF.
+ */
+export function countTextLines(content: string): number {
+  if (!content) return 0
+  const normalized = content.replace(/\r\n/g, '\n')
+  const trimmed = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized
+  return trimmed ? trimmed.split('\n').length : 0
+}
+
+/**
+ * Resolve the correct working directory for an issue, respecting worktrees.
+ * Falls back to `projectRoot` when the worktree directory doesn't exist.
+ */
+export async function resolveIssueDir(
+  projectId: string,
+  issueId: string,
+  useWorktree: boolean,
+  projectRoot: string,
+): Promise<string> {
+  if (!useWorktree) return projectRoot
+  const wtPath = resolveWorktreePath(projectId, issueId)
+  try {
+    const s = await stat(wtPath)
+    if (s.isDirectory()) return wtPath
+  } catch {
+    // worktree dir doesn't exist — fall back
+  }
+  return projectRoot
+}

--- a/apps/api/test/changes-utils.test.ts
+++ b/apps/api/test/changes-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import { countTextLines, isPathInsideRoot } from '@/utils/changes'
+
+describe('isPathInsideRoot', () => {
+  test('allows simple relative paths', () => {
+    expect(isPathInsideRoot('/repo', 'src/file.ts')).toBe(true)
+  })
+
+  test('allows nested paths', () => {
+    expect(isPathInsideRoot('/repo', 'a/b/c/d.txt')).toBe(true)
+  })
+
+  test('rejects parent traversal', () => {
+    expect(isPathInsideRoot('/repo', '../etc/passwd')).toBe(false)
+  })
+
+  test('rejects traversal via intermediate ..', () => {
+    expect(isPathInsideRoot('/repo', 'src/../../etc/passwd')).toBe(false)
+  })
+
+  test('rejects absolute path outside root', () => {
+    expect(isPathInsideRoot('/repo', '/etc/passwd')).toBe(false)
+  })
+
+  test('allows root itself', () => {
+    expect(isPathInsideRoot('/repo', '.')).toBe(true)
+  })
+
+  test('handles root with trailing slash', () => {
+    expect(isPathInsideRoot('/repo/', 'file.ts')).toBe(true)
+    expect(isPathInsideRoot('/repo/', '../x')).toBe(false)
+  })
+})
+
+describe('countTextLines', () => {
+  test('counts simple lines', () => {
+    expect(countTextLines('a\nb\nc')).toBe(3)
+  })
+
+  test('handles trailing newline', () => {
+    expect(countTextLines('a\nb\nc\n')).toBe(3)
+  })
+
+  test('handles CRLF', () => {
+    expect(countTextLines('a\r\nb\r\nc')).toBe(3)
+  })
+
+  test('returns 0 for empty string', () => {
+    expect(countTextLines('')).toBe(0)
+  })
+
+  test('single line no newline', () => {
+    expect(countTextLines('hello')).toBe(1)
+  })
+
+  test('single line with newline', () => {
+    expect(countTextLines('hello\n')).toBe(1)
+  })
+})

--- a/apps/frontend/src/hooks/use-changes-summary.ts
+++ b/apps/frontend/src/hooks/use-changes-summary.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ChangesSummaryData } from '@/lib/event-bus'
 import { eventBus } from '@/lib/event-bus'
 import { kanbanApi } from '@/lib/kanban-api'
@@ -9,21 +9,34 @@ import { queryKeys } from './use-kanban'
  * Returns `{ fileCount, additions, deletions }` for an issue's git changes.
  *
  * Two data sources, layered:
- * 1. Initial fetch via REST `/changes` endpoint (React Query, staleTime 30s)
- * 2. SSE `changes-summary` events override the REST data in real-time
+ * 1. REST `/changes` endpoint (React Query) — authoritative, full detail
+ * 2. SSE `changes-summary` events — used as an optimistic preview only until
+ *    the REST query re-fetches in response to the invalidation
+ *
+ * SSE data is cleared once the REST query completes its re-fetch, so REST
+ * always wins after the round-trip.
  */
 export function useChangesSummary(projectId: string | undefined, issueId: string | undefined) {
   const queryClient = useQueryClient()
 
   // Initial fetch from REST endpoint — derive summary from full response
-  const { data: restData } = useQuery({
+  const { data: restData, dataUpdatedAt } = useQuery({
     queryKey: queryKeys.issueChanges(projectId ?? '', issueId ?? ''),
     queryFn: () => kanbanApi.getIssueChanges(projectId!, issueId!),
     enabled: !!projectId && !!issueId,
   })
 
-  // SSE overlay — real-time updates override REST data
+  // SSE overlay — optimistic preview until REST re-fetches
   const [sseSummary, setSseSummary] = useState<ChangesSummaryData | null>(null)
+  // Track when the SSE event arrived so we can clear it once REST catches up
+  const sseReceivedAt = useRef<number>(0)
+
+  // Clear SSE overlay once REST data has been updated after the SSE event
+  useEffect(() => {
+    if (sseSummary && dataUpdatedAt > sseReceivedAt.current) {
+      setSseSummary(null)
+    }
+  }, [sseSummary, dataUpdatedAt])
 
   useEffect(() => {
     if (!issueId) {
@@ -36,8 +49,9 @@ export function useChangesSummary(projectId: string | undefined, issueId: string
 
     const unsub = eventBus.onChangesSummary((data) => {
       if (data.issueId === issueId) {
+        sseReceivedAt.current = Date.now()
         setSseSummary(data)
-        // Also invalidate the REST query so DiffPanel picks up new data
+        // Invalidate REST query so it re-fetches the authoritative data
         if (projectId) {
           queryClient.invalidateQueries({
             queryKey: queryKeys.issueChanges(projectId, issueId),
@@ -50,18 +64,17 @@ export function useChangesSummary(projectId: string | undefined, issueId: string
   }, [issueId, projectId, queryClient])
 
   // Derive summary from REST response
-  const restSummary = restData ?
-      {
+  const restSummary = restData
+    ? {
         issueId: issueId ?? '',
         fileCount: restData.files.length,
         additions: restData.additions,
         deletions: restData.deletions,
         root: restData.root,
-      } :
-    null
+      }
+    : null
 
-  // SSE data takes priority, but preserve REST root as fallback
-  // (SSE payloads don't carry root, so worktree paths would be lost)
+  // SSE data is used as optimistic preview; preserve REST root
   if (sseSummary) {
     return {
       ...sseSummary,


### PR DESCRIPTION
## Summary

- **Worktree support in SSE watcher**: `computeAndEmit()` now resolves worktree paths via `resolveWorktreePath()`, matching the REST endpoint behavior. Previously always used `project.directory`, showing wrong data for worktree issues.
- **Complete additions/deletions counting**: Now combines `git diff --numstat` (unstaged) + `git diff --cached --numstat` (staged) + manual line counting for untracked files. Previously only ran unstaged diff, causing 0 additions/deletions when files were staged or untracked.
- **SSE as optimistic preview**: SSE data auto-clears once REST re-fetches (`dataUpdatedAt > sseReceivedAt`), so authoritative REST data always wins. Previously SSE permanently overrode REST data until the user navigated away.

## Test plan

- [ ] Execute an issue in a worktree project — verify ChatInput shows correct file count and +/- stats
- [ ] Stage some changes (`git add`) before session ends — verify additions/deletions include staged lines
- [ ] Create new untracked files — verify their line counts appear in additions
- [ ] After session completes, manually edit a file — verify ChatInput updates on next REST fetch instead of showing stale SSE snapshot