### PR TITLE
feat: add global environment variables for engine processes

### DIFF
--- a/apps/api/src/engines/safe-env.ts
+++ b/apps/api/src/engines/safe-env.ts
@@ -29,10 +29,6 @@ export function getCachedGlobalEnvVars(): Record<string, string> {
   return _globalEnvCache
 }
 
-export function invalidateGlobalEnvCache(): void {
-  _globalEnvCacheAt = 0
-}
-
 /**
  * Keys that user-provided envVars (from project settings) must never override.
  * These control security-critical paths and authentication credentials.

--- a/apps/api/src/engines/safe-env.ts
+++ b/apps/api/src/engines/safe-env.ts
@@ -3,6 +3,36 @@ import { logger } from '@/logger'
 
 import type { EngineType } from './types'
 
+// In-memory cache for global env vars — sync access for safeEnv(), async refresh.
+let _globalEnvCache: Record<string, string> = {}
+let _globalEnvCacheAt = 0
+const CACHE_TTL_MS = 30_000 // 30s
+
+/** Refresh global env vars cache from DB (call on startup + after settings change). */
+export async function refreshGlobalEnvCache(): Promise<void> {
+  try {
+    const { getAppSetting } = await import('@/db/helpers')
+    const raw = await getAppSetting('engine:globalEnvVars')
+    _globalEnvCache = raw ? JSON.parse(raw) as Record<string, string> : {}
+  } catch {
+    _globalEnvCache = {}
+  }
+  _globalEnvCacheAt = Date.now()
+}
+
+/** Get cached global env vars (sync). Returns empty object if cache cold. */
+export function getCachedGlobalEnvVars(): Record<string, string> {
+  // Trigger async refresh if stale (non-blocking)
+  if (Date.now() - _globalEnvCacheAt > CACHE_TTL_MS) {
+    void refreshGlobalEnvCache()
+  }
+  return _globalEnvCache
+}
+
+export function invalidateGlobalEnvCache(): void {
+  _globalEnvCacheAt = 0
+}
+
 /**
  * Keys that user-provided envVars (from project settings) must never override.
  * These control security-critical paths and authentication credentials.
@@ -75,13 +105,15 @@ const SAFE_ENV_KEYS = [
 
 /**
  * Build an env object containing only allowlisted vars from process.env,
- * merged with any extra vars from the caller.
+ * merged with global env vars (from app settings) and any extra vars from the caller.
  *
- * Protected keys (PATH, HOME, API keys, etc.) cannot be overridden by
- * user-supplied `extra` vars. When an `engineType` is provided, only the
- * relevant API key(s) for that engine are included.
+ * Priority (highest wins): project envVars (extra) > global envVars > process.env allowlist.
+ * Protected keys (PATH, HOME, API keys, etc.) cannot be overridden by user-supplied vars.
  */
-export function safeEnv(extra?: Record<string, string>, engineType?: EngineType): Record<string, string> {
+export function safeEnv(
+  extra?: Record<string, string>,
+  engineType?: EngineType,
+): Record<string, string> {
   // Determine which API keys to include based on engine type
   const allowedApiKeys = engineType
     ? new Set(ENGINE_API_KEYS[engineType] ?? [])
@@ -98,6 +130,19 @@ export function safeEnv(extra?: Record<string, string>, engineType?: EngineType)
     }
   }
 
