### PR TITLE
fix: correct variable scoping bug and update stale tests

### DIFF
--- a/apps/api/test/issue-lock.test.ts
+++ b/apps/api/test/issue-lock.test.ts
@@ -58,7 +58,7 @@ describe('withIssueLock deep behavior', () => {
     await Bun.sleep(5)
 
     // Current implementation counts active holder + queued entries in lockDepth.
-    const queued = Array.from({ length: 9 }).fill(withIssueLock(ctx, issueId, async () => {}))
+    const queued = Array.from({ length: 9 }, () => withIssueLock(ctx, issueId, async () => {}))
 
     await expect(withIssueLock(ctx, issueId, async () => {})).rejects.toThrow('Lock queue full')
 
@@ -80,9 +80,9 @@ describe('withIssueLock deep behavior', () => {
     ctx.lockDepth.set(issueId, 1)
 
     const originalSetTimeout = globalThis.setTimeout
-    ;(globalThis as any).setTimeout = ((handler: any, timeout?: number) => {
+    ;(globalThis as any).setTimeout = ((handler: any, timeout?: number, ...args: any[]) => {
       const ms = timeout === 30_000 ? 15 : timeout
-      return originalSetTimeout(handler, ms)
+      return originalSetTimeout(handler, ms, ...args)
     }) as typeof setTimeout
 
     try {


### PR DESCRIPTION
## Summary
- Fix `ReferenceError` in `flushPendingAsFollowUp` and `triggerIssueExecution` where `relocated` was declared with `const` inside `try` blocks but referenced in `catch` handlers — hoisted to `let` outside `try`
- Update pending message tests to match the upsert/merge model (multiple messages merge into a single row, not separate rows)
- Fix `issue-lock.test.ts`: replace `Array.from().fill()` (copies same Promise ref) with `Array.from(_, () => ...)` (calls `withIssueLock` 9 times); forward `...args` in `setTimeout` mock to preserve resolve value
- Remove obsolete `promotePendingMessages` test block (function was removed from source)

## Test plan
- [x] All 425 tests pass (0 failures)