### PR TITLE
Handle pending messages individually

### DIFF
--- a/apps/api/src/db/pending-messages.ts
+++ b/apps/api/src/db/pending-messages.ts
@@ -4,10 +4,12 @@ import { UPLOAD_DIR } from '@/uploads'
 import { db } from '.'
 import { attachments as attachmentsTable, issueLogs } from './schema'
 
+function isQueuedMessageType(type: unknown): boolean {
+  return type === 'pending' || type === 'done'
+}
+
 /**
- * Retrieve the single pending user message for a given issue (if any).
- * A pending message is a user-message log entry with metadata.type === 'pending'.
- * After the upsert merge model there should be at most one per issue.
+ * Retrieve the oldest visible queued user message for a given issue (if any).
  */
 export async function getPendingMessage(issueId: string) {
   const rows = await db
@@ -25,7 +27,7 @@ export async function getPendingMessage(issueId: string) {
   return (
     rows.find((row) => {
       try {
-        return JSON.parse(row.metadata!).type === 'pending'
+        return isQueuedMessageType(JSON.parse(row.metadata!).type)
       } catch {
         return false
       }
@@ -33,7 +35,6 @@ export async function getPendingMessage(issueId: string) {
   )
 }
 
-/** @deprecated Use getPendingMessage (returns single). Kept for migration. */
 export async function getPendingMessages(issueId: string) {
   const rows = await db
     .select()
@@ -49,7 +50,7 @@ export async function getPendingMessages(issueId: string) {
     .orderBy(asc(issueLogs.turnIndex), asc(issueLogs.entryIndex))
   return rows.filter((row) => {
     try {
-      return JSON.parse(row.metadata!).type === 'pending'
+      return isQueuedMessageType(JSON.parse(row.metadata!).type)
     } catch {
       return false
     }
@@ -57,10 +58,33 @@ export async function getPendingMessages(issueId: string) {
 }
 
 /**
- * Upsert a pending message for an issue.
- * If a pending row already exists: append content with \n\n separator, merge metadata.
- * If no pending row exists: insert a new one.
- * Returns the messageId (ULID) of the pending row.
+ * Retrieve a specific queued user message by messageId.
+ * Returns null when the row does not exist, is not visible, or is not queueable.
+ */
+export async function getPendingMessageById(issueId: string, messageId: string) {
+  const [row] = await db
+    .select()
+    .from(issueLogs)
+    .where(
+      and(
+        eq(issueLogs.id, messageId),
+        eq(issueLogs.issueId, issueId),
+        eq(issueLogs.entryType, 'user-message'),
+        eq(issueLogs.visible, 1),
+        isNotNull(issueLogs.metadata),
+      ),
+    )
+  if (!row) return null
+  try {
+    return isQueuedMessageType(JSON.parse(row.metadata!).type) ? row : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Insert a new queued message for an issue.
+ * Each queued input is persisted as its own user-message row.
  */
 export async function upsertPendingMessage(
   issueId: string,
@@ -68,53 +92,6 @@ export async function upsertPendingMessage(
   metadata: Record<string, unknown> = { type: 'pending' },
 ): Promise<string> {
   const { ulid } = await import('ulid')
-  const existing = await getPendingMessage(issueId)
-
-  if (existing) {
-    // Merge content
-    const mergedContent = [existing.content, content.trim()].filter(Boolean).join('\n\n')
-
-    // Merge metadata
-    let existingMeta: Record<string, unknown> = {}
-    try {
-      existingMeta = existing.metadata ? JSON.parse(existing.metadata) : {}
-    } catch {
-      // ignore
-    }
-
-    // Merge displayPrompt: append if both have it
-    const existingDisplay = existingMeta.displayPrompt as string | undefined
-    const newDisplay = metadata.displayPrompt as string | undefined
-    const mergedDisplay =
-      existingDisplay && newDisplay ?
-        `${existingDisplay}\n\n${newDisplay}` :
-        newDisplay || existingDisplay
-
-    // Merge attachments arrays
-    const existingAttachments = (existingMeta.attachments ?? []) as unknown[]
-    const newAttachments = (metadata.attachments ?? []) as unknown[]
-    const mergedAttachments = [...existingAttachments, ...newAttachments]
-
-    const mergedMeta: Record<string, unknown> = {
-      ...existingMeta,
-      ...metadata,
-      type: 'pending',
-      ...(mergedDisplay ? { displayPrompt: mergedDisplay } : {}),
-      ...(mergedAttachments.length > 0 ? { attachments: mergedAttachments } : {}),
-    }
-
-    await db
-      .update(issueLogs)
-      .set({
-        content: mergedContent,
-        metadata: JSON.stringify(mergedMeta),
-      })
-      .where(eq(issueLogs.id, existing.id))
-
-    return existing.id
-  }
-
-  // Insert new pending row
   const messageId = ulid()
   await db.transaction(async (tx) => {
     const [maxRow] = await tx
@@ -135,7 +112,7 @@ export async function upsertPendingMessage(
       entryIndex,
       entryType: 'user-message',
       content: (displayPrompt ?? content).trim(),
-      metadata: JSON.stringify({ ...metadata, type: 'pending' }),
+      metadata: JSON.stringify(metadata),
       timestamp: new Date().toISOString(),
       visible: 1,
     })
@@ -144,11 +121,11 @@ export async function upsertPendingMessage(
 }
 
 /**
- * Delete the pending message for an issue (user recall/edit).
+ * Delete a specific queued message for an issue (user recall/edit).
  * Returns the deleted row's content, metadata, and attachment info
  * so the frontend can fill the input box.
  */
-export async function deletePendingMessage(issueId: string): Promise<{
+export async function deletePendingMessage(issueId: string, messageId: string): Promise<{
   id: string
   content: string
   metadata: Record<string, unknown>
@@ -159,7 +136,7 @@ export async function deletePendingMessage(issueId: string): Promise<{
     size: number
   }>
 } | null> {
-  const pending = await getPendingMessage(issueId)
+  const pending = await getPendingMessageById(issueId, messageId)
   if (!pending) return null
 
   let meta: Record<string, unknown> = {}
@@ -196,7 +173,7 @@ export async function deletePendingMessage(issueId: string): Promise<{
 }
 
 /**
- * Relocate pending messages for AI processing:
+ * Relocate one queued message for AI processing:
  * 1. Atomically mark pending as visible=0 (optimistic lock)
  * 2. Return the content + metadata for caller to create a new entry at current position
  *
@@ -210,7 +187,14 @@ export async function relocatePendingForProcessing(issueId: string): Promise<{
   displayPrompt: string | undefined
   metadata: Record<string, unknown>
 } | null> {
-  const pending = await getPendingMessage(issueId)
+  const all = await getPendingMessages(issueId)
+  const pending = all.find((row) => {
+    try {
+      return JSON.parse(row.metadata!).type === 'pending'
+    } catch {
+      return false
+    }
+  }) ?? null
   if (!pending) return null
 
   // Optimistic lock: only hide if still visible
@@ -310,25 +294,4 @@ export async function getAttachmentContextForLogIds(
     result.set(logId, buildFileContextFromRows(attachmentRows))
   }
   return result
-}
-
-/**
- * Collect all pending messages for an issue and merge them into a single
- * prompt string, including attachment file context. Returns the merged prompt
- * and the IDs of consumed pending messages.
- */
-export async function collectPendingWithAttachments(
-  issueId: string,
-): Promise<{ prompt: string, pendingIds: string[] }> {
-  const pending = await getPendingMessages(issueId)
-  if (pending.length === 0) return { prompt: '', pendingIds: [] }
-  const attachmentCtx = await getAttachmentContextForLogIds(pending.map(m => m.id))
-  const parts = pending.map((m) => {
-    const fileCtx = attachmentCtx.get(m.id) ?? ''
-    return (m.content + fileCtx).trim()
-  })
-  return {
-    prompt: parts.filter(Boolean).join('\n\n'),
-    pendingIds: pending.map(m => m.id),
-  }
 }

--- a/apps/api/src/engines/issue/orchestration/restart.ts
+++ b/apps/api/src/engines/issue/orchestration/restart.ts
@@ -1,5 +1,4 @@
 import { cleanupStaleSessions } from '@/db/helpers'
-import { collectPendingWithAttachments, markPendingMessagesDispatched } from '@/db/pending-messages'
 import { getIssueWithSession, updateIssueSession } from '@/engines/engine-store'
 import { engineRegistry } from '@/engines/executors'
 import type { EngineContext } from '@/engines/issue/context'
@@ -43,9 +42,6 @@ export async function restartIssue(
     const executor = engineRegistry.get(engineType)
     if (!executor) throw new Error(`No executor for engine type: ${engineType}`)
 
-    // Collect pending messages to merge into the restart prompt
-    const { prompt: pendingPrompt, pendingIds } = await collectPendingWithAttachments(issueId)
-
     await updateIssueSession(issueId, { sessionStatus: 'running' })
 
     const baseDir = await resolveWorkingDir(issue.projectId)
@@ -66,13 +62,12 @@ export async function restartIssue(
     const executionId = crypto.randomUUID()
     const projCtx = await getProjectExecContext(issue.projectId)
 
-    // Prepend project system prompt + merge pending messages
+    // Prepend project system prompt only. Pending follow-ups remain queued and
+    // will be flushed one-by-one after each turn completes.
     const basePrompt = projCtx.systemPrompt ?
       `${projCtx.systemPrompt}\n\n${issue.sessionFields.prompt ?? ''}` :
         (issue.sessionFields.prompt ?? '')
-    const effectivePrompt = pendingPrompt ?
-        [basePrompt, pendingPrompt].filter(Boolean).join('\n\n') :
-      basePrompt
+    const effectivePrompt = basePrompt
 
     const spawnOpts = {
       workingDir,
@@ -133,15 +128,6 @@ export async function restartIssue(
       spawned.externalSessionId ?? issue.sessionFields.externalSessionId ?? undefined,
     )
     monitorCompletion(ctx, executionId, issueId, engineType, false)
-
-    // Mark pending messages as dispatched after successful spawn
-    if (pendingIds.length > 0) {
-      await markPendingMessagesDispatched(pendingIds)
-      logger.info(
-        { issueId, pendingCount: pendingIds.length },
-        'restart_pending_messages_dispatched',
-      )
-    }
 
     return { executionId }
   })

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -7,7 +7,6 @@ import { STATUS_IDS } from '@/config'
 import { db } from '@/db'
 import { getAppSetting } from '@/db/helpers'
 import {
-  collectPendingWithAttachments,
   relocatePendingForProcessing,
   restorePendingVisibility,
 } from '@/db/pending-messages'
@@ -77,8 +76,6 @@ export const followUpSchema = z.object({
 })
 
 export type IssueRow = typeof issuesTable.$inferSelect
-
-export { getPendingMessages, markPendingMessagesDispatched } from '@/db/pending-messages'
 
 export function serializeIssue(row: IssueRow, childCount?: number) {
   return {
@@ -202,23 +199,6 @@ export function flushPendingAsFollowUp(issueId: string, issue: { model: string |
 
 export function normalizePrompt(input: string): string {
   return input.replace(/^(?:\\n|\s)+/g, '').replace(/(?:\\n|\s)+$/g, '')
-}
-
-/**
- * Collect any queued pending messages, merge them into the prompt.
- * Includes attachment file context so the AI engine sees uploaded files.
- * Returns the effective prompt and pending IDs for deferred deletion.
- * Callers MUST delete pending messages only AFTER the engine call succeeds
- * to prevent message loss on failure.
- */
-export async function collectPendingMessages(
-  issueId: string,
-  basePrompt: string,
-): Promise<{ prompt: string, pendingIds: string[] }> {
-  const { prompt: pendingPrompt, pendingIds } = await collectPendingWithAttachments(issueId)
-  if (pendingIds.length === 0) return { prompt: basePrompt, pendingIds: [] }
-  const prompt = [basePrompt, pendingPrompt].filter(Boolean).join('\n\n')
-  return { prompt, pendingIds }
 }
 
 /**

--- a/apps/api/src/routes/issues/command.ts
+++ b/apps/api/src/routes/issues/command.ts
@@ -6,11 +6,9 @@ import { findProject, getAppSetting } from '@/db/helpers'
 import { issueEngine } from '@/engines/issue'
 import { logger } from '@/logger'
 import {
-  collectPendingMessages,
   ensureWorking,
   executeIssueSchema,
   getProjectOwnedIssue,
-  markPendingMessagesDispatched,
   normalizePrompt,
   parseProjectEnvVars,
 } from './_shared'
@@ -109,20 +107,15 @@ command.post(
       }
       // Prepend project-level system prompt if configured
       const basePrompt = project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt
-      const { prompt: effectivePrompt, pendingIds } = await collectPendingMessages(
-        issueId,
-        basePrompt,
-      )
       const envVars = parseProjectEnvVars(project.envVars)
       const result = await issueEngine.executeIssue(issueId, {
         engineType: body.engineType,
-        prompt: effectivePrompt,
+        prompt: basePrompt,
         workingDir: effectiveWorkingDir,
         model: body.model,
         permissionMode: body.permissionMode,
         envVars,
       })
-      await markPendingMessagesDispatched(pendingIds)
       return c.json({
         success: true,
         data: {
@@ -172,10 +165,7 @@ command.post('/:id/restart', async (c) => {
     if (!guard.ok) {
       return c.json({ success: false, error: guard.reason! }, 400)
     }
-    // Collect pending messages so they are processed by the restarted session
-    const { pendingIds } = await collectPendingMessages(issueId, '')
     const result = await issueEngine.restartIssue(issueId)
-    await markPendingMessagesDispatched(pendingIds)
     return c.json({
       success: true,
       data: { executionId: result.executionId, issueId },

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -1,19 +1,18 @@
 import { Hono } from 'hono'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
-import { getPendingMessage, upsertPendingMessage } from '@/db/pending-messages'
+import { getPendingMessages, upsertPendingMessage } from '@/db/pending-messages'
 import { attachments } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
-import { emitIssueLogRemoved, emitIssueLogUpdated } from '@/events/issue-events'
+import { emitIssueLogRemoved } from '@/events/issue-events'
 import { logger } from '@/logger'
 import type { SavedFile } from '@/uploads'
 import { saveUploadedFile, validateFiles } from '@/uploads'
 import {
-  collectPendingMessages,
   ensureWorking,
+  flushPendingAsFollowUp,
   followUpSchema,
   getProjectOwnedIssue,
-  markPendingMessagesDispatched,
   normalizePrompt,
 } from './_shared'
 
@@ -139,9 +138,8 @@ async function insertAttachmentRecords(
 }
 
 /**
- * Upsert a pending message and notify frontend via SSE.
- * If merging into existing, emit log-removed for old + log-updated for merged.
- * If inserting new, emit log (new entry).
+ * Insert a pending message and attach uploaded files to that specific row.
+ * The frontend already adds the optimistic log entry with the returned messageId.
  */
 async function upsertAndNotify(
   issueId: string,
@@ -149,36 +147,11 @@ async function upsertAndNotify(
   meta: Record<string, unknown>,
   savedFiles: SavedFile[],
 ): Promise<string> {
-  // Check if there's an existing pending to detect merge vs insert
-  const existingPending = await getPendingMessage(issueId)
-
   const messageId = await upsertPendingMessage(issueId, prompt, meta)
 
   if (savedFiles.length > 0) {
     await insertAttachmentRecords(issueId, messageId, savedFiles)
   }
-
-  if (existingPending) {
-    // Merged into existing — emit log-updated with the new merged content
-    const updated = await getPendingMessage(issueId)
-    if (updated) {
-      let parsedMeta: Record<string, unknown> | undefined
-      try {
-        parsedMeta = updated.metadata ? JSON.parse(updated.metadata) : undefined
-      } catch {
-        // ignore
-      }
-      emitIssueLogUpdated(issueId, {
-        messageId: updated.id,
-        entryType: 'user-message',
-        content: updated.content,
-        turnIndex: updated.turnIndex,
-        timestamp: updated.timestamp ?? undefined,
-        ...(parsedMeta ? { metadata: parsedMeta } : {}),
-      })
-    }
-  }
-  // For new inserts, the frontend already handles optimistic append via appendServerMessage
 
   return messageId
 }
@@ -239,6 +212,8 @@ message.post('/:id/follow-up', async (c) => {
     )
   }
 
+  const pendingBefore = await getPendingMessages(issueId)
+
   // Save uploaded files and insert attachment records
   let savedFiles: SavedFile[] = []
   if (files.length > 0) {
@@ -278,15 +253,21 @@ message.post('/:id/follow-up', async (c) => {
     return c.json({ success: true, data: { issueId, messageId, queued: true } })
   }
 
+  if (issue.statusId === 'working' && pendingBefore.length > 0) {
+    const messageId = await upsertAndNotify(issueId, prompt, pendingMeta('pending'), savedFiles)
+    flushPendingAsFollowUp(issueId, { model: issue.model })
+    logger.debug(
+      { issueId, pendingCount: pendingBefore.length + 1 },
+      'followup_queued_behind_existing_pending',
+    )
+    return c.json({ success: true, data: { issueId, messageId, queued: true } })
+  }
+
   try {
     const guard = await ensureWorking(issue)
     if (!guard.ok) {
       return c.json({ success: false, error: guard.reason! }, 400)
     }
-    const { prompt: effectivePrompt, pendingIds } = await collectPendingMessages(
-      issueId,
-      fullPrompt,
-    )
     const firstWord = prompt.split(/\s/)[0] ?? ''
     const categorized = issueEngine.getCategorizedCommands(
       issueId,
@@ -305,19 +286,13 @@ message.post('/:id/follow-up', async (c) => {
     const hasFollowUpMeta = Object.keys(followUpMeta).length > 0
     const result = await issueEngine.followUpIssue(
       issueId,
-      effectivePrompt,
+      fullPrompt,
       parsed.model,
       parsed.permissionMode as 'auto' | 'supervised' | 'plan' | undefined,
       parsed.busyAction as 'queue' | 'cancel' | undefined,
       parsed.displayPrompt ?? (savedFiles.length > 0 ? prompt || undefined : undefined),
       hasFollowUpMeta ? followUpMeta : undefined,
     )
-    // Hide old pending messages and notify frontend
-    if (pendingIds.length > 0) {
-      await markPendingMessagesDispatched(pendingIds)
-      emitIssueLogRemoved(issueId, pendingIds)
-    }
-
     // Link attachments to the server-assigned message log
     if (savedFiles.length > 0 && result.messageId) {
       await insertAttachmentRecords(issueId, result.messageId, savedFiles)
@@ -361,7 +336,7 @@ message.post('/:id/follow-up', async (c) => {
   }
 })
 
-// DELETE /api/projects/:projectId/issues/:id/pending — Recall pending message
+// DELETE /api/projects/:projectId/issues/:id/pending?messageId=... — Recall pending message
 message.delete('/:id/pending', async (c) => {
   const projectId = c.req.param('projectId')!
   const project = await findProject(projectId)
@@ -375,8 +350,13 @@ message.delete('/:id/pending', async (c) => {
     return c.json({ success: false, error: 'Issue not found' }, 404)
   }
 
+  const messageId = c.req.query('messageId')?.trim()
+  if (!messageId || messageId.length > 26 || !/^[0-9A-Z]{26}$/.test(messageId)) {
+    return c.json({ success: false, error: 'messageId must be a valid ULID' }, 400)
+  }
+
   const { deletePendingMessage } = await import('@/db/pending-messages')
-  const result = await deletePendingMessage(issueId)
+  const result = await deletePendingMessage(issueId, messageId)
   if (!result) {
     return c.json({ success: false, error: 'No pending message found' }, 404)
   }

--- a/apps/api/test/api-pending-messages.test.ts
+++ b/apps/api/test/api-pending-messages.test.ts
@@ -203,6 +203,54 @@ describe('Pending messages consumed on transition to working', () => {
     )
     expect(pendingMsgs.length).toBe(0)
   })
+
+  test('done issue queued follow-up is consumed after moving back to working', async () => {
+    const issue = expectSuccess(
+      await post<Issue>(`/api/projects/${projectId}/issues`, {
+        title: 'Done Queue Consume Test',
+        statusId: 'done',
+        engineType: 'echo',
+        model: 'auto',
+      }),
+    )
+
+    const followUp = await post<{ issueId: string, queued: boolean }>(
+      `/api/projects/${projectId}/issues/${issue.id}/follow-up`,
+      { prompt: 'queued while done' },
+    )
+    expect(followUp.status).toBe(200)
+    expect(followUp.json.success).toBe(true)
+    if (followUp.json.success) {
+      expect(followUp.json.data.queued).toBe(true)
+    }
+
+    let logsResult = await get<LogsResponse>(`/api/projects/${projectId}/issues/${issue.id}/logs`)
+    let logs = expectSuccess(logsResult)
+    const queuedDone = logs.logs.filter(
+      l => l.entryType === 'user-message' && l.metadata?.type === 'done',
+    )
+    expect(queuedDone).toHaveLength(1)
+    expect(queuedDone[0]?.content).toBe('queued while done')
+
+    await patch(`/api/projects/${projectId}/issues/${issue.id}`, {
+      statusId: 'working',
+    })
+
+    await waitFor(async () => {
+      const r = await get<Issue>(`/api/projects/${projectId}/issues/${issue.id}`)
+      const current = expectSuccess(r)
+      return current.statusId === 'review' && current.sessionStatus === 'completed'
+    }, 5000)
+
+    logsResult = await get<LogsResponse>(`/api/projects/${projectId}/issues/${issue.id}/logs`)
+    logs = expectSuccess(logsResult)
+    const remainingQueued = logs.logs.filter(
+      l =>
+        l.entryType === 'user-message'
+        && (l.metadata?.type === 'pending' || l.metadata?.type === 'done'),
+    )
+    expect(remainingQueued).toHaveLength(0)
+  })
 })
 
 // ============================

--- a/apps/api/test/pending-messages-unit.test.ts
+++ b/apps/api/test/pending-messages-unit.test.ts
@@ -1,25 +1,18 @@
 import { beforeAll, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { db } from '@/db'
-import { promotePendingMessages } from '@/db/pending-messages'
+import {
+  deletePendingMessage,
+  getPendingMessage,
+  getPendingMessageById,
+  getPendingMessages,
+  markPendingMessagesDispatched,
+  relocatePendingForProcessing,
+  restorePendingVisibility,
+  upsertPendingMessage,
+} from '@/db/pending-messages'
 import { issueLogs, issues as issuesTable, projects as projectsTable } from '@/db/schema'
-// We import the shared helpers directly
-import { getPendingMessages, markPendingMessagesDispatched } from '@/routes/issues/_shared'
-
-/**
- * Pending messages unit tests — tests the low-level pending message
- * functions directly against the DB, verifying:
- * 1. getPendingMessages returns only pending=true messages
- * 2. markPendingMessagesDispatched marks entries as pending=false
- * 3. After marking dispatched, getPendingMessages returns empty
- * 4. collectPendingMessages-style merge works correctly
- *
- * These test the functions exported from _shared.ts and imported via
- * session.ts route module.
- */
 import './setup'
-
-// ---------- Test setup ----------
 
 let projectId: string
 let issueCounter = 0
@@ -42,37 +35,6 @@ async function createTestIssue(title?: string) {
   return row!
 }
 
-/**
- * Insert a pending message directly in the DB (equivalent to what
- * persistPendingMessage in session.ts does).
- */
-async function insertPendingMessage(issueId: string, content: string) {
-  await db.insert(issueLogs).values({
-    issueId,
-    turnIndex: 0,
-    entryIndex: Date.now(), // unique
-    entryType: 'user-message',
-    content,
-    metadata: JSON.stringify({ type: 'pending' }),
-    timestamp: new Date().toISOString(),
-  })
-}
-
-/**
- * Insert a dispatched (non-pending) message directly in the DB.
- */
-async function insertDispatchedMessage(issueId: string, content: string) {
-  await db.insert(issueLogs).values({
-    issueId,
-    turnIndex: 0,
-    entryIndex: Date.now(),
-    entryType: 'user-message',
-    content,
-    metadata: JSON.stringify({ type: 'dispatched' }),
-    timestamp: new Date().toISOString(),
-  })
-}
-
 beforeAll(async () => {
   const [p] = await db
     .insert(projectsTable)
@@ -84,253 +46,134 @@ beforeAll(async () => {
   projectId = p!.id
 })
 
-// ============================
-// getPendingMessages
-// ============================
-
-describe('getPendingMessages', () => {
-  test('returns pending messages for an issue', async () => {
+describe('pending message storage', () => {
+  test('stores multiple pending rows independently', async () => {
     const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'hello pending')
-    await insertPendingMessage(issue.id, 'another pending')
+
+    const firstId = await upsertPendingMessage(issue.id, 'first pending', { type: 'pending' })
+    const secondId = await upsertPendingMessage(issue.id, 'second pending', { type: 'pending' })
+
+    expect(firstId).not.toBe(secondId)
 
     const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(2)
-    expect(pending[0]!.content).toBe('hello pending')
-    expect(pending[1]!.content).toBe('another pending')
+    expect(pending).toHaveLength(2)
+    expect(pending.map(row => row.id)).toEqual([firstId, secondId])
+    expect(pending.map(row => row.content)).toEqual(['first pending', 'second pending'])
   })
 
-  test('returns only messages with metadata.type=pending', async () => {
-    const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'pending one')
-    await insertDispatchedMessage(issue.id, 'dispatched one')
-    await insertPendingMessage(issue.id, 'pending two')
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(2)
-    expect(pending.map(m => m.content)).toEqual(['pending one', 'pending two'])
-  })
-
-  test('returns empty array when no pending messages exist', async () => {
+  test('preserves non-pending queued types when inserting', async () => {
     const issue = await createTestIssue()
 
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(0)
-  })
-
-  test('does not return messages with null metadata', async () => {
-    const issue = await createTestIssue()
-    // Insert a message with no metadata
-    await db.insert(issueLogs).values({
-      issueId: issue.id,
-      turnIndex: 0,
-      entryIndex: 0,
-      entryType: 'user-message',
-      content: 'no metadata',
-      metadata: null,
-      timestamp: new Date().toISOString(),
-    })
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(0)
-  })
-
-  test('does not return non-user-message entries even with pending metadata', async () => {
-    const issue = await createTestIssue()
-    // Insert a system message with pending=true (should not happen, but test the filter)
-    await db.insert(issueLogs).values({
-      issueId: issue.id,
-      turnIndex: 0,
-      entryIndex: 0,
-      entryType: 'system-message',
-      content: 'system with pending',
-      metadata: JSON.stringify({ type: 'pending' }),
-      timestamp: new Date().toISOString(),
-    })
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(0)
-  })
-
-  test('does not return messages from a different issue', async () => {
-    const issue1 = await createTestIssue()
-    const issue2 = await createTestIssue()
-    await insertPendingMessage(issue1.id, 'for issue 1')
-    await insertPendingMessage(issue2.id, 'for issue 2')
-
-    const pending1 = await getPendingMessages(issue1.id)
-    expect(pending1.length).toBe(1)
-    expect(pending1[0]!.content).toBe('for issue 1')
-
-    const pending2 = await getPendingMessages(issue2.id)
-    expect(pending2.length).toBe(1)
-    expect(pending2[0]!.content).toBe('for issue 2')
-  })
-})
-
-// ============================
-// markPendingMessagesDispatched
-// ============================
-
-describe('markPendingMessagesDispatched', () => {
-  test('marks specified pending messages as dispatched', async () => {
-    const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'to dispatch')
-    await insertPendingMessage(issue.id, 'to keep pending')
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(2)
-
-    // Mark only the first one as dispatched
-    await markPendingMessagesDispatched([pending[0]!.id])
-
-    const remaining = await getPendingMessages(issue.id)
-    expect(remaining.length).toBe(1)
-    expect(remaining[0]!.content).toBe('to keep pending')
-  })
-
-  test('marks all pending messages as dispatched when given all IDs', async () => {
-    const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'msg 1')
-    await insertPendingMessage(issue.id, 'msg 2')
-    await insertPendingMessage(issue.id, 'msg 3')
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(3)
-
-    await markPendingMessagesDispatched(pending.map(m => m.id))
-
-    const after = await getPendingMessages(issue.id)
-    expect(after.length).toBe(0)
-  })
-
-  test('does nothing when given empty array', async () => {
-    const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'should remain')
-
-    await markPendingMessagesDispatched([])
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(1)
-  })
-
-  test('after marking dispatched, getPendingMessages returns empty', async () => {
-    const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'lifecycle test')
-
-    let pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(1)
-
-    await markPendingMessagesDispatched(pending.map(m => m.id))
-
-    pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(0)
-  })
-})
-
-// ============================
-// Pending message lifecycle
-// ============================
-
-describe('Pending message lifecycle', () => {
-  test('full lifecycle: insert -> get -> mark dispatched -> verify empty', async () => {
-    const issue = await createTestIssue()
-
-    // 1. Insert multiple pending messages
-    await insertPendingMessage(issue.id, 'first message')
-    await insertPendingMessage(issue.id, 'second message')
-    await insertPendingMessage(issue.id, 'third message')
-
-    // 2. Get pending messages
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(3)
-
-    // 3. Merge into a prompt (simulates collectPendingMessages logic)
-    const basePrompt = 'base instruction'
-    const merged = [basePrompt, ...pending.map(m => m.content)].filter(Boolean).join('\n\n')
-    expect(merged).toBe('base instruction\n\nfirst message\n\nsecond message\n\nthird message')
-
-    // 4. Mark as dispatched after successful dispatch
-    await markPendingMessagesDispatched(pending.map(m => m.id))
-
-    // 5. Verify no pending messages remain
-    const after = await getPendingMessages(issue.id)
-    expect(after.length).toBe(0)
-  })
-
-  test('pending messages preserve content after metadata parsing', async () => {
-    const issue = await createTestIssue()
-    const specialContent = 'message with "quotes" and\nnewlines\tand\ttabs'
-    await insertPendingMessage(issue.id, specialContent)
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(1)
-    expect(pending[0]!.content).toBe(specialContent)
-
-    // Verify the metadata is valid JSON with pending=true
-    const metadata = JSON.parse(pending[0]!.metadata!)
-    expect(metadata.type).toBe('pending')
-  })
-
-  test('collectPendingMessages-style merge with empty base prompt', async () => {
-    const issue = await createTestIssue()
-    await insertPendingMessage(issue.id, 'only message')
-
-    const pending = await getPendingMessages(issue.id)
-    const merged = ['', ...pending.map(m => m.content)].filter(Boolean).join('\n\n')
-    expect(merged).toBe('only message')
-  })
-
-  test('collectPendingMessages-style merge returns base when no pending', async () => {
-    const issue = await createTestIssue()
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(0)
-
-    const basePrompt = 'just the base'
-    const merged =
-      pending.length === 0 ?
-        basePrompt :
-          [basePrompt, ...pending.map(m => m.content)].filter(Boolean).join('\n\n')
-    expect(merged).toBe('just the base')
-  })
-})
-
-describe('promotePendingMessages', () => {
-  test('returns updated entries and removes pending metadata while preserving other fields', async () => {
-    const issue = await createTestIssue()
-    await db.insert(issueLogs).values({
-      issueId: issue.id,
-      turnIndex: 2,
-      entryIndex: Date.now(),
-      entryType: 'user-message',
-      content: 'promote me',
-      metadata: JSON.stringify({
-        type: 'pending',
-        attachments: [{ id: 'att-1', name: 'spec.txt', size: 12 }],
-      }),
-      timestamp: new Date().toISOString(),
-    })
-
-    const pending = await getPendingMessages(issue.id)
-    expect(pending.length).toBe(1)
-
-    const updated = await promotePendingMessages([pending[0]!.id])
-    expect(updated).toHaveLength(1)
-    expect(updated[0]!.messageId).toBe(pending[0]!.id)
-    expect(updated[0]!.metadata?.type).toBeUndefined()
-    expect(updated[0]!.metadata?.attachments).toEqual([{ id: 'att-1', name: 'spec.txt', size: 12 }])
-
-    const pendingAfter = await getPendingMessages(issue.id)
-    expect(pendingAfter).toHaveLength(0)
-
+    const messageId = await upsertPendingMessage(issue.id, 'done message', { type: 'done' })
     const [row] = await db
       .select({ metadata: issueLogs.metadata })
       .from(issueLogs)
-      .where(eq(issueLogs.id, pending[0]!.id))
+      .where(eq(issueLogs.id, messageId))
+
     expect(row).toBeTruthy()
-    expect(JSON.parse(row!.metadata!)).toEqual({
-      attachments: [{ id: 'att-1', name: 'spec.txt', size: 12 }],
-    })
+    expect(JSON.parse(row!.metadata!)).toEqual({ type: 'done' })
+    const queued = await getPendingMessages(issue.id)
+    expect(queued).toHaveLength(1)
+    expect(queued[0]?.id).toBe(messageId)
+  })
+
+  test('getPendingMessage returns the oldest visible pending row', async () => {
+    const issue = await createTestIssue()
+
+    const firstId = await upsertPendingMessage(issue.id, 'first pending', { type: 'pending' })
+    await upsertPendingMessage(issue.id, 'second pending', { type: 'pending' })
+
+    const oldest = await getPendingMessage(issue.id)
+    expect(oldest?.id).toBe(firstId)
+    expect(oldest?.content).toBe('first pending')
+  })
+
+  test('getPendingMessageById returns visible queueable rows only', async () => {
+    const issue = await createTestIssue()
+
+    const pendingId = await upsertPendingMessage(issue.id, 'visible pending', { type: 'pending' })
+    const doneId = await upsertPendingMessage(issue.id, 'done row', { type: 'done' })
+
+    expect((await getPendingMessageById(issue.id, pendingId))?.id).toBe(pendingId)
+    expect((await getPendingMessageById(issue.id, doneId))?.id).toBe(doneId)
+  })
+})
+
+describe('pending message recall', () => {
+  test('deletes only the targeted pending row', async () => {
+    const issue = await createTestIssue()
+
+    const firstId = await upsertPendingMessage(issue.id, 'first pending', { type: 'pending' })
+    const secondId = await upsertPendingMessage(issue.id, 'second pending', { type: 'pending' })
+
+    const recalled = await deletePendingMessage(issue.id, secondId)
+    expect(recalled?.id).toBe(secondId)
+    expect(recalled?.content).toBe('second pending')
+
+    const remaining = await getPendingMessages(issue.id)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]?.id).toBe(firstId)
+  })
+
+  test('allows recalling a queued done message by messageId', async () => {
+    const issue = await createTestIssue()
+    const doneId = await upsertPendingMessage(issue.id, 'done recall', { type: 'done' })
+
+    const recalled = await deletePendingMessage(issue.id, doneId)
+    expect(recalled?.id).toBe(doneId)
+    expect(recalled?.metadata).toEqual({ type: 'done' })
+    expect(await getPendingMessages(issue.id)).toHaveLength(0)
+  })
+})
+
+describe('pending message dispatch', () => {
+  test('relocates one pending row at a time in chronological order', async () => {
+    const issue = await createTestIssue()
+
+    const firstId = await upsertPendingMessage(issue.id, 'first pending', { type: 'pending' })
+    const secondId = await upsertPendingMessage(issue.id, 'second pending', { type: 'pending' })
+
+    const firstRelocated = await relocatePendingForProcessing(issue.id)
+    expect(firstRelocated?.oldId).toBe(firstId)
+    expect(firstRelocated?.prompt).toBe('first pending')
+
+    let pending = await getPendingMessages(issue.id)
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.id).toBe(secondId)
+
+    const secondRelocated = await relocatePendingForProcessing(issue.id)
+    expect(secondRelocated?.oldId).toBe(secondId)
+    expect(secondRelocated?.prompt).toBe('second pending')
+
+    pending = await getPendingMessages(issue.id)
+    expect(pending).toHaveLength(0)
+  })
+
+  test('restorePendingVisibility makes a failed relocation retryable', async () => {
+    const issue = await createTestIssue()
+    const pendingId = await upsertPendingMessage(issue.id, 'retry me', { type: 'pending' })
+
+    const relocated = await relocatePendingForProcessing(issue.id)
+    expect(relocated?.oldId).toBe(pendingId)
+    expect(await getPendingMessages(issue.id)).toHaveLength(0)
+
+    restorePendingVisibility(pendingId)
+
+    const pending = await getPendingMessages(issue.id)
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.id).toBe(pendingId)
+  })
+
+  test('markPendingMessagesDispatched hides only the provided IDs', async () => {
+    const issue = await createTestIssue()
+
+    const firstId = await upsertPendingMessage(issue.id, 'first pending', { type: 'pending' })
+    const secondId = await upsertPendingMessage(issue.id, 'second pending', { type: 'pending' })
+
+    await markPendingMessagesDispatched([firstId])
+
+    const pending = await getPendingMessages(issue.id)
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.id).toBe(secondId)
   })
 })

--- a/apps/frontend/src/components/issue-detail/AcpTimeline.tsx
+++ b/apps/frontend/src/components/issue-detail/AcpTimeline.tsx
@@ -84,7 +84,7 @@ export function AcpTimeline({
   isRunning?: boolean
   workingStep?: string | null
   onCancel?: () => void
-  onEditPending?: () => void
+  onEditPending?: (messageId: string) => void
   isCancelling?: boolean
   hasOlderLogs?: boolean
   isLoadingOlder?: boolean
@@ -223,7 +223,7 @@ export function AcpTimeline({
                       (
                         <button
                           type="button"
-                          onClick={onEditPending}
+                          onClick={() => onEditPending(entry.messageId ?? `acp-pending-${idx}`)}
                           className="absolute right-2 top-2 hidden rounded-md border border-border/40 bg-background/90 px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground group-hover:inline-flex"
                         >
                           {t('common.edit')}

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -183,9 +183,9 @@ export function ChatBody({
     appendServerMessage,
   } = useSessionState(projectId, issueId, issue)
 
-  const handleEditPending = useCallback(async () => {
+  const handleEditPending = useCallback(async (messageId: string) => {
     try {
-      const result = await kanbanApi.deletePendingMessage(projectId, issueId)
+      const result = await kanbanApi.deletePendingMessage(projectId, issueId, messageId)
       setPendingEditContent(result.content)
       removeEntries([result.id])
     } catch {

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -332,23 +332,19 @@ export function ChatInput({
         const isCommand =
           firstWord.startsWith('/') &&
           (normalizedCommands.length === 0 || normalizedCommands.includes(firstWord))
-        const metadata: Record<string, unknown> | undefined = isTodo ?
+        const isQueued = result.queued === true
+        const metadata: Record<string, unknown> | undefined = isTodo || (isWorking && isQueued) ?
             {
               type: 'pending',
               ...(filesMeta ? { attachments: filesMeta } : {}),
             } :
           isDone ?
               { type: 'done', ...(filesMeta ? { attachments: filesMeta } : {}) } :
-            isWorking && isThinking ?
-                {
-                  type: 'pending',
-                  ...(filesMeta ? { attachments: filesMeta } : {}),
-                } :
-              isCommand ?
-                  { type: 'command' } :
-                filesMeta ?
-                    { attachments: filesMeta } :
-                  undefined
+            isCommand ?
+                { type: 'command' } :
+              filesMeta ?
+                  { attachments: filesMeta } :
+                undefined
         onMessageSent?.(result.messageId, prompt, metadata)
       }
       // Auto-scroll to bottom after sending

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -140,7 +140,7 @@ export function SessionMessages(props: {
   isRunning?: boolean
   workingStep?: string | null
   onCancel?: () => void
-  onEditPending?: () => void
+  onEditPending?: (messageId: string) => void
   isCancelling?: boolean
   hasOlderLogs?: boolean
   isLoadingOlder?: boolean
@@ -172,7 +172,7 @@ function LegacySessionMessages({
   isRunning?: boolean
   workingStep?: string | null
   onCancel?: () => void
-  onEditPending?: () => void
+  onEditPending?: (messageId: string) => void
   isCancelling?: boolean
   hasOlderLogs?: boolean
   isLoadingOlder?: boolean
@@ -214,14 +214,19 @@ function LegacySessionMessages({
 
   const prevLenRef = useRef(messages.length)
   const prevFirstIdRef = useRef(messages[0]?.id)
+  const firstMessageId = messages[0]?.id
+  // Track last message content length so streaming updates trigger auto-scroll
+  const lastMsg = messages.at(-1)
+  const lastContentLen = lastMsg?.type === 'assistant'
+    ? (lastMsg.entry.content?.length ?? 0)
+    : 0
 
   useEffect(() => {
     if (!initialScrollDone.current) return
-    const firstId = messages[0]?.id
     const wasOlderPrepend =
       messages.length > prevLenRef.current &&
       prevFirstIdRef.current &&
-      firstId !== prevFirstIdRef.current
+      firstMessageId !== prevFirstIdRef.current
 
     if (
       !wasOlderPrepend &&
@@ -235,8 +240,8 @@ function LegacySessionMessages({
       })
     }
     prevLenRef.current = messages.length
-    prevFirstIdRef.current = firstId
-  }, [messages, isRunning, scrollRef])
+    prevFirstIdRef.current = firstMessageId
+  }, [firstMessageId, isRunning, lastContentLen, messages.length, scrollRef])
 
   if (messages.length === 0 && pendingMessages.length === 0 && !isRunning) return null
 
@@ -298,11 +303,11 @@ function LegacySessionMessages({
               {pendingMessages.map(msg => (
                 <div key={msg.id} className="group relative">
                   <ChatMessageRow message={msg} />
-                  {onEditPending ?
+                  {onEditPending && (msg.status === 'pending' || msg.status === 'done') ?
                       (
                         <button
                           type="button"
-                          onClick={onEditPending}
+                          onClick={() => onEditPending(msg.entry.messageId ?? msg.id)}
                           className="absolute right-2 top-2 hidden rounded-md border border-border/40 bg-background/90 px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground group-hover:inline-flex"
                         >
                           {t('common.edit')}

--- a/apps/frontend/src/hooks/use-acp-timeline.ts
+++ b/apps/frontend/src/hooks/use-acp-timeline.ts
@@ -174,10 +174,11 @@ function rebuildAcpTimeline(entries: NormalizedLogEntry[]): AcpTimelineResult {
         pendingStreamingAssistant &&
         pendingStreamingAssistant.turnIndex === entry.turnIndex
       ) {
+        const current: NormalizedLogEntry = pendingStreamingAssistant
         pendingStreamingAssistant = {
-          ...pendingStreamingAssistant,
-          content: `${pendingStreamingAssistant.content}${entry.content}`,
-          timestamp: entry.timestamp ?? pendingStreamingAssistant.timestamp,
+          ...current,
+          content: `${current.content}${entry.content}`,
+          timestamp: entry.timestamp ?? current.timestamp,
         }
       } else {
         flushStreamingAssistant()

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -352,7 +352,7 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
 
 interface ChatMessagesResult {
   messages: ChatMessage[]
-  pendingMessages: ChatMessage[]
+  pendingMessages: UserChatMessage[]
 }
 
 /**
@@ -364,7 +364,7 @@ export function useChatMessages(logs: NormalizedLogEntry[]): ChatMessagesResult 
   return useMemo(() => {
     const all = rebuildMessages(logs)
     const messages: ChatMessage[] = []
-    const pendingMessages: ChatMessage[] = []
+    const pendingMessages: UserChatMessage[] = []
     for (const msg of all) {
       if (msg.type === 'user' && (msg.status === 'pending' || msg.status === 'done')) {
         pendingMessages.push(msg)

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -199,7 +199,7 @@ export const kanbanApi = {
   restartIssue: (projectId: string, issueId: string) =>
     post<ExecuteIssueResponse>(`/api/projects/${projectId}/issues/${issueId}/restart`, {}),
 
-  deletePendingMessage: (projectId: string, issueId: string) =>
+  deletePendingMessage: (projectId: string, issueId: string, messageId: string) =>
     del<{
       id: string
       content: string
@@ -210,7 +210,9 @@ export const kanbanApi = {
         mimeType: string
         size: number
       }>
-    }>(`/api/projects/${projectId}/issues/${issueId}/pending`),
+    }>(
+      `/api/projects/${projectId}/issues/${issueId}/pending?messageId=${encodeURIComponent(messageId)}`,
+    ),
 
   autoTitleIssue: async (projectId: string, issueId: string) => {
     const res = await fetch(`/api/projects/${projectId}/issues/${issueId}/auto-title`, {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-03-13 21:10 [progress]
+
+- BUG-012 / PLAN-023: Keep pending messages separate and editable
+- `apps/api/src/db/pending-messages.ts` now stores each queued message as its own row and supports per-message lookup/delete/relocation
+- `apps/api/src/routes/issues/message.ts` now recalls pending rows by `messageId` and flushes queued follow-ups one message at a time
+- `apps/api/src/routes/issues/command.ts` and `apps/api/src/engines/issue/orchestration/restart.ts` no longer pre-merge all pending prompts before execution
+- `apps/frontend/src/components/issue-detail/ChatBody.tsx` and `SessionMessages.tsx` now let users edit pending rows individually
+- Added regression coverage for separate pending storage, per-message recall, and queued done-message flushing
+
 ## 2026-03-13 04:54 [progress]
 
 ENG-011 / PLAN-020: Restore grouped tool rendering for ACP

--- a/docs/plan/PLAN-023.md
+++ b/docs/plan/PLAN-023.md
@@ -1,0 +1,50 @@
+# PLAN-023 Keep pending messages separate and editable
+
+- **task**: BUG-012
+- **status**: completed
+- **owner**: local
+- **created**: 2026-03-13
+
+## Context
+
+- The previous implementation enforced a single pending row per issue.
+- `upsertPendingMessage()` reused the existing row and merged message content, display prompt text, and attachments into one record.
+- The UI already rendered pending items at the bottom, but recall/edit behavior still targeted a single issue-level pending row.
+- `turn-completion`, `flushPendingAsFollowUp()`, `execute`, and `restart` still had paths that pre-merged queued user intent before sending it back to the engine.
+
+## Proposal
+
+1. Store every queued pending message as its own row.
+2. Recall and edit pending messages by `messageId` instead of by issue.
+3. Keep pending rows visible in order and expose an edit action on each row.
+4. Consume queued messages one at a time in flush, execute, and restart paths.
+5. Preserve SSE and rollback behavior at per-message precision.
+
+## Scope
+
+- Update pending DB helpers for insert, query, delete, and relocation behavior.
+- Update follow-up, execute, restart, and turn-completion flows to stop pre-merging pending prompts.
+- Update frontend pending edit behavior to target a specific message row.
+- Add regression coverage for separate pending storage, per-message recall, and per-message relocation/flush.
+
+## Risks
+
+- Sequential flush means a single turn completion only advances one queued row, so idle-state recovery had to be verified carefully.
+- Existing execute/restart behavior previously assumed a combined prompt; changing that behavior could expose ordering bugs.
+- The frontend still restores recalled content into one composer, so the edit entrypoint had to stay aligned with the selected `messageId`.
+
+## Alternatives
+
+1. Full per-message handling.
+This keeps UI semantics and engine semantics aligned.
+
+2. Split only the UI while keeping backend batching.
+This would still misrepresent what the engine actually receives, so it was rejected.
+
+## Result
+
+- Pending rows are now stored, recalled, and relocated individually.
+- Follow-up recall requires `messageId`.
+- Working issues with existing queued rows append a new row, then flush in order.
+- Execute and restart stop merging queued prompts ahead of time.
+- The pending section in the chat UI supports per-row edit actions.

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -25,3 +25,4 @@
 - [x] **PLAN-020 ACP 时间线恢复工具组展示** - task: `ENG-011` - owner: codex - file: `docs/plan/PLAN-020.md`
 - [x] **PLAN-021 禁止会话内 follow-up 切换模型** - task: `ENG-012` - owner: codex - file: `docs/plan/PLAN-021.md`
 - [x] **PLAN-022 修复 ACP 重复占位 tool action 发射** - task: `BUG-011` - owner: codex - file: `docs/plan/PLAN-022.md`
+- [x] **PLAN-023 Keep pending messages separate and editable** - task: `BUG-012` - owner: local - file: `docs/plan/PLAN-023.md`

--- a/docs/task/BUG-012.md
+++ b/docs/task/BUG-012.md
@@ -1,0 +1,48 @@
+# BUG-012 Pending messages should not merge automatically
+
+- **status**: completed
+- **priority**: P1
+- **owner**: local
+- **created**: 2026-03-13
+
+## Problem
+
+Multiple pending messages were merged into a single database row, which caused three user-facing issues:
+
+1. Users could not edit or recall one queued message at a time.
+2. Message boundaries and ordering were hidden in the UI.
+3. Auto-flush could combine separate intents into one follow-up prompt.
+
+## Investigation
+
+- `apps/api/src/db/pending-messages.ts` reused the existing pending row and appended content, display prompt data, and attachments.
+- `apps/api/src/routes/issues/message.ts` reused that behavior for `todo`, `done`, active-turn queueing, and follow-up failure fallback.
+- `apps/frontend/src/components/issue-detail/ChatBody.tsx` only supported recalling a single issue-level pending row.
+- `apps/api/src/engines/issue/lifecycle/turn-completion.ts` and `apps/api/src/routes/issues/_shared.ts` still contained pending-flush paths that could collapse queued input back into one follow-up.
+
+## Goal
+
+Keep pending messages separate, let users edit them individually, and process them in order as individual queue items.
+
+## Scope
+
+- `apps/api/src/db/pending-messages.ts`
+- `apps/api/src/routes/issues/message.ts`
+- `apps/api/src/routes/issues/_shared.ts`
+- `apps/api/src/engines/issue/lifecycle/turn-completion.ts`
+- `apps/api/src/routes/issues/command.ts`
+- `apps/frontend/src/components/issue-detail/ChatBody.tsx`
+- `apps/frontend/src/components/issue-detail/SessionMessages.tsx`
+- `apps/frontend/src/lib/kanban-api.ts`
+
+## Linked Plan
+
+- `PLAN-023`
+
+## Outcome
+
+- Pending messages are stored in separate rows instead of being merged.
+- Pending edit/recall now targets a specific `messageId`.
+- Working issues with queued rows append a new queued row and then flush in FIFO order.
+- Execute and restart no longer pre-merge all pending input.
+- The pending UI now exposes per-row edit actions.

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -117,3 +117,4 @@
 - [x] **BUG-008 ACP Codex model id 含 `/` 导致 400** `P1` - owner: codex - file: `docs/task/BUG-008.md`
 - [-] **BUG-009 模型发现链路缺少可诊断日志** `P1` - owner: codex - plan: `PLAN-011` - file: `docs/task/BUG-009.md`
 - [x] **BUG-010 ACP assistant streaming 未落地导致前端无返回** `P0` - owner: codex - plan: `PLAN-012` - file: `docs/task/BUG-010.md`
+- [x] **BUG-012 Pending messages should not merge automatically** `P1` - owner: local - plan: `PLAN-023` - file: `docs/task/BUG-012.md`


### PR DESCRIPTION
## Summary
- store pending follow-ups as independent log rows instead of merging them into one record
- edit and recall pending messages by `messageId` so each pending item can be handled separately
- stop execute and restart from pre-merging all pending inputs, and keep pending flushes moving one item at a time

## Testing
- `bun test apps/api/test/pending-messages-unit.test.ts apps/api/test/turn-completion-regression.test.ts apps/api/test/api-pending-messages.test.ts apps/api/test/followup-reconciliation.test.ts`
- `bun --filter @bkd/frontend build`
- `bunx eslint apps/api/src/db/pending-messages.ts apps/api/src/engines/issue/orchestration/restart.ts apps/api/src/routes/issues/_shared.ts apps/api/src/routes/issues/command.ts apps/api/src/routes/issues/message.ts apps/api/test/pending-messages-unit.test.ts apps/frontend/src/components/issue-detail/ChatBody.tsx apps/frontend/src/components/issue-detail/SessionMessages.tsx apps/frontend/src/hooks/use-chat-messages.ts apps/frontend/src/lib/kanban-api.ts`

## Notes
- `bun --filter @bkd/api test` still reports unrelated existing failures in `issue-lock.test.ts` and one auto-execute fallback case.