+  // Merge global env vars (from app settings cache)
+  const globalVars = getCachedGlobalEnvVars()
+  if (globalVars) {
+    for (const [key, value] of Object.entries(globalVars)) {
+      if (PROTECTED_KEYS.has(key)) {
+        logger.warn({ key }, 'env_override_blocked: global envVar tried to override a protected key')
+        continue
+      }
+      env[key] = value
+    }
+  }
+
+  // Merge project-level env vars (highest priority)
   if (extra) {
     for (const [key, value] of Object.entries(extra)) {
       if (PROTECTED_KEYS.has(key)) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import {
   startupReconciliation,
   stopPeriodicReconciliation,
 } from './engines/reconciler'
+import { refreshGlobalEnvCache } from './engines/safe-env'
 import { startChangesSummaryWatcher, stopChangesSummaryWatcher } from './events/changes-summary'
 import { startCron } from './cron'
 import { logger } from './logger'
@@ -63,6 +64,11 @@ void migrateSlashCommandsKey()
   .catch((err) => {
     logger.error({ err }, 'slash_commands_cache_load_failed')
   })
+
+// Pre-warm global env vars cache from DB
+void refreshGlobalEnvCache().catch((err) => {
+  logger.error({ err }, 'global_env_cache_load_failed')
+})
 
 // Load max concurrent executions setting from DB
 void issueEngine.initMaxConcurrent().catch((err) => {

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -13,6 +13,7 @@ import {
   setServerUrl,
 } from '@/db/helpers'
 import { DEFAULT_LOG_PAGE_SIZE, LOG_PAGE_SIZE_KEY } from '@/engines/issue/constants'
+import { invalidateGlobalEnvCache } from '@/engines/safe-env'
 import { getCachedCategorizedCommands } from '@/engines/issue/queries'
 import type { WriteFilterRule } from '@/engines/write-filter'
 import { DEFAULT_FILTER_RULES, WRITE_FILTER_RULES_KEY } from '@/engines/write-filter'
@@ -321,6 +322,50 @@ general.patch(
         },
       },
     })
+  },
+)
+
+// --- Global Engine Environment Variables ---
+
+export const GLOBAL_ENV_VARS_KEY = 'engine:globalEnvVars'
+
+// GET /api/settings/global-env-vars
+general.get('/global-env-vars', async (c) => {
+  const raw = await getAppSetting(GLOBAL_ENV_VARS_KEY)
+  let vars: Record<string, string> = {}
+  if (raw) {
+    try {
+      vars = JSON.parse(raw) as Record<string, string>
+    } catch { /* ignore */ }
+  }
+  return c.json({ success: true, data: vars })
+})
+
+// PUT /api/settings/global-env-vars
+general.put(
+  '/global-env-vars',
+  zValidator(
+    'json',
+    z.object({
+      vars: z.record(z.string(), z.string()).refine(
+        obj => Object.keys(obj).length <= 50,
+        { message: 'Maximum 50 environment variables allowed' },
+      ),
+    }),
+    (result, c) => {
+      if (!result.success) {
+        return c.json(
+          { success: false, error: result.error.issues.map(i => i.message).join(', ') },
+          400,
+        )
+      }
+    },
+  ),
+  async (c) => {
+    const { vars } = c.req.valid('json')
+    await setAppSetting(GLOBAL_ENV_VARS_KEY, JSON.stringify(vars))
+    invalidateGlobalEnvCache()
+    return c.json({ success: true, data: vars })
   },
 )
 

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -13,7 +13,7 @@ import {
   setServerUrl,
 } from '@/db/helpers'
 import { DEFAULT_LOG_PAGE_SIZE, LOG_PAGE_SIZE_KEY } from '@/engines/issue/constants'
-import { invalidateGlobalEnvCache } from '@/engines/safe-env'
+import { refreshGlobalEnvCache } from '@/engines/safe-env'
 import { getCachedCategorizedCommands } from '@/engines/issue/queries'
 import type { WriteFilterRule } from '@/engines/write-filter'
 import { DEFAULT_FILTER_RULES, WRITE_FILTER_RULES_KEY } from '@/engines/write-filter'
