### PR TITLE
fix: correct migration 0011 journal ordering

### DIFF
--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -82,7 +82,7 @@
     {
       "idx": 11,
       "version": "6",
-      "when": 1773267961046,
+      "when": 1773273600001,
       "tag": "0011_sleepy_captain_marvel",
       "breakpoints": true
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -262,6 +262,12 @@ CHAT-001 Phase 1 完成：聊天界面 UI 优化后端基础设施
 - fix: ChatInput 刷新按钮不触发日志重新拉取，补充 `_refreshCounter` 到 effect 依赖数组（BUG-002）
 - fix: 升级系统移除自动下载，改为仅检查并提示新版本（BUG-003）
 
+## 2026-03-12 06:45 [BUG-P0]
+
+- 修复 `apps/api/drizzle/meta/_journal.json` 中 `0011_sleepy_captain_marvel` 的 `when` 倒序问题
+- 原值早于 `0010_smart_bullseye`，会被 Drizzle 迁移器按 `created_at` 过滤逻辑永久跳过
+- 修复后自动迁移可继续在升级时补上 `projects.is_archived` 列
+
 ## 2026-03-08 10:30 [progress]
 
 **CRASH-002**: 修复永久卡死根本原因 + Issue 级别诊断日志

--- a/docs/task/BUG-007.md
+++ b/docs/task/BUG-007.md
@@ -1,0 +1,70 @@
+# BUG-007 升级后 /api/projects 因缺失 is_archived 列返回 500
+
+- **status**: in_progress
+- **priority**: P0
+- **owner**: local
+
+## Problem
+
+升级到 `v0.0.25` 后，`GET /api/projects` 返回 500，导致项目列表无法正常加载。
+
+## Investigation
+
+已确认生产进程为 `/app/bkd/bkd`，当前环境变量 `DB_PATH=/app/bkd/data/db/bkd.db`。
+
+日志证据：
+
+- `/app/bkd/data/logs/bkd.log` 在 `2026-03-12 06:36` 后多次记录：
+  - `GET /api/projects 500`
+  - `SQLiteError: no such column: projects.is_archived`
+
+数据库证据：
+
+- `/app/bkd/data/db/bkd.db` 的 `projects` 表当前没有 `is_archived` 列。
+- `__drizzle_migrations` 只有 11 条记录，最大 `created_at = 1773273600000`，停留在 `0010`。
+- 仓库与发布包都已包含 `0011_sleepy_captain_marvel.sql`，内容为：
+  - `ALTER TABLE projects ADD is_archived integer DEFAULT 0 NOT NULL`
+
+代码证据：
+
+- `apps/api/src/routes/projects.ts` 的列表查询会执行：
+  - `where(and(eq(projectsTable.isDeleted, 0), eq(projectsTable.isArchived, archived ? 1 : 0)))`
+- 发布包 `/app/bkd/data/app/v0.0.25/server.js` 同样包含 `is_archived` 字段与 `0011` migration。
+
+## Current Conclusion
+
+直接根因是运行中的数据库 schema 落后于 `v0.0.25` 代码，`0011_sleepy_captain_marvel` 没有成功应用，导致 `/api/projects` 查询引用了不存在的 `projects.is_archived` 列。
+
+自动迁移未生效的根因已确认：
+
+- Drizzle migrator 只会执行 `folderMillis > lastDbMigration.created_at` 的迁移。
+- `apps/api/drizzle/meta/_journal.json` 中：
+  - `0010_smart_bullseye.when = 1773273600000`
+  - `0011_sleepy_captain_marvel.when = 1773267961046`
+- 也就是说 `0011` 的时间戳比 `0010` 更早，虽然它排在 journal 最后，但在运行时会被当成“旧迁移”直接跳过。
+
+发布包 `/app/bkd/data/app/v0.0.25/server.js` 中已确认 migrator 逻辑：
+
+- 读取 `__drizzle_migrations` 最新一条 `created_at`
+- 仅当 `lastDbMigration.created_at < migration.folderMillis` 时才插入并执行迁移
+
+因此当前数据库的最后一条迁移停在 `0010` 是预期结果，`0011` 因时间戳倒序永远不会被自动应用。
+
+另有一个待继续确认的保护缺口：同一份运行日志里出现过 `schema_verification_passed`，说明启动期的 schema 校验未能拦截这次缺列状态。
+
+## Next Step
+
+1. 修复生产库 schema，使 `0011_sleepy_captain_marvel` 落库。
+2. 修复 migration journal 的 `0011.when`，确保后续环境不会继续跳过该迁移。
+3. 继续排查为什么启动时的 `verifySchema()` 没有阻止服务带着缺列状态上线。
+
+## Progress
+
+已完成第 2 步：
+
+- 将 `apps/api/drizzle/meta/_journal.json` 中 `0011_sleepy_captain_marvel.when` 从 `1773267961046` 修正为 `1773273600001`
+
+已验证：
+
+- 在数据库副本 `/tmp/bkd-db-copy-mCNVWn.db` 上，通过加载 `apps/api/src/db/index.ts` 触发真实迁移流程后，`__drizzle_migrations` 已新增 `0011` 记录
+- `projects` 表已出现 `is_archived` 列

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -98,3 +98,4 @@
 - [x] **BUG-004 非 dev 模式不应返回 tool-use 消息** `P1` - owner: claude - file: `docs/task/BUG-004.md`
 - [x] **BUG-005 File browser rejects valid worktree root paths** `P1` - owner: claude - file: `docs/task/BUG-005.md`
 - [x] **BUG-006 Pending messages not displayed for todo issues** `P1` - owner: claude - file: `docs/task/BUG-006.md`
+- [-] **BUG-007 升级后 /api/projects 因缺失 is_archived 列返回 500** `P0` - owner: local - file: `docs/task/BUG-007.md`


### PR DESCRIPTION
## Summary
- correct `0011_sleepy_captain_marvel` `when` in `apps/api/drizzle/meta/_journal.json`
- keep migration ordering monotonic so Drizzle does not skip migration 0011
- record the investigation and fix in task/changelog docs

## Root Cause
Drizzle executes migrations by comparing each migration `when` value with the latest `created_at` in `__drizzle_migrations`.

`0010_smart_bullseye` had `when = 1773273600000`, while `0011_sleepy_captain_marvel` had `when = 1773267961046`.
Because `0011` was earlier than `0010`, it was treated as an old migration and skipped, leaving `projects.is_archived` unapplied.

## Verification
- validated that `0011.when > 0010.when`
- ran the app DB initialization path against a database copy
- confirmed the copy gained the `projects.is_archived` column and a new `__drizzle_migrations` row for migration 0011