### PR TITLE
fix: prevent premature review transition during active engine turns

### DIFF
--- a/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
+++ b/apps/api/src/engines/issue/lifecycle/completion-monitor.ts
@@ -12,6 +12,7 @@ import type { EngineType, ProcessStatus } from '@/engines/types'
 import { logger } from '@/logger'
 import { settleIssue } from './settle'
 import { spawnFollowUpProcess, spawnRetry } from './spawn'
+import { flushSettleTimer } from './turn-completion'
 
 // ---------- Helpers ----------
 
@@ -94,7 +95,11 @@ export function monitorCompletion(
 
       // If the issue was already settled by handleTurnCompleted (conversational
       // engines where the process stays alive between turns), just clean up.
+      // If a delayed settle timer is still pending, flush it now — the process
+      // has exited so there's no reason to wait for the grace period.
       if (managed.turnSettled) {
+        flushSettleTimer(ctx, managed)
+
         const finalState = (managed.logicalFailure ? 'failed' : 'completed') as ProcessStatus
         if (finalState === 'completed') dispatch(managed, { type: 'MARK_COMPLETED' })
         else dispatch(managed, { type: 'MARK_FAILED' })

--- a/apps/api/src/engines/issue/lifecycle/index.ts
+++ b/apps/api/src/engines/issue/lifecycle/index.ts
@@ -1,4 +1,4 @@
 export { monitorCompletion } from './completion-monitor'
 export { settleIssue } from './settle'
 export { spawnFollowUpProcess, spawnFresh, spawnRetry, spawnWithSessionFallback } from './spawn'
-export { flushQueuedInputs, handleTurnCompleted } from './turn-completion'
+export { flushQueuedInputs, flushSettleTimer, handleTurnCompleted } from './turn-completion'

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -129,8 +129,10 @@ export function handleTurnCompleted(
         // follow-up within SETTLE_GRACE_MS, the START_TURN dispatch clears
         // this timer and the issue stays in 'working'.
         if (managed.settleTimer) clearTimeout(managed.settleTimer)
+        managed.settleTimerStatus = finalStatus
         managed.settleTimer = setTimeout(() => {
           managed.settleTimer = undefined
+          managed.settleTimerStatus = undefined
           void settleAfterGrace(ctx, issueId, executionId, managed, finalStatus)
         }, SETTLE_GRACE_MS)
       }
@@ -139,6 +141,7 @@ export function handleTurnCompleted(
       if (managed.settleTimer) {
         clearTimeout(managed.settleTimer)
         managed.settleTimer = undefined
+        managed.settleTimerStatus = undefined
       }
       logger.error({ issueId, executionId, error }, 'issue_turn_settle_failed')
       // Safety net: ensure frontend is always notified even if settlement
@@ -242,8 +245,10 @@ export function flushSettleTimer(
 ): void {
   if (!managed.settleTimer) return
   clearTimeout(managed.settleTimer)
+  const finalStatus = managed.settleTimerStatus ?? (managed.logicalFailure ? 'failed' : 'completed')
   managed.settleTimer = undefined
-  void settleAfterGrace(ctx, managed.issueId, managed.executionId, managed, managed.logicalFailure ? 'failed' : 'completed')
+  managed.settleTimerStatus = undefined
+  void settleAfterGrace(ctx, managed.issueId, managed.executionId, managed, finalStatus)
 }
 
 export async function flushQueuedInputs(

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -9,6 +9,11 @@ import type { ProcessStatus } from '@/engines/types'
 import { emitIssueLogRemoved } from '@/events/issue-events'
 import { logger } from '@/logger'
 
+// Grace period before moving a conversational issue to 'review' after a turn
+// completes. If the user sends a follow-up within this window, the
+// START_TURN dispatch clears the settle timer and the issue stays in 'working'.
+const SETTLE_GRACE_MS = 3_000
+
 // ---------- Turn completion ----------
 
 export function handleTurnCompleted(
@@ -36,8 +41,7 @@ export function handleTurnCompleted(
 
   // No queued inputs — the AI turn is done and the process is idle.
   // For conversational engines the subprocess stays alive, so monitorCompletion
-  // (which awaits subprocess.exited) will not fire yet. Settle the issue now:
-  // update DB session status and auto-move to review.
+  // (which awaits subprocess.exited) will not fire yet.
   //
   // IMPORTANT: Do NOT change managed.state here. The subprocess is still alive
   // and can receive follow-up input. Keeping state as 'running' ensures
@@ -50,6 +54,10 @@ export function handleTurnCompleted(
   const finalStatus = managed.logicalFailure ? 'failed' : 'completed'
   emitStateChange(issueId, executionId, finalStatus as ProcessStatus)
 
+  // Phase 1: Immediately update sessionStatus + handle session errors + pending
+  // DB messages. The statusId change (working → review) and the frontend
+  // settlement event are deferred to Phase 2 so that follow-ups sent within
+  // SETTLE_GRACE_MS keep the issue in 'working'.
   void (async () => {
     try {
       // Detect session ID error: the CLI couldn't find the session
@@ -110,28 +118,28 @@ export function handleTurnCompleted(
         }
       }
 
-      // Guard: if a follow-up reactivated the issue while this async block
-      // was running, the DB sessionStatus will no longer match finalStatus.
-      // Emitting a stale settled event would cause the frontend to block
-      // live log events for the new active execution.
-      const freshIssue = await getIssueWithSession(issueId)
-      if (freshIssue && freshIssue.sessionFields.sessionStatus !== finalStatus) {
-        logger.debug(
-          {
-            issueId,
-            executionId,
-            finalStatus,
-            currentStatus: freshIssue.sessionFields.sessionStatus,
-          },
-          'issue_turn_settle_skipped_reactivated',
-        )
-        return
+      // Phase 2: Move to review.
+      // If the process already exited (non-conversational engines like echo
+      // or claude-code one-shot), settle immediately — the grace period is
+      // only useful while the process is still alive and can accept follow-ups.
+      if (managed.exitCode !== undefined) {
+        await settleAfterGrace(ctx, issueId, executionId, managed, finalStatus)
+      } else {
+        // Process still alive — schedule delayed settle. If the user sends a
+        // follow-up within SETTLE_GRACE_MS, the START_TURN dispatch clears
+        // this timer and the issue stays in 'working'.
+        if (managed.settleTimer) clearTimeout(managed.settleTimer)
+        managed.settleTimer = setTimeout(() => {
+          managed.settleTimer = undefined
+          void settleAfterGrace(ctx, issueId, executionId, managed, finalStatus)
+        }, SETTLE_GRACE_MS)
       }
-
-      await autoMoveToReview(issueId)
-      emitIssueSettled(issueId, executionId, finalStatus)
-      logger.info({ issueId, executionId, finalStatus }, 'issue_turn_settled')
     } catch (error) {
+      // Cancel any pending delayed settle — the fallback below will handle it.
+      if (managed.settleTimer) {
+        clearTimeout(managed.settleTimer)
+        managed.settleTimer = undefined
+      }
       logger.error({ issueId, executionId, error }, 'issue_turn_settle_failed')
       // Safety net: ensure frontend is always notified even if settlement
       // partially failed. Without this, the frontend never receives the
@@ -173,6 +181,69 @@ export function handleTurnCompleted(
       emitIssueSettled(issueId, executionId, finalStatus)
     }
   })()
+}
+
+/**
+ * Phase 2 of turn settlement: runs after SETTLE_GRACE_MS.
+ * Moves the issue to 'review' and emits the settled event, unless a new
+ * turn started during the grace period (turnSettled would be false).
+ */
+async function settleAfterGrace(
+  ctx: EngineContext,
+  issueId: string,
+  executionId: string,
+  managed: ManagedProcess,
+  finalStatus: string,
+): Promise<void> {
+  try {
+    // Guard: if a new turn started during the grace period, skip
+    if (!managed.turnSettled) {
+      logger.debug({ issueId, executionId }, 'issue_turn_settle_cancelled_new_turn')
+      return
+    }
+
+    // Guard: if a follow-up reactivated the issue while we waited, the DB
+    // sessionStatus will no longer match finalStatus.
+    const freshIssue = await getIssueWithSession(issueId)
+    if (freshIssue && freshIssue.sessionFields.sessionStatus !== finalStatus) {
+      logger.debug(
+        {
+          issueId,
+          executionId,
+          finalStatus,
+          currentStatus: freshIssue.sessionFields.sessionStatus,
+        },
+        'issue_turn_settle_skipped_reactivated',
+      )
+      return
+    }
+
+    await autoMoveToReview(issueId)
+    emitIssueSettled(issueId, executionId, finalStatus)
+    logger.info({ issueId, executionId, finalStatus }, 'issue_turn_settled')
+  } catch (err) {
+    logger.error({ issueId, executionId, err }, 'issue_turn_delayed_settle_failed')
+    // Safety net: always notify frontend even on error
+    if (managed.turnSettled) {
+      emitIssueSettled(issueId, executionId, finalStatus)
+    }
+  }
+}
+
+/**
+ * Flush a pending settle timer immediately (e.g. when the process exits).
+ * This avoids waiting the full SETTLE_GRACE_MS for engines where the process
+ * exits after each turn — the grace period is only useful while the process
+ * is still alive and can receive follow-up input.
+ */
+export function flushSettleTimer(
+  ctx: EngineContext,
+  managed: ManagedProcess,
+): void {
+  if (!managed.settleTimer) return
+  clearTimeout(managed.settleTimer)
+  managed.settleTimer = undefined
+  void settleAfterGrace(ctx, managed.issueId, managed.executionId, managed, managed.logicalFailure ? 'failed' : 'completed')
 }
 
 export async function flushQueuedInputs(

--- a/apps/api/src/engines/issue/state/index.ts
+++ b/apps/api/src/engines/issue/state/index.ts
@@ -19,6 +19,12 @@ export function dispatch(managed: ManagedProcess, action: ManagedAction): void {
       managed.stallDetectedAt = undefined
       managed.stallProbeAt = undefined
       managed.metaTurn = action.metaTurn
+      // Cancel any pending settle timer — a new turn started before the
+      // grace period expired, so the issue should stay in 'working'.
+      if (managed.settleTimer) {
+        clearTimeout(managed.settleTimer)
+        managed.settleTimer = undefined
+      }
       break
     case 'TURN_COMPLETED':
       managed.turnInFlight = false

--- a/apps/api/src/engines/issue/state/index.ts
+++ b/apps/api/src/engines/issue/state/index.ts
@@ -24,6 +24,7 @@ export function dispatch(managed: ManagedProcess, action: ManagedAction): void {
       if (managed.settleTimer) {
         clearTimeout(managed.settleTimer)
         managed.settleTimer = undefined
+        managed.settleTimerStatus = undefined
       }
       break
     case 'TURN_COMPLETED':

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -100,4 +100,10 @@ export interface ManagedProcess {
    * within the grace period prevent the premature review transition.
    */
   settleTimer?: ReturnType<typeof setTimeout>
+  /**
+   * The finalStatus ('completed' | 'failed') captured at turn-completion time.
+   * Stored so that flushSettleTimer uses the same value that was persisted to
+   * the DB in Phase 1, avoiding a mismatch if logicalFailure changes later.
+   */
+  settleTimerStatus?: string
 }

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -94,4 +94,10 @@ export interface ManagedProcess {
    * to prevent the race where status moves to "review" while logs are still streaming.
    */
   stdoutDone?: Promise<void>
+  /**
+   * Timer handle for the delayed autoMoveToReview after a turn completes.
+   * Cleared when a new turn starts (START_TURN) so that follow-ups sent
+   * within the grace period prevent the premature review transition.
+   */
+  settleTimer?: ReturnType<typeof setTimeout>
 }

--- a/apps/api/src/engines/reconciler.ts
+++ b/apps/api/src/engines/reconciler.ts
@@ -47,6 +47,12 @@ export async function reconcileStaleWorkingIssues(): Promise<number> {
   for (const issue of staleIssues) {
     if (hasActiveProcess(issue.id)) continue
 
+    // Skip issues that are still being spawned. The 'pending' status means
+    // executeIssue has been triggered but the process hasn't registered in
+    // ProcessManager yet (worktree creation can take 3-7 seconds). Moving
+    // these to review would race with the spawn pipeline.
+    if (issue.sessionStatus === 'pending') continue
+
     const isTerminal =
       issue.sessionStatus === 'completed' ||
       issue.sessionStatus === 'failed' ||

--- a/apps/api/test/reconciler.test.ts
+++ b/apps/api/test/reconciler.test.ts
@@ -109,6 +109,20 @@ describe('reconcileStaleWorkingIssues', () => {
   })
 
   test('marks non-terminal sessionStatus as failed when moving to review', async () => {
+    // Use 'running' — reconciler should treat this as stale (no active process)
+    const issue = await createDirectIssue({
+      statusId: 'working',
+      sessionStatus: 'running',
+    })
+
+    await reconcileStaleWorkingIssues()
+
+    const updated = await getIssue(issue.id)
+    expect(updated!.statusId).toBe('review')
+    expect(updated!.sessionStatus).toBe('failed')
+  })
+
+  test('skips issues with pending sessionStatus (spawn in progress)', async () => {
     const issue = await createDirectIssue({
       statusId: 'working',
       sessionStatus: 'pending',
@@ -117,8 +131,9 @@ describe('reconcileStaleWorkingIssues', () => {
     await reconcileStaleWorkingIssues()
 
     const updated = await getIssue(issue.id)
-    expect(updated!.statusId).toBe('review')
-    expect(updated!.sessionStatus).toBe('failed')
+    // Should remain working — pending means spawn is in progress
+    expect(updated!.statusId).toBe('working')
+    expect(updated!.sessionStatus).toBe('pending')
   })
 
   test('does not touch non-working issues', async () => {
@@ -154,13 +169,19 @@ describe('reconcileStaleWorkingIssues', () => {
     })
     const issue2 = await createDirectIssue({
       statusId: 'working',
-      sessionStatus: 'pending',
+      sessionStatus: 'completed',
       title: 'Multi Stale 2',
     })
     const issue3 = await createDirectIssue({
       statusId: 'working',
-      sessionStatus: 'completed',
+      sessionStatus: 'failed',
       title: 'Multi Stale 3',
+    })
+    // pending should NOT be reconciled (spawn in progress)
+    const pendingIssue = await createDirectIssue({
+      statusId: 'working',
+      sessionStatus: 'pending',
+      title: 'Multi Stale Pending',
     })
 
     const count = await reconcileStaleWorkingIssues()
@@ -170,6 +191,10 @@ describe('reconcileStaleWorkingIssues', () => {
       const updated = await getIssue(id)
       expect(updated!.statusId).toBe('review')
     }
+
+    // Pending issue should remain untouched
+    const pending = await getIssue(pendingIssue.id)
+    expect(pending!.statusId).toBe('working')
   })
 
   test('ignores soft-deleted working issues', async () => {


### PR DESCRIPTION
## Summary

- **Reconciler race fix**: Skip issues with `sessionStatus='pending'` during reconciliation. Previously, the reconciler could move an issue to `review` before the engine process finished spawning, causing the issue to appear idle when it was actually starting up.
- **Turn-completion settlement fix**: Replace immediate `autoMoveToReview` with a 3-second grace period (`SETTLE_GRACE_MS`) for conversational engines. The old behavior triggered review transition on every `result` stream entry, even while the process was still producing output. The grace timer is cancelled when a new turn starts (`START_TURN`), and flushed immediately when the process exits (`flushSettleTimer`).

## Changes

| File | Change |
|------|--------|
| `reconciler.ts` | Skip `pending` sessionStatus issues |
| `types.ts` | Add `settleTimer` field to `ManagedProcess` |
| `state/index.ts` | Clear settle timer on `START_TURN` dispatch |
| `turn-completion.ts` | Split into Phase 1 (immediate DB update) + Phase 2 (delayed review transition); add `settleAfterGrace` + `flushSettleTimer` |
| `completion-monitor.ts` | Call `flushSettleTimer` when process exits with `turnSettled=true` |
| `lifecycle/index.ts` | Export `flushSettleTimer` |
| `reconciler.test.ts` | Add test for pending skip; update existing tests |

## Test plan

- [x] Reconciler tests pass (including new pending-skip test)
- [x] Follow-up tests pass (echo engine settles immediately via exitCode check)
- [ ] Manual: verify conversational engine (claude-code) stays in `working` during multi-entry turns
- [ ] Manual: verify issue transitions to `review` ~3s after last turn entry
- [ ] Manual: verify follow-up within grace period keeps issue in `working`