@@ -364,7 +364,7 @@ general.put(
   async (c) => {
     const { vars } = c.req.valid('json')
     await setAppSetting(GLOBAL_ENV_VARS_KEY, JSON.stringify(vars))
-    invalidateGlobalEnvCache()
+    await refreshGlobalEnvCache()
     return c.json({ success: true, data: vars })
   },
 )

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -30,6 +30,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Field } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -51,6 +52,7 @@ import {
   useEngineAvailability,
   useEngineProfiles,
   useEngineSettings,
+  useGlobalEnvVars,
   useLogPageSize,
   useMaxConcurrentExecutions,
   useMcpSettings,
@@ -59,6 +61,7 @@ import {
   useRestoreDeletedIssue,
   useRunCleanup,
   useServerInfo,
+  useSetGlobalEnvVars,
   useSetLogPageSize,
   useSetMaxConcurrentExecutions,
   useSetUpgradeEnabled,
@@ -348,7 +351,84 @@ function GeneralSection({ open }: { open: boolean }) {
           {t('settings.maxConcurrentExecutionsHint')}
         </p>
       </Field>
+
+      <GlobalEnvVarsSection open={open} />
     </div>
+  )
+}
+
+function envVarsToText(vars: Record<string, string>): string {
+  return Object.entries(vars)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n')
+}
+
+function textToEnvVars(text: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx <= 0) continue
+    const key = trimmed.slice(0, eqIdx).trim()
+    const val = trimmed.slice(eqIdx + 1).trim()
+    if (key) result[key] = val
+  }
+  return result
+}
+
+function GlobalEnvVarsSection({ open }: { open: boolean }) {
+  const { t } = useTranslation()
+  const { data: envVars } = useGlobalEnvVars(open)
+  const setGlobalEnvVars = useSetGlobalEnvVars()
+  const [text, setText] = useState('')
+  const loaded = useRef(false)
+
+  useEffect(() => {
+    if (envVars && !loaded.current) {
+      setText(envVarsToText(envVars))
+      loaded.current = true
+    }
+  }, [envVars])
+
+  useEffect(() => {
+    if (!open) {
+      loaded.current = false
+    }
+  }, [open])
+
+  const isDirty = loaded.current && envVarsToText(envVars ?? {}) !== text
+
+  const handleSave = () => {
+    setGlobalEnvVars.mutate(textToEnvVars(text), {
+      onSuccess: (data) => {
+        setText(envVarsToText(data))
+      },
+    })
+  }
+
+  return (
+    <Field>
+      <Label>{t('settings.globalEnvVars')}</Label>
+      <Textarea
+        className="font-mono text-xs"
+        rows={5}
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder={t('settings.globalEnvVarsPlaceholder')}
+      />
+      <p className="text-[11px] text-muted-foreground">{t('settings.globalEnvVarsHint')}</p>
+      {isDirty && (
+        <div className="flex justify-end mt-1">
+          <Button size="sm" onClick={handleSave} disabled={setGlobalEnvVars.isPending}>
+            {setGlobalEnvVars.isPending
+              ? <Loader2 className="size-3 animate-spin mr-1" />
+              : <Check className="size-3 mr-1" />}
+            {t('common.save')}
+          </Button>
+        </div>
+      )}
+    </Field>
   )
 }
 

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -40,6 +40,7 @@ export const queryKeys = {
   systemInfo: () => ['settings', 'systemInfo'] as const,
   reviewIssues: () => ['issues', 'review'] as const,
   mcpSettings: () => ['settings', 'mcpSettings'] as const,
+  globalEnvVars: () => ['settings', 'globalEnvVars'] as const,
   webhooks: () => ['settings', 'webhooks'] as const,
   webhookDeliveries: (id: string) => ['settings', 'webhooks', id, 'deliveries'] as const,
   cronJobs: () => ['cron', 'jobs'] as const,
@@ -638,6 +639,27 @@ export function useUpdateMcpSettings() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.mcpSettings(),
       })
+    },
+  })
+}
+
+// --- Global Engine Environment Variables hooks ---
+
+export function useGlobalEnvVars(enabled = false) {
+  return useQuery({
+    queryKey: queryKeys.globalEnvVars(),
+    queryFn: () => kanbanApi.getGlobalEnvVars(),
+    enabled,
+    staleTime: STALE_TIME.CONFIG,
+  })
+}
+
+export function useSetGlobalEnvVars() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: Record<string, string>) => kanbanApi.setGlobalEnvVars(vars),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.globalEnvVars() })
     },
   })
 }

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -5,7 +5,8 @@
     "search": "Search...",
     "select": "Select",
     "edit": "Edit",
