### PR TITLE
fix: skip redundant API calls when reselecting same model or engine

### DIFF
--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -844,7 +844,7 @@ function ModelsSection({ open }: { open: boolean }) {
                     <button
                       key={eng.engineType}
                       type="button"
-                      onClick={() => updateDefaultEngine.mutate(eng.engineType)}
+                      onClick={() => !isSelected && updateDefaultEngine.mutate(eng.engineType)}
                       className={cn(
                         'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
                         isSelected ?
@@ -1402,7 +1402,7 @@ function EngineCard({
                   <button
                     key={m.id}
                     type="button"
-                    onClick={() => onChangeDefault(m.id)}
+                    onClick={() => !isSelected && onChangeDefault(m.id)}
                     className={cn(
                       'flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors text-left',
                       isSelected ?


### PR DESCRIPTION
## Summary
- Add `isSelected` guard to the default model click handler in `EngineCard`, preventing unnecessary `PATCH /api/engines/:type/settings` requests when clicking the already-active model
- Apply the same guard to the default engine selector in `ModelsSection`

## Test plan
- [ ] Open Settings > Models, expand an engine card, click the already-selected model — verify no network request is fired
- [ ] Click a different model — verify the PATCH request fires normally
- [ ] Click the already-selected default engine button — verify no network request
- [ ] Click a different engine button — verify the PATCH request fires normally

Closes #77