### PR TITLE
fix: prevent false session.failed webhook on review→done transition

### DIFF
--- a/apps/api/src/engines/issue/orchestration/cancel.ts
+++ b/apps/api/src/engines/issue/orchestration/cancel.ts
@@ -1,4 +1,4 @@
-import { updateIssueSession } from '@/engines/engine-store'
+import { getIssueWithSession, updateIssueSession } from '@/engines/engine-store'
 import { CANCEL_MAX_RETRIES, CANCEL_RESPONSE_TIMEOUT_MS } from '@/engines/issue/constants'
 import type { EngineContext } from '@/engines/issue/context'
 import { emitIssueSettled } from '@/engines/issue/events'
@@ -193,10 +193,19 @@ export async function cancelIssue(
       logger.info({ issueId, interruptedCount: active.length }, 'issue_cancel_soft_interrupted')
       return 'interrupted' as const
     }
-    // No active processes — mark as cancelled in DB and notify frontend
-    await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
-    emitIssueSettled(issueId, '', 'cancelled')
-    logger.info({ issueId, cancelledCount: 0 }, 'issue_cancel_completed')
+    // No active processes — only update session status if it's not already
+    // in a terminal state. When an issue moves from review → done, the
+    // session has already settled (completed/failed) and we should not
+    // overwrite that status or emit a spurious settled event (which would
+    // trigger a misleading session.failed webhook).
+    const issue = await getIssueWithSession(issueId)
+    const currentStatus = issue?.sessionFields.sessionStatus
+    const isTerminal = currentStatus === 'completed' || currentStatus === 'failed' || currentStatus === 'cancelled'
+    if (!isTerminal) {
+      await updateIssueSession(issueId, { sessionStatus: 'cancelled' })
+      emitIssueSettled(issueId, '', 'cancelled')
+    }
+    logger.info({ issueId, cancelledCount: 0, skippedSettle: isTerminal }, 'issue_cancel_completed')
     return 'cancelled' as const
   })
 


### PR DESCRIPTION
## Summary

- When dragging an issue from **review → done**, `cancelIssue()` was unconditionally emitting a `done` event with `finalStatus: 'cancelled'`, even when no active engine processes existed
- The webhook dispatcher mapped any non-`completed` finalStatus to `session.failed`, sending a misleading ❌ notification
- Now checks if the session is already in a terminal state (`completed`/`failed`/`cancelled`) before updating status or emitting events, preventing the spurious webhook

## Test plan

- [ ] Move an issue from review → done, verify no `session.failed` webhook is sent
- [ ] Cancel an actively running issue, verify `session.failed` webhook still fires correctly
- [ ] Move a failed issue to done, verify no duplicate `session.failed` webhook