-    "copy": "Copy"
+    "copy": "Copy",
+    "save": "Save"
   },
   "project": {
     "projects": "Projects",
@@ -327,6 +328,9 @@
     "logPageSizeHint": "Number of conversation messages (user and assistant) to load per page",
     "maxConcurrentExecutions": "Max concurrent sessions",
     "maxConcurrentExecutionsHint": "Maximum number of AI agent sessions that can run simultaneously (1–50)",
+    "globalEnvVars": "Global environment variables",
+    "globalEnvVarsHint": "These variables are injected into all engine processes. One per line in KEY=VALUE format. Lines starting with # are ignored. Protected keys (PATH, HOME, API keys) cannot be overridden.",
+    "globalEnvVarsPlaceholder": "BKD_URL=https://example.com\nCUSTOM_VAR=value\n# Comments are ignored",
     "worktreeAutoCleanup": "Auto-cleanup worktrees",
     "worktreeAutoCleanupHint": "Automatically remove worktrees for issues that have been done for more than 1 day",
     "upgradeEnabled": "Auto-check updates",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -5,7 +5,8 @@
     "search": "搜索...",
     "select": "选择",
     "edit": "编辑",
-    "copy": "复制"
+    "copy": "复制",
+    "save": "保存"
   },
   "project": {
     "projects": "项目",
@@ -327,6 +328,9 @@
     "logPageSizeHint": "每次加载的对话消息数量（用户和助手消息）",
     "maxConcurrentExecutions": "最大并发会话数",
     "maxConcurrentExecutionsHint": "允许同时运行的 AI 代理会话最大数量（1–50）",
+    "globalEnvVars": "全局环境变量",
+    "globalEnvVarsHint": "这些变量会注入到所有引擎进程中。每行一个，格式为 KEY=VALUE。以 # 开头的行会被忽略。受保护的键（PATH、HOME、API 密钥）无法被覆盖。",
+    "globalEnvVarsPlaceholder": "BKD_URL=https://example.com\nCUSTOM_VAR=value\n# 注释会被忽略",
     "worktreeAutoCleanup": "自动清理工作区",
     "worktreeAutoCleanupHint": "自动清理已完成超过 1 天的工作区",
     "upgradeEnabled": "自动检查更新",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -157,6 +157,10 @@ function patch<T>(url: string, body: unknown) {
   return request<T>(url, { method: 'PATCH', body: JSON.stringify(body) })
 }
 
+function put<T>(url: string, body: unknown) {
+  return request<T>(url, { method: 'PUT', body: JSON.stringify(body) })
+}
+
 function del<T>(url: string) {
   return request<T>(url, { method: 'DELETE' })
 }
@@ -626,6 +630,11 @@ export const kanbanApi = {
   updateNote: (id: string, data: { title?: string, content?: string, isPinned?: boolean }) =>
     patch<Note>(`/api/notes/${id}`, data),
   deleteNote: (id: string) => del<{ id: string }>(`/api/notes/${id}`),
+
+  // Global Engine Environment Variables
+  getGlobalEnvVars: () => get<Record<string, string>>('/api/settings/global-env-vars'),
+  setGlobalEnvVars: (vars: Record<string, string>) =>
+    put<Record<string, string>>('/api/settings/global-env-vars', { vars }),
 
   // Cron
   getCronJobs: () => get<CronJob[]>('/api/cron'),


### PR DESCRIPTION
## Summary

- Add configurable global environment variables that are injected into all engine subprocesses
- Variables are stored in `appSettings` (key: `engine:globalEnvVars`) with in-memory cache (30s TTL)
- Priority order: project-level envVars > global envVars > process.env allowlist
- Protected keys (PATH, HOME, API keys) cannot be overridden by user-defined vars
- New API endpoints: `GET/PUT /api/settings/global-env-vars`
- New UI section in App Settings > General with KEY=VALUE textarea editor

## Test plan

- [ ] Open App Settings > General, verify "Global environment variables" section appears
- [ ] Add variables (e.g. `BKD_URL=https://example.com`), save, reload and verify persistence
- [ ] Run an engine task and verify global env vars are present in the subprocess environment
- [ ] Set a project-level env var with the same key — verify project-level takes priority
- [ ] Try overriding a protected key (e.g. `PATH=/bad`) — verify it is ignored
- [ ] Verify cache invalidation: save new vars, immediately run a task, confirm new values are used