### PR TITLE
fix: merge all pending messages before dispatching to agent

### DIFF
--- a/apps/api/src/db/pending-messages.ts
+++ b/apps/api/src/db/pending-messages.ts
@@ -182,50 +182,73 @@ export async function deletePendingMessage(issueId: string, messageId: string): 
  * log-removed SSE for the old messageId.
  */
 export async function relocatePendingForProcessing(issueId: string): Promise<{
-  oldId: string
+  oldIds: string[]
   prompt: string
   displayPrompt: string | undefined
   metadata: Record<string, unknown>
 } | null> {
   const all = await getPendingMessages(issueId)
-  const pending = all.find((row) => {
+  const pendingRows = all.filter((row) => {
     try {
       return JSON.parse(row.metadata!).type === 'pending'
     } catch {
       return false
     }
-  }) ?? null
-  if (!pending) return null
+  })
+  if (pendingRows.length === 0) return null
 
   // Optimistic lock: only hide if still visible
-  const result = db
-    .update(issueLogs)
-    .set({ visible: 0 })
-    .where(and(eq(issueLogs.id, pending.id), eq(issueLogs.visible, 1)))
-    .run()
+  const relocated: typeof pendingRows = []
+  for (const row of pendingRows) {
+    const result = db
+      .update(issueLogs)
+      .set({ visible: 0 })
+      .where(and(eq(issueLogs.id, row.id), eq(issueLogs.visible, 1)))
+      .run()
+    if (result.changes > 0) relocated.push(row)
+  }
+  if (relocated.length === 0) return null
 
-  // Check affected rows — if 0, user already recalled this pending
-  if (result.changes === 0) return null
+  // Build merged prompt from all relocated messages with attachment context
+  const logIds = relocated.map(r => r.id)
+  const attachmentCtx = await getAttachmentContextForLogIds(logIds)
 
-  let meta: Record<string, unknown> = {}
-  try {
-    meta = pending.metadata ? JSON.parse(pending.metadata) : {}
-  } catch {
-    // ignore
+  const prompts: string[] = []
+  const displayParts: string[] = []
+  for (const row of relocated) {
+    let meta: Record<string, unknown> = {}
+    try {
+      meta = row.metadata ? JSON.parse(row.metadata) : {}
+    } catch { /* ignore */ }
+    const fileCtx = attachmentCtx.get(row.id) ?? ''
+    prompts.push((row.content + fileCtx).trim())
+    displayParts.push((meta.displayPrompt as string | undefined) ?? row.content)
   }
 
-  // Build full prompt with attachment context
-  const attachmentCtx = await getAttachmentContextForLogIds([pending.id])
-  const fileCtx = attachmentCtx.get(pending.id) ?? ''
-  const prompt = (pending.content + fileCtx).trim()
-
-  const { type: _type, ...restMeta } = meta
+  // Merge metadata from all messages: collect attachments from every row,
+  // use last-wins for scalar fields (model, permissionMode, etc.)
+  const allAttachments: unknown[] = []
+  let mergedMeta: Record<string, unknown> = {}
+  for (const row of relocated) {
+    let meta: Record<string, unknown> = {}
+    try {
+      meta = row.metadata ? JSON.parse(row.metadata) : {}
+    } catch { /* ignore */ }
+    const { type: _type, attachments: rowAttachments, ...rest } = meta
+    Object.assign(mergedMeta, rest)
+    if (Array.isArray(rowAttachments)) {
+      allAttachments.push(...rowAttachments)
+    }
+  }
+  if (allAttachments.length > 0) {
+    mergedMeta.attachments = allAttachments
+  }
 
   return {
-    oldId: pending.id,
-    prompt,
-    displayPrompt: (meta.displayPrompt as string | undefined) ?? pending.content,
-    metadata: restMeta,
+    oldIds: logIds,
+    prompt: prompts.join('\n\n'),
+    displayPrompt: displayParts.join('\n\n') || undefined,
+    metadata: mergedMeta,
   }
 }
 
@@ -233,11 +256,20 @@ export async function relocatePendingForProcessing(issueId: string): Promise<{
  * Restore a relocated pending message back to visible if dispatch failed.
  * Prevents losing user input when the engine call fails after relocation.
  */
-export function restorePendingVisibility(pendingId: string): void {
-  db.update(issueLogs)
-    .set({ visible: 1 })
-    .where(and(eq(issueLogs.id, pendingId), eq(issueLogs.visible, 0)))
-    .run()
+export function restorePendingVisibility(pendingIds: string | string[]): void {
+  const ids = Array.isArray(pendingIds) ? pendingIds : [pendingIds]
+  if (ids.length === 0) return
+  if (ids.length === 1) {
+    db.update(issueLogs)
+      .set({ visible: 1 })
+      .where(and(eq(issueLogs.id, ids[0]), eq(issueLogs.visible, 0)))
+      .run()
+  } else {
+    db.update(issueLogs)
+      .set({ visible: 1 })
+      .where(and(inArray(issueLogs.id, ids), eq(issueLogs.visible, 0)))
+      .run()
+  }
 }
 
 /**

--- a/apps/api/src/db/pending-messages.ts
+++ b/apps/api/src/db/pending-messages.ts
@@ -173,13 +173,13 @@ export async function deletePendingMessage(issueId: string, messageId: string): 
 }
 
 /**
- * Relocate one queued message for AI processing:
- * 1. Atomically mark pending as visible=0 (optimistic lock)
- * 2. Return the content + metadata for caller to create a new entry at current position
+ * Relocate all queued pending messages for AI processing:
+ * 1. Atomically mark all pending rows as visible=0 inside a transaction
+ * 2. Return the merged content + metadata for caller to create a single entry
  *
  * Returns null if no pending found or already consumed (race with user edit).
  * Caller should use persistUserMessage() to create the new entry, then emit
- * log-removed SSE for the old messageId.
+ * log-removed SSE for the old messageIds.
  */
 export async function relocatePendingForProcessing(issueId: string): Promise<{
   oldIds: string[]
@@ -197,16 +197,20 @@ export async function relocatePendingForProcessing(issueId: string): Promise<{
   })
   if (pendingRows.length === 0) return null
 
-  // Optimistic lock: only hide if still visible
-  const relocated: typeof pendingRows = []
-  for (const row of pendingRows) {
-    const result = db
-      .update(issueLogs)
-      .set({ visible: 0 })
-      .where(and(eq(issueLogs.id, row.id), eq(issueLogs.visible, 1)))
-      .run()
-    if (result.changes > 0) relocated.push(row)
-  }
+  // Atomic relocation: hide all pending rows in a single transaction
+  // to prevent concurrent flushes from splitting the batch
+  const relocated = db.transaction(() => {
+    const claimed: typeof pendingRows = []
+    for (const row of pendingRows) {
+      const result = db
+        .update(issueLogs)
+        .set({ visible: 0 })
+        .where(and(eq(issueLogs.id, row.id), eq(issueLogs.visible, 1)))
+        .run()
+      if (result.changes > 0) claimed.push(row)
+    }
+    return claimed
+  })
   if (relocated.length === 0) return null
 
   // Build merged prompt from all relocated messages with attachment context
@@ -228,7 +232,7 @@ export async function relocatePendingForProcessing(issueId: string): Promise<{
   // Merge metadata from all messages: collect attachments from every row,
   // use last-wins for scalar fields (model, permissionMode, etc.)
   const allAttachments: unknown[] = []
-  let mergedMeta: Record<string, unknown> = {}
+  const mergedMeta: Record<string, unknown> = {}
   for (const row of relocated) {
     let meta: Record<string, unknown> = {}
     try {
@@ -247,7 +251,7 @@ export async function relocatePendingForProcessing(issueId: string): Promise<{
   return {
     oldIds: logIds,
     prompt: prompts.join('\n\n'),
-    displayPrompt: displayParts.join('\n\n') || undefined,
+    displayPrompt: displayParts.length > 0 ? displayParts.join('\n\n') : undefined,
     metadata: mergedMeta,
   }
 }

--- a/apps/api/src/engines/issue/lifecycle/turn-completion.ts
+++ b/apps/api/src/engines/issue/lifecycle/turn-completion.ts
@@ -93,7 +93,7 @@ export function handleTurnCompleted(
       const relocated = await relocatePendingForProcessing(issueId)
       if (relocated) {
         logger.info(
-          { issueId, executionId, oldPendingId: relocated.oldId },
+          { issueId, executionId, oldPendingIds: relocated.oldIds, mergedCount: relocated.oldIds.length },
           'auto_flush_pending_after_turn',
         )
         try {
@@ -107,13 +107,13 @@ export function handleTurnCompleted(
             relocated.displayPrompt,
             relocated.metadata,
           )
-          // Notify frontend to remove the old pending entry
-          emitIssueLogRemoved(issueId, [relocated.oldId])
+          // Notify frontend to remove the old pending entries
+          emitIssueLogRemoved(issueId, relocated.oldIds)
           logger.debug({ issueId, executionId }, 'turn_deferred_to_followup')
           return
         } catch (flushErr) {
           logger.error({ issueId, err: flushErr }, 'auto_flush_pending_failed')
-          restorePendingVisibility(relocated.oldId)
+          restorePendingVisibility(relocated.oldIds)
           // Fall through to normal review flow
         }
       }

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -180,12 +180,12 @@ export function flushPendingAsFollowUp(issueId: string, issue: { model: string |
         relocated.displayPrompt,
         relocated.metadata,
       )
-      // Notify frontend to remove old pending entry
-      emitIssueLogRemoved(issueId, [relocated.oldId])
-      logger.debug({ issueId, oldPendingId: relocated.oldId }, 'pending_flushed_as_followup')
+      // Notify frontend to remove old pending entries
+      emitIssueLogRemoved(issueId, relocated.oldIds)
+      logger.debug({ issueId, oldPendingIds: relocated.oldIds, mergedCount: relocated.oldIds.length }, 'pending_flushed_as_followup')
     } catch (err) {
       logger.error({ issueId, err }, 'pending_flush_followup_failed')
-      if (relocated) restorePendingVisibility(relocated.oldId)
+      if (relocated) restorePendingVisibility(relocated.oldIds)
     }
   })()
 }
@@ -294,12 +294,12 @@ export function triggerIssueExecution(
       })
       // Notify frontend to remove old pending entry after successful execution
       if (relocated) {
-        emitIssueLogRemoved(issueId, [relocated.oldId])
+        emitIssueLogRemoved(issueId, relocated.oldIds)
       }
       logger.debug({ issueId, hadPending: !!relocated }, 'auto_execute_started')
     } catch (err) {
       logger.error({ issueId, err }, 'auto_execute_failed')
-      if (relocated) restorePendingVisibility(relocated.oldId)
+      if (relocated) restorePendingVisibility(relocated.oldIds)
       issueEngine.setLastError(issueId, err instanceof Error ? err.message : 'auto_execute_failed')
       try {
         await db

--- a/apps/api/test/pending-messages-unit.test.ts
+++ b/apps/api/test/pending-messages-unit.test.ts
@@ -127,26 +127,54 @@ describe('pending message recall', () => {
 })
 
 describe('pending message dispatch', () => {
-  test('relocates one pending row at a time in chronological order', async () => {
+  test('relocates all pending rows at once and merges prompts', async () => {
     const issue = await createTestIssue()
 
     const firstId = await upsertPendingMessage(issue.id, 'first pending', { type: 'pending' })
     const secondId = await upsertPendingMessage(issue.id, 'second pending', { type: 'pending' })
 
-    const firstRelocated = await relocatePendingForProcessing(issue.id)
-    expect(firstRelocated?.oldId).toBe(firstId)
-    expect(firstRelocated?.prompt).toBe('first pending')
+    const relocated = await relocatePendingForProcessing(issue.id)
+    expect(relocated?.oldIds).toEqual([firstId, secondId])
+    expect(relocated?.prompt).toBe('first pending\n\nsecond pending')
+    expect(relocated?.displayPrompt).toBe('first pending\n\nsecond pending')
 
-    let pending = await getPendingMessages(issue.id)
-    expect(pending).toHaveLength(1)
-    expect(pending[0]?.id).toBe(secondId)
-
-    const secondRelocated = await relocatePendingForProcessing(issue.id)
-    expect(secondRelocated?.oldId).toBe(secondId)
-    expect(secondRelocated?.prompt).toBe('second pending')
-
-    pending = await getPendingMessages(issue.id)
+    const pending = await getPendingMessages(issue.id)
     expect(pending).toHaveLength(0)
+
+    // No more pending messages to relocate
+    const empty = await relocatePendingForProcessing(issue.id)
+    expect(empty).toBeNull()
+  })
+
+  test('merges attachments metadata from all pending messages', async () => {
+    const issue = await createTestIssue()
+
+    const att1 = { id: 'a1', name: 'file1.txt', mimeType: 'text/plain', size: 100 }
+    const att2 = { id: 'a2', name: 'file2.png', mimeType: 'image/png', size: 200 }
+
+    await upsertPendingMessage(issue.id, 'msg with file1', {
+      type: 'pending',
+      attachments: [att1],
+    })
+    await upsertPendingMessage(issue.id, 'msg with file2', {
+      type: 'pending',
+      attachments: [att2],
+    })
+
+    const relocated = await relocatePendingForProcessing(issue.id)
+    expect(relocated).not.toBeNull()
+    expect(relocated!.metadata.attachments).toEqual([att1, att2])
+    expect(relocated!.prompt).toBe('msg with file1\n\nmsg with file2')
+  })
+
+  test('merges metadata without attachments when none present', async () => {
+    const issue = await createTestIssue()
+
+    await upsertPendingMessage(issue.id, 'plain msg', { type: 'pending' })
+
+    const relocated = await relocatePendingForProcessing(issue.id)
+    expect(relocated).not.toBeNull()
+    expect(relocated!.metadata.attachments).toBeUndefined()
   })
 
   test('restorePendingVisibility makes a failed relocation retryable', async () => {
@@ -154,10 +182,10 @@ describe('pending message dispatch', () => {
     const pendingId = await upsertPendingMessage(issue.id, 'retry me', { type: 'pending' })
 
     const relocated = await relocatePendingForProcessing(issue.id)
-    expect(relocated?.oldId).toBe(pendingId)
+    expect(relocated?.oldIds).toEqual([pendingId])
     expect(await getPendingMessages(issue.id)).toHaveLength(0)
 
-    restorePendingVisibility(pendingId)
+    restorePendingVisibility(relocated!.oldIds)
 
     const pending = await getPendingMessages(issue.id)
     expect(pending).toHaveLength(1)


### PR DESCRIPTION
## Summary
- `relocatePendingForProcessing` now collects **all** pending messages at once instead of picking only the oldest one, merges their prompts with `\n\n` separators, and returns `oldIds: string[]` for batch cleanup
- `restorePendingVisibility` updated to accept `string | string[]` for batch restore on failure
- All callers (`turn-completion.ts`, `_shared.ts`) updated to use the new batch interface

## Test plan
- [x] Updated `pending-messages-unit.test.ts` to verify batch relocation and merged prompt output
- [x] All 9 tests pass
- [x] Lint clean