### PR TITLE
feat: add AI interaction to whiteboard mindmap (Phase 2)

### DIFF
--- a/apps/api/src/openapi/routes.ts
+++ b/apps/api/src/openapi/routes.ts
@@ -42,6 +42,8 @@ import {
   UpdateWhiteboardNodeSchema,
   WebhookDeliverySchema,
   WebhookSchema,
+  WhiteboardAskResponseSchema,
+  WhiteboardAskSchema,
   WhiteboardNodeSchema,
   WorktreeEntrySchema,
   WriteFilterRuleSchema,
@@ -1110,6 +1112,20 @@ export const bulkUpdateWhiteboardNodes = createRoute({
   responses: {
     200: successResponse(z.array(WhiteboardNodeSchema), 'Updated nodes'),
     404: errorResponse('Project not found'),
+    500: errorResponse('Internal error'),
+  },
+})
+
+export const whiteboardAsk = createRoute({
+  method: 'post',
+  path: '/ask',
+  tags: ['Whiteboard'],
+  summary: 'Ask AI about a whiteboard node',
+  operationId: 'whiteboardAsk',
+  request: { body: { content: { 'application/json': { schema: WhiteboardAskSchema } } } },
+  responses: {
+    200: successResponse(WhiteboardAskResponseSchema, 'AI request submitted'),
+    404: errorResponse('Project or node not found'),
     500: errorResponse('Internal error'),
   },
 })

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -501,7 +501,7 @@ export const WhiteboardAskSchema = z.object({
   nodeId: z.string(),
   action: z.enum(['explore', 'explain', 'simplify', 'examples', 'custom']),
   prompt: z.string().max(32768).optional(),
-  engineType: z.string().optional(),
+  engineType: z.string().regex(/^(claude-code|codex|acp(:.+)?)$/).optional(),
   model: z.string().regex(/^[\w./:\-[\]]{1,160}$/).optional(),
 }).openapi('WhiteboardAsk')
 

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -496,3 +496,17 @@ export const BulkUpdateWhiteboardNodeSchema = z.object({
     sortOrder: z.string().max(50).optional(),
   })).min(1).max(500),
 }).openapi('BulkUpdateWhiteboardNode')
+
+export const WhiteboardAskSchema = z.object({
+  nodeId: z.string(),
+  action: z.enum(['explore', 'explain', 'simplify', 'examples', 'custom']),
+  prompt: z.string().max(32768).optional(),
+  engineType: z.string().optional(),
+  model: z.string().regex(/^[\w./:\-[\]]{1,160}$/).optional(),
+}).openapi('WhiteboardAsk')
+
+export const WhiteboardAskResponseSchema = z.object({
+  issueId: z.string(),
+  executionId: z.string().optional(),
+  queued: z.boolean().optional(),
+}).openapi('WhiteboardAskResponse')

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -326,6 +326,33 @@ message.post('/:id/follow-up', async (c) => {
   }
 })
 
+// GET /api/projects/:projectId/issues/:id/pending — List pending messages
+message.get('/:id/pending', async (c) => {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404)
+  }
+
+  const issueId = c.req.param('id')!
+  const issue = await getProjectOwnedIssue(project.id, issueId)
+  if (!issue) {
+    return c.json({ success: false, error: 'Issue not found' }, 404)
+  }
+
+  const { getPendingMessages } = await import('@/db/pending-messages')
+  const rows = await getPendingMessages(issueId)
+
+  const entries = rows.map(row => ({
+    messageId: row.id,
+    content: row.content,
+    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    createdAt: row.createdAt,
+  }))
+
+  return c.json({ success: true, data: entries })
+})
+
 // DELETE /api/projects/:projectId/issues/:id/pending?messageId=... — Recall pending message
 message.delete('/:id/pending', async (c) => {
   const projectId = c.req.param('projectId')!

--- a/apps/api/src/routes/whiteboard.ts
+++ b/apps/api/src/routes/whiteboard.ts
@@ -7,6 +7,7 @@ import { findProject, getAppSetting, getDefaultEngine, getEngineDefaultModel } f
 import { issues as issuesTable, whiteboardNodes } from '@/db/schema'
 import { issueEngine } from '@/engines/issue/engine'
 import type { EngineType } from '@/engines/types'
+import { parseProjectEnvVars } from '@/routes/issues/_shared'
 import { logger } from '@/logger'
 import { createOpenAPIRouter } from '@/openapi/hono'
 import * as R from '@/openapi/routes'
@@ -302,11 +303,18 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
       try {
         await mkdir(resolvedDir, { recursive: true })
         const s = await stat(resolvedDir)
-        if (s.isDirectory()) effectiveWorkingDir = resolvedDir
-      } catch {
-        logger.warn({ projectId: project.id, resolvedDir }, 'whiteboard_workdir_prepare_failed')
+        if (!s.isDirectory()) {
+          return c.json({ success: false, error: 'Project directory is not a valid directory' }, 500 as const)
+        }
+        effectiveWorkingDir = resolvedDir
+      } catch (dirErr) {
+        logger.warn({ projectId: project.id, resolvedDir, err: dirErr }, 'whiteboard_workdir_prepare_failed')
+        return c.json({ success: false, error: 'Failed to prepare project working directory' }, 500 as const)
       }
     }
+
+    const envVars = parseProjectEnvVars(project.envVars)
+    const displayPrompt = `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`
 
     if (!boundIssueId) {
       // Create a new whiteboard issue
@@ -343,34 +351,45 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
         .returning()
       boundIssueId = newIssue.id
 
-      // Execute the issue (first turn) — bind root node only after success
-      const result = await issueEngine.executeIssue(boundIssueId, {
-        engineType: resolvedEngine,
-        prompt: project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt,
-        workingDir: effectiveWorkingDir,
-        model: resolvedModel,
-        displayPrompt: `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,
-      })
+      // Execute the issue (first turn) — roll back issue on failure
+      try {
+        const result = await issueEngine.executeIssue(boundIssueId, {
+          engineType: resolvedEngine,
+          prompt: project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt,
+          workingDir: effectiveWorkingDir,
+          model: resolvedModel,
+          envVars,
+          displayPrompt,
+        })
 
-      // Bind to the root node after successful execution
-      const rootNode = allNodes.find(n => !n.parentId)
-      if (rootNode) {
-        await db.update(whiteboardNodes)
-          .set({ boundIssueId: newIssue.id, updatedAt: new Date() })
-          .where(eq(whiteboardNodes.id, rootNode.id))
+        // Bind to the root node after successful execution
+        const rootNode = allNodes.find(n => !n.parentId)
+        if (rootNode) {
+          await db.update(whiteboardNodes)
+            .set({ boundIssueId: newIssue.id, updatedAt: new Date() })
+            .where(eq(whiteboardNodes.id, rootNode.id))
+        }
+
+        return c.json({
+          success: true,
+          data: { issueId: boundIssueId, executionId: result.executionId },
+        }, 200 as const)
+      } catch (execErr) {
+        // Roll back orphan issue on first-turn failure
+        logger.error({ err: execErr, issueId: boundIssueId }, 'whiteboard_first_execute_failed')
+        await db.update(issuesTable)
+          .set({ isDeleted: 1, updatedAt: new Date() })
+          .where(eq(issuesTable.id, boundIssueId))
+        return c.json({ success: false, error: 'Failed to start whiteboard AI session' }, 500 as const)
       }
-
-      return c.json({
-        success: true,
-        data: { issueId: boundIssueId, executionId: result.executionId },
-      }, 200 as const)
     }
 
-    // Validate bound issue still exists (may have been soft-deleted from kanban)
+    // Validate bound issue still exists and has a usable session
     const [boundIssue] = await db
-      .select({ id: issuesTable.id })
+      .select({ id: issuesTable.id, sessionStatus: issuesTable.sessionStatus, externalSessionId: issuesTable.externalSessionId })
       .from(issuesTable)
       .where(and(eq(issuesTable.id, boundIssueId), eq(issuesTable.isDeleted, 0)))
+
     if (!boundIssue) {
       // Clear stale binding so next ask creates a fresh issue
       const rootNode = allNodes.find(n => !n.parentId)
@@ -382,6 +401,23 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
       return c.json({ success: false, error: 'Bound issue was deleted. Please try again.' }, 404 as const)
     }
 
+    // If the bound issue has no session (e.g. session ID was reset on failure),
+    // re-execute instead of following up on a broken session
+    if (!boundIssue.externalSessionId) {
+      const result = await issueEngine.executeIssue(boundIssueId, {
+        engineType: resolvedEngine,
+        prompt: project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt,
+        workingDir: effectiveWorkingDir,
+        model: resolvedModel,
+        envVars,
+        displayPrompt,
+      })
+      return c.json({
+        success: true,
+        data: { issueId: boundIssueId, executionId: result.executionId },
+      }, 200 as const)
+    }
+
     // Follow-up on existing bound issue — do not override the issue's model
     const result = await issueEngine.followUpIssue(
       boundIssueId,
@@ -389,7 +425,7 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
       undefined,
       undefined,
       'queue',
-      `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,
+      displayPrompt,
     )
 
     return c.json({

--- a/apps/api/src/routes/whiteboard.ts
+++ b/apps/api/src/routes/whiteboard.ts
@@ -242,8 +242,10 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
 
     const nodeMap = new Map(allNodes.map(n => [n.id, n]))
     const path: string[] = []
+    const visitedPath = new Set<string>()
     let current: typeof targetNode | undefined = targetNode
-    while (current) {
+    while (current && !visitedPath.has(current.id)) {
+      visitedPath.add(current.id)
       path.unshift(current.label || 'Untitled')
       current = current.parentId ? nodeMap.get(current.parentId) : undefined
     }
@@ -266,10 +268,13 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
 
     // Find or create the bound whiteboard issue
     let boundIssueId = targetNode.boundIssueId
-    // Walk up to root to find a bound issue
+    // Walk up to root to find a bound issue (with cycle guard)
     if (!boundIssueId) {
+      const visitedWalk = new Set<string>()
       let walk: typeof targetNode | undefined = targetNode
       while (walk && !boundIssueId) {
+        if (visitedWalk.has(walk.id)) break
+        visitedWalk.add(walk.id)
         boundIssueId = walk.boundIssueId
         walk = walk.parentId ? nodeMap.get(walk.parentId) : undefined
       }
@@ -359,6 +364,22 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
         success: true,
         data: { issueId: boundIssueId, executionId: result.executionId },
       }, 200 as const)
+    }
+
+    // Validate bound issue still exists (may have been soft-deleted from kanban)
+    const [boundIssue] = await db
+      .select({ id: issuesTable.id })
+      .from(issuesTable)
+      .where(and(eq(issuesTable.id, boundIssueId), eq(issuesTable.isDeleted, 0)))
+    if (!boundIssue) {
+      // Clear stale binding so next ask creates a fresh issue
+      const rootNode = allNodes.find(n => !n.parentId)
+      if (rootNode) {
+        await db.update(whiteboardNodes)
+          .set({ boundIssueId: null, updatedAt: new Date() })
+          .where(eq(whiteboardNodes.id, rootNode.id))
+      }
+      return c.json({ success: false, error: 'Bound issue was deleted. Please try again.' }, 404 as const)
     }
 
     // Follow-up on existing bound issue — do not override the issue's model

--- a/apps/api/src/routes/whiteboard.ts
+++ b/apps/api/src/routes/whiteboard.ts
@@ -1,7 +1,10 @@
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray, max } from 'drizzle-orm'
+import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { db } from '@/db'
-import { findProject } from '@/db/helpers'
+import { findProject, getDefaultEngine, getEngineDefaultModel } from '@/db/helpers'
 import { issues as issuesTable, whiteboardNodes } from '@/db/schema'
+import { issueEngine } from '@/engines/issue/engine'
+import type { EngineType } from '@/engines/types'
 import { logger } from '@/logger'
 import { createOpenAPIRouter } from '@/openapi/hono'
 import * as R from '@/openapi/routes'
@@ -206,6 +209,152 @@ whiteboardRoutes.openapi(R.bulkUpdateWhiteboardNodes, async (c) => {
   } catch (err) {
     logger.error({ err }, 'whiteboard_bulk_update_failed')
     return c.json({ success: false, error: 'Failed to bulk update whiteboard nodes' }, 500 as const)
+  }
+})
+
+// POST /ask — AI interaction via bound issue follow-up
+whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
+  try {
+    const projectId = c.req.param('projectId')
+    const project = await findProject(projectId)
+    if (!project) {
+      return c.json({ success: false, error: 'Project not found' }, 404 as const)
+    }
+
+    const body = c.req.valid('json')
+
+    // Find the target node
+    const [targetNode] = await db
+      .select()
+      .from(whiteboardNodes)
+      .where(and(eq(whiteboardNodes.id, body.nodeId), eq(whiteboardNodes.projectId, project.id), notDeleted))
+    if (!targetNode) {
+      return c.json({ success: false, error: 'Node not found' }, 404 as const)
+    }
+
+    // Build node path (root → target) for context
+    const allNodes = await db
+      .select()
+      .from(whiteboardNodes)
+      .where(and(eq(whiteboardNodes.projectId, project.id), notDeleted))
+
+    const nodeMap = new Map(allNodes.map(n => [n.id, n]))
+    const path: string[] = []
+    let current: typeof targetNode | undefined = targetNode
+    while (current) {
+      path.unshift(current.label || 'Untitled')
+      current = current.parentId ? nodeMap.get(current.parentId) : undefined
+    }
+
+    // Build action-specific prompt
+    const contextLines = [
+      `Project: ${project.name}`,
+      `Node path: ${path.join(' > ')}`,
+      targetNode.content ? `Node content:\n${targetNode.content}` : '',
+    ].filter(Boolean).join('\n')
+
+    const actionPrompts: Record<string, string> = {
+      explore: `${contextLines}\n\nGenerate 3-7 subtopics for this node. For each subtopic, output a markdown heading (##) followed by a brief description paragraph. Example:\n\n## Subtopic Title\nBrief description of the subtopic.`,
+      explain: `${contextLines}\n\nExplain this topic in detail. Provide a clear, structured explanation.`,
+      simplify: `${contextLines}\n\nSimplify and rewrite the content of this node to be more concise and easier to understand.`,
+      examples: `${contextLines}\n\nProvide 3-5 concrete examples related to this topic. For each example, output a markdown heading (##) followed by a description.`,
+      custom: `${contextLines}\n\n${body.prompt ?? ''}`,
+    }
+    const prompt = actionPrompts[body.action] ?? actionPrompts.custom
+
+    // Find or create the bound whiteboard issue
+    let boundIssueId = targetNode.boundIssueId
+    // Walk up to root to find a bound issue
+    if (!boundIssueId) {
+      let walk: typeof targetNode | undefined = targetNode
+      while (walk && !boundIssueId) {
+        boundIssueId = walk.boundIssueId
+        walk = walk.parentId ? nodeMap.get(walk.parentId) : undefined
+      }
+    }
+
+    const resolvedEngine = (body.engineType ?? await getDefaultEngine() ?? 'claude-code') as EngineType
+    let resolvedModel = body.model
+    if (!resolvedModel) {
+      const savedModel = await getEngineDefaultModel(resolvedEngine)
+      if (savedModel && savedModel !== 'auto') resolvedModel = savedModel
+    }
+
+    if (!boundIssueId) {
+      // Create a new whiteboard issue
+      const [maxNumRow] = await db
+        .select({ maxNum: max(issuesTable.issueNumber) })
+        .from(issuesTable)
+        .where(eq(issuesTable.projectId, project.id))
+      const issueNumber = (maxNumRow?.maxNum ?? 0) + 1
+      const [lastItem] = await db
+        .select({ sortOrder: issuesTable.sortOrder })
+        .from(issuesTable)
+        .where(and(
+          eq(issuesTable.projectId, project.id),
+          eq(issuesTable.statusId, 'working'),
+          eq(issuesTable.isDeleted, 0),
+        ))
+        .orderBy(desc(issuesTable.sortOrder))
+        .limit(1)
+      const sortOrder = generateKeyBetween(lastItem?.sortOrder ?? null, null)
+
+      const [newIssue] = await db
+        .insert(issuesTable)
+        .values({
+          projectId: project.id,
+          statusId: 'working',
+          issueNumber,
+          title: `[Whiteboard] ${project.name}`,
+          tag: JSON.stringify(['whiteboard']),
+          sortOrder,
+          engineType: resolvedEngine,
+          model: resolvedModel ?? null,
+          prompt,
+        })
+        .returning()
+      boundIssueId = newIssue.id
+
+      // Bind to the root node (first node with no parent)
+      const rootNode = allNodes.find(n => !n.parentId)
+      if (rootNode) {
+        await db.update(whiteboardNodes)
+          .set({ boundIssueId: newIssue.id, updatedAt: new Date() })
+          .where(eq(whiteboardNodes.id, rootNode.id))
+      }
+
+      // Execute the issue (first turn)
+      const result = await issueEngine.executeIssue(boundIssueId, {
+        engineType: resolvedEngine,
+        prompt: project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt,
+        workingDir: project.directory ?? undefined,
+        model: resolvedModel,
+        displayPrompt: `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,
+      })
+
+      return c.json({
+        success: true,
+        data: { issueId: boundIssueId, executionId: result.executionId },
+      }, 200 as const)
+    }
+
+    // Follow-up on existing bound issue
+    const result = await issueEngine.followUpIssue(
+      boundIssueId,
+      prompt,
+      resolvedModel,
+      undefined,
+      'queue',
+      `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,
+    )
+
+    return c.json({
+      success: true,
+      data: { issueId: boundIssueId, executionId: result.executionId, queued: false },
+    }, 200 as const)
+  } catch (err) {
+    logger.error({ err }, 'whiteboard_ask_failed')
+    return c.json({ success: false, error: 'Failed to process whiteboard AI request' }, 500 as const)
   }
 })
 

--- a/apps/api/src/routes/whiteboard.ts
+++ b/apps/api/src/routes/whiteboard.ts
@@ -1,7 +1,9 @@
+import { mkdir, stat } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import { and, desc, eq, inArray, max } from 'drizzle-orm'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { db } from '@/db'
-import { findProject, getDefaultEngine, getEngineDefaultModel } from '@/db/helpers'
+import { findProject, getAppSetting, getDefaultEngine, getEngineDefaultModel } from '@/db/helpers'
 import { issues as issuesTable, whiteboardNodes } from '@/db/schema'
 import { issueEngine } from '@/engines/issue/engine'
 import type { EngineType } from '@/engines/types'
@@ -280,6 +282,27 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
       if (savedModel && savedModel !== 'auto') resolvedModel = savedModel
     }
 
+    // SEC-016: Validate and resolve working directory
+    let effectiveWorkingDir: string | undefined
+    if (project.directory) {
+      const resolvedDir = resolve(project.directory)
+      const workspaceRoot = await getAppSetting('workspace:defaultPath')
+      if (workspaceRoot && workspaceRoot !== '/') {
+        const resolvedRoot = resolve(workspaceRoot)
+        if (!resolvedDir.startsWith(`${resolvedRoot}/`) && resolvedDir !== resolvedRoot) {
+          logger.warn({ projectId: project.id, resolvedDir, workspaceRoot: resolvedRoot }, 'whiteboard_workdir_outside_workspace')
+          return c.json({ success: false, error: 'Project directory is outside the configured workspace' }, 500 as const)
+        }
+      }
+      try {
+        await mkdir(resolvedDir, { recursive: true })
+        const s = await stat(resolvedDir)
+        if (s.isDirectory()) effectiveWorkingDir = resolvedDir
+      } catch {
+        logger.warn({ projectId: project.id, resolvedDir }, 'whiteboard_workdir_prepare_failed')
+      }
+    }
+
     if (!boundIssueId) {
       // Create a new whiteboard issue
       const [maxNumRow] = await db
@@ -315,7 +338,16 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
         .returning()
       boundIssueId = newIssue.id
 
-      // Bind to the root node (first node with no parent)
+      // Execute the issue (first turn) — bind root node only after success
+      const result = await issueEngine.executeIssue(boundIssueId, {
+        engineType: resolvedEngine,
+        prompt: project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt,
+        workingDir: effectiveWorkingDir,
+        model: resolvedModel,
+        displayPrompt: `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,
+      })
+
+      // Bind to the root node after successful execution
       const rootNode = allNodes.find(n => !n.parentId)
       if (rootNode) {
         await db.update(whiteboardNodes)
@@ -323,26 +355,17 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
           .where(eq(whiteboardNodes.id, rootNode.id))
       }
 
-      // Execute the issue (first turn)
-      const result = await issueEngine.executeIssue(boundIssueId, {
-        engineType: resolvedEngine,
-        prompt: project.systemPrompt ? `${project.systemPrompt}\n\n${prompt}` : prompt,
-        workingDir: project.directory ?? undefined,
-        model: resolvedModel,
-        displayPrompt: `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,
-      })
-
       return c.json({
         success: true,
         data: { issueId: boundIssueId, executionId: result.executionId },
       }, 200 as const)
     }
 
-    // Follow-up on existing bound issue
+    // Follow-up on existing bound issue — do not override the issue's model
     const result = await issueEngine.followUpIssue(
       boundIssueId,
       prompt,
-      resolvedModel,
+      undefined,
       undefined,
       'queue',
       `[Whiteboard] ${body.action}: ${targetNode.label || 'Untitled'}`,

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -291,7 +291,6 @@ export function ChatBody({
                 hasOlderLogs={hasOlderLogs}
                 isLoadingOlder={isLoadingOlder}
                 onLoadOlder={loadOlderLogs}
-                onEditPending={handleEditPending}
               />
             </Suspense>
           </div>

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -20,6 +20,7 @@ import {
   useSlashCommands,
   useUpdateIssue,
 } from '@/hooks/use-kanban'
+import { useInvalidatePendingMessages, usePendingMessages } from '@/hooks/use-pending-messages'
 import { kanbanApi } from '@/lib/kanban-api'
 import { STATUS_MAP } from '@/lib/statuses'
 import type { Issue, NormalizedLogEntry } from '@/types/kanban'
@@ -64,9 +65,7 @@ export function useSessionState(
   const hasSession = !!issue?.sessionStatus
   const isTodo = issue?.statusId === 'todo'
   const isDone = issue?.statusId === 'done'
-  // Enable stream for all issue states — pending messages can exist in any state
-  // and must be visible after page refresh
-  const streamEnabled = !!issue || hasSession
+  const streamEnabled = hasSession || isTodo || isDone
 
   const {
     logs,
@@ -185,15 +184,20 @@ export function ChatBody({
     appendServerMessage,
   } = useSessionState(projectId, issueId, issue)
 
+  // Always fetch pending messages independently of stream state
+  const { data: serverPendingMessages } = usePendingMessages(projectId, issueId)
+  const invalidatePending = useInvalidatePendingMessages()
+
   const handleEditPending = useCallback(async (messageId: string) => {
     try {
       const result = await kanbanApi.deletePendingMessage(projectId, issueId, messageId)
       setPendingEditContent(result.content)
       removeEntries([result.id])
+      invalidatePending(projectId, issueId)
     } catch {
       /* ignore — pending may have been consumed already */
     }
-  }, [projectId, issueId, removeEntries])
+  }, [projectId, issueId, removeEntries, invalidatePending])
 
   // Reset cancelling state when the session settles or a new turn starts.
   // Without the sessionStatus check, a follow-up that keeps isThinking=true
@@ -331,6 +335,27 @@ export function ChatBody({
         onDelete={handleDelete}
         isDeleting={deleteIssueMutation.isPending}
       />
+
+      {/* Pending messages — always visible regardless of stream state */}
+      {serverPendingMessages && serverPendingMessages.length > 0 && (
+        <div className="border-t border-border/30 px-4 py-2 space-y-1.5">
+          {serverPendingMessages.map(msg => (
+            <div key={msg.messageId} className="group relative flex items-start gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm">
+              <span className="shrink-0 text-xs text-muted-foreground/60">
+                {msg.metadata?.type === 'done' ? '📋' : '⏳'}
+              </span>
+              <span className="flex-1 line-clamp-2 text-muted-foreground">{msg.content}</span>
+              <button
+                type="button"
+                onClick={() => handleEditPending(msg.messageId)}
+                className="hidden shrink-0 rounded-md border border-border/40 bg-background/90 px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground group-hover:inline-flex"
+              >
+                {t('common.edit')}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Input */}
       <ChatInput

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -64,7 +64,9 @@ export function useSessionState(
   const hasSession = !!issue?.sessionStatus
   const isTodo = issue?.statusId === 'todo'
   const isDone = issue?.statusId === 'done'
-  const streamEnabled = hasSession || isTodo || isDone
+  // Enable stream for all issue states — pending messages can exist in any state
+  // and must be visible after page refresh
+  const streamEnabled = !!issue || hasSession
 
   const {
     logs,

--- a/apps/frontend/src/components/issue-detail/LogEntry.tsx
+++ b/apps/frontend/src/components/issue-detail/LogEntry.tsx
@@ -463,11 +463,13 @@ function AssistantMessage({
         <MarkdownContent content={content} className="text-[14px] leading-[1.75]" />
       </div>
       <Dialog open={viewOpen} onOpenChange={setViewOpen}>
-        <DialogContent className="w-[90vw] max-w-[90vw] sm:max-w-[90vw] max-h-[90vh] overflow-y-auto">
+        <DialogContent className="w-[90vw] max-w-[90vw] sm:max-w-[90vw] max-h-[90vh] flex flex-col">
           <DialogTitle className="sr-only">{t('session.viewMessage')}</DialogTitle>
-          <Suspense fallback={<div className="p-4 text-sm text-muted-foreground">Loading...</div>}>
-            <MarkdownRenderer content={content} />
-          </Suspense>
+          <div className="flex-1 overflow-y-auto min-h-0">
+            <Suspense fallback={<div className="p-4 text-sm text-muted-foreground">Loading...</div>}>
+              <MarkdownRenderer content={content} />
+            </Suspense>
+          </div>
         </DialogContent>
       </Dialog>
       <div className="flex items-center gap-2 mt-1">

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -1,4 +1,4 @@
-import type { ChatMessage, NormalizedLogEntry, TaskPlanChatMessage, UserChatMessage } from '@bkd/shared'
+import type { ChatMessage, NormalizedLogEntry, TaskPlanChatMessage } from '@bkd/shared'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { CheckCircle2, ChevronDown, Circle, ListTodo, Loader2 } from 'lucide-react'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
@@ -141,7 +141,6 @@ export function SessionMessages(props: {
   isRunning?: boolean
   workingStep?: string | null
   onCancel?: () => void
-  onEditPending?: (messageId: string) => void
   isCancelling?: boolean
   hasOlderLogs?: boolean
   isLoadingOlder?: boolean
@@ -165,7 +164,6 @@ function LegacySessionMessages({
   isRunning = false,
   workingStep,
   onCancel,
-  onEditPending,
   isCancelling = false,
   hasOlderLogs = false,
   isLoadingOlder = false,
@@ -176,7 +174,6 @@ function LegacySessionMessages({
   isRunning?: boolean
   workingStep?: string | null
   onCancel?: () => void
-  onEditPending?: (messageId: string) => void
   isCancelling?: boolean
   hasOlderLogs?: boolean
   isLoadingOlder?: boolean
@@ -283,10 +280,6 @@ function LegacySessionMessages({
         workingStep={workingStep}
         onCancel={onCancel}
       />
-      <PendingMessagesList
-        messages={pendingMessages}
-        onEditPending={onEditPending}
-      />
     </div>
   )
 }
@@ -387,35 +380,3 @@ function ThinkingIndicator({
 }
 
 // ── Pending messages ─────────────────────────────────────
-
-function PendingMessagesList({
-  messages,
-  onEditPending,
-}: {
-  messages: UserChatMessage[]
-  onEditPending?: (messageId: string) => void
-}) {
-  const { t } = useTranslation()
-  if (messages.length === 0) return null
-
-  return (
-    <div className="mt-1 border-t border-border/30 pt-2">
-      {messages.map(msg => (
-        <div key={msg.id} className="group relative">
-          <ChatMessageRow message={msg} />
-          {onEditPending && (msg.status === 'pending' || msg.status === 'done') ?
-              (
-                <button
-                  type="button"
-                  onClick={() => onEditPending(msg.entry.messageId ?? msg.id)}
-                  className="absolute right-2 top-2 hidden rounded-md border border-border/40 bg-background/90 px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground group-hover:inline-flex"
-                >
-                  {t('common.edit')}
-                </button>
-              ) :
-            null}
-        </div>
-      ))}
-    </div>
-  )
-}

--- a/apps/frontend/src/components/whiteboard/AskAIPopover.tsx
+++ b/apps/frontend/src/components/whiteboard/AskAIPopover.tsx
@@ -1,0 +1,109 @@
+import { BookOpen, Lightbulb, MessageSquare, Search, Sparkles, Zap } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
+type AskAction = 'explore' | 'explain' | 'simplify' | 'examples' | 'custom'
+
+interface AskAIPopoverProps {
+  nodeId: string
+  isLoading: boolean
+  onAsk: (nodeId: string, action: AskAction, prompt?: string) => void
+}
+
+export function AskAIPopover({ nodeId, isLoading, onAsk }: AskAIPopoverProps) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [customPrompt, setCustomPrompt] = useState('')
+
+  const handleAction = useCallback((action: AskAction) => {
+    onAsk(nodeId, action)
+    setOpen(false)
+  }, [nodeId, onAsk])
+
+  const handleCustomSubmit = useCallback(() => {
+    if (!customPrompt.trim()) return
+    onAsk(nodeId, 'custom', customPrompt.trim())
+    setCustomPrompt('')
+    setOpen(false)
+  }, [nodeId, customPrompt, onAsk])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleCustomSubmit()
+    }
+  }, [handleCustomSubmit])
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className="inline-flex h-6 w-6 items-center justify-center rounded-md text-primary hover:bg-accent hover:text-primary disabled:opacity-50"
+        disabled={isLoading}
+        title={t('whiteboard.askAI')}
+      >
+        {isLoading
+          ? <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          : <Sparkles className="h-3.5 w-3.5" />}
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-72 p-0"
+        side="right"
+        align="start"
+      >
+        <div className="p-3">
+          <p className="text-xs font-medium text-muted-foreground mb-2">
+            {t('whiteboard.quickActions')}
+          </p>
+          <div className="flex flex-col gap-1">
+            <button
+              type="button"
+              className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm hover:bg-accent text-left"
+              onClick={() => handleAction('explore')}
+            >
+              <Search className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              {t('whiteboard.actionExplore')}
+            </button>
+            <button
+              type="button"
+              className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm hover:bg-accent text-left"
+              onClick={() => handleAction('explain')}
+            >
+              <BookOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              {t('whiteboard.actionExplain')}
+            </button>
+            <button
+              type="button"
+              className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm hover:bg-accent text-left"
+              onClick={() => handleAction('simplify')}
+            >
+              <Zap className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              {t('whiteboard.actionSimplify')}
+            </button>
+            <button
+              type="button"
+              className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm hover:bg-accent text-left"
+              onClick={() => handleAction('examples')}
+            >
+              <Lightbulb className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              {t('whiteboard.actionExamples')}
+            </button>
+          </div>
+        </div>
+        <div className="border-t px-3 py-2.5">
+          <div className="flex items-center gap-2">
+            <MessageSquare className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <input
+              type="text"
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              placeholder={t('whiteboard.askPlaceholder')}
+              value={customPrompt}
+              onChange={e => setCustomPrompt(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/frontend/src/components/whiteboard/MindmapNode.tsx
+++ b/apps/frontend/src/components/whiteboard/MindmapNode.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { AskAIPopover } from './AskAIPopover'
 
 interface MindmapNodeData {
   id: string
@@ -13,6 +14,7 @@ interface MindmapNodeData {
   hasChildren: boolean
   isCollapsed: boolean
   parentId: string | null
+  askingNodeId: string | null
   [key: string]: unknown
 }
 
@@ -67,6 +69,12 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
       detail: { nodeId: data.id },
     }))
   }, [data.id])
+
+  const onAskAI = useCallback((nodeId: string, action: string, prompt?: string) => {
+    window.dispatchEvent(new CustomEvent('wb:ask-ai', {
+      detail: { nodeId, action, prompt },
+    }))
+  }, [])
 
   return (
     <div
@@ -127,6 +135,11 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
         >
           <Plus className="h-3.5 w-3.5" />
         </Button>
+        <AskAIPopover
+          nodeId={data.id}
+          isLoading={data.askingNodeId === data.id}
+          onAsk={onAskAI}
+        />
         {data.hasChildren && (
           <Button
             variant="ghost"

--- a/apps/frontend/src/components/whiteboard/MindmapNode.tsx
+++ b/apps/frontend/src/components/whiteboard/MindmapNode.tsx
@@ -80,7 +80,7 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
     <div
       className={cn(
         'rounded-lg border bg-card px-4 py-3 shadow-sm transition-shadow',
-        'min-w-[200px] max-w-[320px]',
+        'w-[280px]',
         selected && 'ring-2 ring-primary shadow-md',
       )}
     >

--- a/apps/frontend/src/components/whiteboard/MindmapNode.tsx
+++ b/apps/frontend/src/components/whiteboard/MindmapNode.tsx
@@ -80,7 +80,7 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
     <div
       className={cn(
         'rounded-lg border bg-card px-4 py-3 shadow-sm transition-shadow',
-        'w-[280px]',
+        'min-w-[200px] max-w-[320px]',
         selected && 'ring-2 ring-primary shadow-md',
       )}
     >

--- a/apps/frontend/src/components/whiteboard/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/components/whiteboard/WhiteboardCanvas.tsx
@@ -64,6 +64,7 @@ function LayoutedFlow({
   const { fitView } = useReactFlow()
   const layoutDoneRef = useRef(false)
   const dataKeyRef = useRef('')
+  const layoutVersionRef = useRef(0)
 
   // Listen for custom events from MindmapNode
   useEffect(() => {
@@ -97,7 +98,9 @@ function LayoutedFlow({
   }, [onAddChild, onUpdateNode, onDeleteNode, onToggleCollapse])
 
   // Phase 1: set initial nodes at origin for xyflow to measure
-  const dataKey = `${flatNodes.map(n => n.id).join(',')
+  // Key includes IDs, labels, content, parentIds, collapsed state, and askingNodeId
+  // so any topology or content change triggers a rebuild
+  const dataKey = `${flatNodes.map(n => `${n.id}:${n.parentId ?? ''}:${n.label}:${n.content}`).join(',')
   }|${[...collapsedIds].join(',')}`
   + `|${askingNodeId ?? ''}`
 
@@ -105,6 +108,7 @@ function LayoutedFlow({
     if (dataKey === dataKeyRef.current) return
     dataKeyRef.current = dataKey
     layoutDoneRef.current = false
+    layoutVersionRef.current += 1
     const { nodes: initialNodes, edges: initialEdges } = buildInitialNodes(
       flatNodes,
       collapsedIds,
@@ -118,8 +122,11 @@ function LayoutedFlow({
   useEffect(() => {
     if (!nodesInitialized || layoutDoneRef.current || nodes.length === 0) return
     layoutDoneRef.current = true
+    const version = layoutVersionRef.current
 
     computeLayout(nodes, edges).then((result) => {
+      // Ignore stale results if data changed while layout was computing
+      if (layoutVersionRef.current !== version) return
       setNodes(result.nodes)
       setEdges(result.edges)
       requestAnimationFrame(() => fitView({ padding: 0.3, duration: 200 }))

--- a/apps/frontend/src/components/whiteboard/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/components/whiteboard/WhiteboardCanvas.tsx
@@ -4,13 +4,16 @@ import {
   Controls,
   MiniMap,
   ReactFlow,
+  ReactFlowProvider,
   useEdgesState,
+  useNodesInitialized,
   useNodesState,
+  useReactFlow,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { computeLayout } from '@/lib/whiteboard-layout'
+import { buildInitialNodes, computeLayout } from '@/lib/whiteboard-layout'
 import type { WhiteboardNode } from '@/types/kanban'
 import { MindmapNode } from './MindmapNode'
 
@@ -28,7 +31,25 @@ interface WhiteboardCanvasProps {
   onToggleCollapse: (nodeId: string, isCollapsed: boolean) => void
 }
 
-export function WhiteboardCanvas({
+export function WhiteboardCanvas(props: WhiteboardCanvasProps) {
+  const { t } = useTranslation()
+
+  if (props.flatNodes.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        {t('whiteboard.empty')}
+      </div>
+    )
+  }
+
+  return (
+    <ReactFlowProvider>
+      <LayoutedFlow {...props} />
+    </ReactFlowProvider>
+  )
+}
+
+function LayoutedFlow({
   flatNodes,
   collapsedIds,
   askingNodeId,
@@ -37,9 +58,12 @@ export function WhiteboardCanvas({
   onDeleteNode,
   onToggleCollapse,
 }: WhiteboardCanvasProps) {
-  const { t } = useTranslation()
   const [nodes, setNodes, onNodesChange] = useNodesState<XYNode>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<XYEdge>([])
+  const nodesInitialized = useNodesInitialized()
+  const { fitView } = useReactFlow()
+  const layoutDoneRef = useRef(false)
+  const dataKeyRef = useRef('')
 
   // Listen for custom events from MindmapNode
   useEffect(() => {
@@ -72,19 +96,35 @@ export function WhiteboardCanvas({
     }
   }, [onAddChild, onUpdateNode, onDeleteNode, onToggleCollapse])
 
-  // Recompute layout when nodes or collapsed state changes
+  // Phase 1: set initial nodes at origin for xyflow to measure
+  const dataKey = `${flatNodes.map(n => n.id).join(',')
+  }|${[...collapsedIds].join(',')}`
+  + `|${askingNodeId ?? ''}`
+
   useEffect(() => {
-    let cancelled = false
-    computeLayout(flatNodes, collapsedIds, askingNodeId).then((result) => {
-      if (!cancelled) {
-        setNodes(result.nodes)
-        setEdges(result.edges)
-      }
+    if (dataKey === dataKeyRef.current) return
+    dataKeyRef.current = dataKey
+    layoutDoneRef.current = false
+    const { nodes: initialNodes, edges: initialEdges } = buildInitialNodes(
+      flatNodes,
+      collapsedIds,
+      askingNodeId,
+    )
+    setNodes(initialNodes)
+    setEdges(initialEdges)
+  }, [dataKey, flatNodes, collapsedIds, askingNodeId, setNodes, setEdges])
+
+  // Phase 2: after xyflow measures nodes, run elkjs with real dimensions
+  useEffect(() => {
+    if (!nodesInitialized || layoutDoneRef.current || nodes.length === 0) return
+    layoutDoneRef.current = true
+
+    computeLayout(nodes, edges).then((result) => {
+      setNodes(result.nodes)
+      setEdges(result.edges)
+      requestAnimationFrame(() => fitView({ padding: 0.3, duration: 200 }))
     })
-    return () => {
-      cancelled = true
-    }
-  }, [flatNodes, collapsedIds, askingNodeId, setNodes, setEdges])
+  }, [nodesInitialized, nodes, edges, setNodes, setEdges, fitView])
 
   const defaultEdgeOptions = useMemo(() => ({
     style: { stroke: 'hsl(var(--muted-foreground))', strokeWidth: 1.5 },
@@ -93,17 +133,8 @@ export function WhiteboardCanvas({
   const proOptions = useMemo(() => ({ hideAttribution: true }), [])
 
   const onNodeDoubleClick = useCallback((_event: React.MouseEvent, node: { id: string }) => {
-    // Focus the label input on double-click (handled by MindmapNode internally)
     void node
   }, [])
-
-  if (flatNodes.length === 0) {
-    return (
-      <div className="flex h-full items-center justify-center text-muted-foreground">
-        {t('whiteboard.empty')}
-      </div>
-    )
-  }
 
   return (
     <ReactFlow

--- a/apps/frontend/src/components/whiteboard/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/components/whiteboard/WhiteboardCanvas.tsx
@@ -21,6 +21,7 @@ const nodeTypes: NodeTypes = {
 interface WhiteboardCanvasProps {
   flatNodes: WhiteboardNode[]
   collapsedIds: Set<string>
+  askingNodeId: string | null
   onAddChild: (parentId: string) => void
   onUpdateNode: (nodeId: string, data: Record<string, unknown>) => void
   onDeleteNode: (nodeId: string) => void
@@ -30,6 +31,7 @@ interface WhiteboardCanvasProps {
 export function WhiteboardCanvas({
   flatNodes,
   collapsedIds,
+  askingNodeId,
   onAddChild,
   onUpdateNode,
   onDeleteNode,
@@ -73,7 +75,7 @@ export function WhiteboardCanvas({
   // Recompute layout when nodes or collapsed state changes
   useEffect(() => {
     let cancelled = false
-    computeLayout(flatNodes, collapsedIds).then((result) => {
+    computeLayout(flatNodes, collapsedIds, askingNodeId).then((result) => {
       if (!cancelled) {
         setNodes(result.nodes)
         setEdges(result.edges)
@@ -82,7 +84,7 @@ export function WhiteboardCanvas({
     return () => {
       cancelled = true
     }
-  }, [flatNodes, collapsedIds, setNodes, setEdges])
+  }, [flatNodes, collapsedIds, askingNodeId, setNodes, setEdges])
 
   const defaultEdgeOptions = useMemo(() => ({
     style: { stroke: 'hsl(var(--muted-foreground))', strokeWidth: 1.5 },

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -45,6 +45,8 @@ export const queryKeys = {
   webhookDeliveries: (id: string) => ['settings', 'webhooks', id, 'deliveries'] as const,
   cronJobs: () => ['cron', 'jobs'] as const,
   cronJobLogs: (jobId: string) => ['cron', 'jobs', jobId, 'logs'] as const,
+  pendingMessages: (projectId: string, issueId: string) =>
+    ['projects', projectId, 'issues', issueId, 'pending'] as const,
 }
 
 export function useProjects() {

--- a/apps/frontend/src/hooks/use-pending-messages.ts
+++ b/apps/frontend/src/hooks/use-pending-messages.ts
@@ -1,0 +1,18 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { kanbanApi } from '@/lib/kanban-api'
+import { queryKeys } from './use-kanban'
+
+export function usePendingMessages(projectId: string, issueId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.pendingMessages(projectId, issueId ?? ''),
+    queryFn: () => kanbanApi.getPendingMessages(projectId, issueId!),
+    enabled: !!projectId && !!issueId,
+    refetchInterval: 10_000,
+  })
+}
+
+export function useInvalidatePendingMessages() {
+  const qc = useQueryClient()
+  return (projectId: string, issueId: string) =>
+    qc.invalidateQueries({ queryKey: queryKeys.pendingMessages(projectId, issueId) })
+}

--- a/apps/frontend/src/hooks/use-pending-messages.ts
+++ b/apps/frontend/src/hooks/use-pending-messages.ts
@@ -1,13 +1,41 @@
+import { useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { kanbanApi } from '@/lib/kanban-api'
+import { eventBus } from '@/lib/event-bus'
 import { queryKeys } from './use-kanban'
 
 export function usePendingMessages(projectId: string, issueId: string | null) {
+  const qc = useQueryClient()
+
+  // Invalidate on SSE events that indicate pending messages may have been consumed
+  useEffect(() => {
+    if (!issueId) return
+
+    const unsub = eventBus.subscribe(issueId, {
+      onLog: () => {
+        // A new log entry (e.g. engine consumed pending → emitted user-message) — refresh
+        qc.invalidateQueries({ queryKey: queryKeys.pendingMessages(projectId, issueId) })
+      },
+      onLogUpdated: () => {},
+      onLogRemoved: () => {
+        // Pending message recalled/deleted
+        qc.invalidateQueries({ queryKey: queryKeys.pendingMessages(projectId, issueId) })
+      },
+      onState: () => {
+        // Session state changed (e.g. running → completed) — pending may have been consumed
+        qc.invalidateQueries({ queryKey: queryKeys.pendingMessages(projectId, issueId) })
+      },
+      onDone: () => {
+        qc.invalidateQueries({ queryKey: queryKeys.pendingMessages(projectId, issueId) })
+      },
+    })
+    return unsub
+  }, [projectId, issueId, qc])
+
   return useQuery({
     queryKey: queryKeys.pendingMessages(projectId, issueId ?? ''),
     queryFn: () => kanbanApi.getPendingMessages(projectId, issueId!),
     enabled: !!projectId && !!issueId,
-    refetchInterval: 10_000,
   })
 }
 

--- a/apps/frontend/src/hooks/use-whiteboard.ts
+++ b/apps/frontend/src/hooks/use-whiteboard.ts
@@ -112,3 +112,17 @@ export function useBulkUpdateWhiteboardNodes(projectId: string) {
     onSettled: () => qc.invalidateQueries({ queryKey: whiteboardKeys.all(projectId) }),
   })
 }
+
+export function useWhiteboardAsk(projectId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: {
+      nodeId: string
+      action: 'explore' | 'explain' | 'simplify' | 'examples' | 'custom'
+      prompt?: string
+      engineType?: string
+      model?: string
+    }) => kanbanApi.whiteboardAsk(projectId, data),
+    onSettled: () => qc.invalidateQueries({ queryKey: whiteboardKeys.all(projectId) }),
+  })
+}

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -565,7 +565,14 @@
     "expand": "Expand",
     "collapse": "Collapse",
     "untitled": "Untitled",
-    "backToBoard": "Back to board"
+    "backToBoard": "Back to board",
+    "askAI": "Ask AI",
+    "quickActions": "Quick actions",
+    "actionExplore": "Deep explore",
+    "actionExplain": "Explain",
+    "actionSimplify": "Simplify",
+    "actionExamples": "Examples",
+    "askPlaceholder": "Ask anything..."
   },
   "auth": {
     "login": "Login",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -565,7 +565,14 @@
     "expand": "展开",
     "collapse": "折叠",
     "untitled": "无标题",
-    "backToBoard": "返回看板"
+    "backToBoard": "返回看板",
+    "askAI": "询问 AI",
+    "quickActions": "快速操作",
+    "actionExplore": "深入探索",
+    "actionExplain": "解释",
+    "actionSimplify": "简化",
+    "actionExamples": "示例",
+    "askPlaceholder": "随便问点什么..."
   },
   "auth": {
     "login": "登录",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -665,6 +665,16 @@ export const kanbanApi = {
     parentId?: string | null
     sortOrder?: string
   }>) => patch<WhiteboardNode[]>(`/api/projects/${projectId}/whiteboard/nodes/bulk`, { nodes }),
+  whiteboardAsk: (projectId: string, data: {
+    nodeId: string
+    action: 'explore' | 'explain' | 'simplify' | 'examples' | 'custom'
+    prompt?: string
+    engineType?: string
+    model?: string
+  }) => post<{ issueId: string, executionId?: string, queued?: boolean }>(
+    `/api/projects/${projectId}/whiteboard/ask`,
+    data,
+  ),
 
   // Cron
   getCronJobs: () => get<CronJob[]>('/api/cron'),

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -356,6 +356,14 @@ export const kanbanApi = {
       `/api/projects/${projectId}/issues/${issueId}/pending?messageId=${encodeURIComponent(messageId)}`,
     ),
 
+  getPendingMessages: (projectId: string, issueId: string) =>
+    get<Array<{
+      messageId: string
+      content: string
+      metadata: { type: string } | null
+      createdAt: string
+    }>>(`/api/projects/${projectId}/issues/${issueId}/pending`),
+
   autoTitleIssue: async (projectId: string, issueId: string) => {
     const res = await fetch(`/api/projects/${projectId}/issues/${issueId}/auto-title`, {
       method: 'POST',

--- a/apps/frontend/src/lib/whiteboard-layout.ts
+++ b/apps/frontend/src/lib/whiteboard-layout.ts
@@ -15,6 +15,7 @@ interface LayoutResult {
 export async function computeLayout(
   flatNodes: WhiteboardNode[],
   collapsedIds: Set<string>,
+  askingNodeId?: string | null,
 ): Promise<LayoutResult> {
   if (flatNodes.length === 0) {
     return { nodes: [], edges: [] }
@@ -85,6 +86,7 @@ export async function computeLayout(
         ...original,
         hasChildren,
         isCollapsed: collapsedIds.has(elkNode.id),
+        askingNodeId: askingNodeId ?? null,
       },
     }
   })

--- a/apps/frontend/src/lib/whiteboard-layout.ts
+++ b/apps/frontend/src/lib/whiteboard-layout.ts
@@ -4,38 +4,113 @@ import type { WhiteboardNode } from '@/types/kanban'
 
 const elk = new ELK()
 
-const NODE_WIDTH = 280
-const NODE_HEIGHT = 120
+const DEFAULT_NODE_WIDTH = 280
+const DEFAULT_NODE_HEIGHT = 80
 
 interface LayoutResult {
   nodes: Node[]
   edges: Edge[]
 }
 
-export async function computeLayout(
+/**
+ * Build initial xyflow nodes/edges from flat data (no positions yet).
+ * xyflow will mount these to measure their real DOM dimensions.
+ */
+export function buildInitialNodes(
   flatNodes: WhiteboardNode[],
   collapsedIds: Set<string>,
   askingNodeId?: string | null,
-): Promise<LayoutResult> {
+): LayoutResult {
   if (flatNodes.length === 0) {
     return { nodes: [], edges: [] }
   }
 
-  // Build parent→children map
-  const childrenMap = new Map<string | null, WhiteboardNode[]>()
+  const childrenMap = buildChildrenMap(flatNodes)
+  const visibleNodes = collectVisibleNodes(childrenMap, collapsedIds)
+  const visibleIds = new Set(visibleNodes.map(n => n.id))
+
+  const xyNodes: Node[] = visibleNodes.map(n => ({
+    id: n.id,
+    type: 'mindmapNode',
+    position: { x: 0, y: 0 },
+    data: {
+      ...n,
+      hasChildren: (childrenMap.get(n.id)?.length ?? 0) > 0,
+      isCollapsed: collapsedIds.has(n.id),
+      askingNodeId: askingNodeId ?? null,
+    },
+  }))
+
+  const xyEdges = buildEdges(visibleNodes, visibleIds)
+
+  return { nodes: xyNodes, edges: xyEdges }
+}
+
+/**
+ * Run elkjs layout using measured node dimensions from xyflow DOM.
+ * Returns nodes with computed positions.
+ */
+export async function computeLayout(
+  currentNodes: Node[],
+  currentEdges: Edge[],
+): Promise<LayoutResult> {
+  if (currentNodes.length === 0) {
+    return { nodes: [], edges: [] }
+  }
+
+  const elkGraph = {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'mrtree',
+      'elk.direction': 'RIGHT',
+      'elk.spacing.nodeNode': '40',
+      'elk.layered.spacing.nodeNodeBetweenLayers': '60',
+    },
+    children: currentNodes.map(n => ({
+      id: n.id,
+      width: n.measured?.width ?? DEFAULT_NODE_WIDTH,
+      height: n.measured?.height ?? DEFAULT_NODE_HEIGHT,
+    })),
+    edges: currentEdges.map(e => ({
+      id: e.id,
+      sources: [e.source],
+      targets: [e.target],
+    })),
+  }
+
+  const layout = await elk.layout(elkGraph)
+
+  const positionMap = new Map<string, { x: number, y: number }>()
+  for (const child of layout.children ?? []) {
+    positionMap.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 })
+  }
+
+  const layoutedNodes: Node[] = currentNodes.map(n => ({
+    ...n,
+    position: positionMap.get(n.id) ?? n.position,
+  }))
+
+  return { nodes: layoutedNodes, edges: currentEdges }
+}
+
+function buildChildrenMap(flatNodes: WhiteboardNode[]) {
+  const map = new Map<string | null, WhiteboardNode[]>()
   for (const n of flatNodes) {
     const parentId = n.parentId ?? null
-    const list = childrenMap.get(parentId)
+    const list = map.get(parentId)
     if (list) list.push(n)
-    else childrenMap.set(parentId, [n])
+    else map.set(parentId, [n])
   }
-
-  // Sort children by sortOrder
-  for (const children of childrenMap.values()) {
+  for (const children of map.values()) {
     children.sort((a, b) => a.sortOrder.localeCompare(b.sortOrder))
   }
+  return map
+}
 
-  // Collect visible nodes (skip children of collapsed nodes)
+function collectVisibleNodes(
+  childrenMap: Map<string | null, WhiteboardNode[]>,
+  collapsedIds: Set<string>,
+) {
   const visibleNodes: WhiteboardNode[] = []
   const roots = childrenMap.get(null) ?? []
   const queue = [...roots]
@@ -47,53 +122,11 @@ export async function computeLayout(
       if (children) queue.push(...children)
     }
   }
+  return visibleNodes
+}
 
-  const visibleIds = new Set(visibleNodes.map(n => n.id))
-
-  // Build ELK graph
-  const elkGraph = {
-    id: 'root',
-    layoutOptions: {
-      'elk.algorithm': 'mrtree',
-      'elk.direction': 'RIGHT',
-      'elk.spacing.nodeNode': '40',
-      'elk.layered.spacing.nodeNodeBetweenLayers': '60',
-    },
-    children: visibleNodes.map(n => ({
-      id: n.id,
-      width: NODE_WIDTH,
-      height: NODE_HEIGHT,
-    })),
-    edges: visibleNodes
-      .filter(n => n.parentId && visibleIds.has(n.parentId))
-      .map(n => ({
-        id: `e-${n.parentId}-${n.id}`,
-        sources: [n.parentId!],
-        targets: [n.id],
-      })),
-  }
-
-  const layout = await elk.layout(elkGraph)
-
-  const xyNodes: Node[] = (layout.children ?? []).map((elkNode) => {
-    const original = flatNodes.find(n => n.id === elkNode.id)!
-    const hasChildren = (childrenMap.get(elkNode.id)?.length ?? 0) > 0
-    return {
-      id: elkNode.id,
-      type: 'mindmapNode',
-      position: { x: elkNode.x ?? 0, y: elkNode.y ?? 0 },
-      width: NODE_WIDTH,
-      height: NODE_HEIGHT,
-      data: {
-        ...original,
-        hasChildren,
-        isCollapsed: collapsedIds.has(elkNode.id),
-        askingNodeId: askingNodeId ?? null,
-      },
-    }
-  })
-
-  const xyEdges: Edge[] = visibleNodes
+function buildEdges(visibleNodes: WhiteboardNode[], visibleIds: Set<string>): Edge[] {
+  return visibleNodes
     .filter(n => n.parentId && visibleIds.has(n.parentId))
     .map(n => ({
       id: `e-${n.parentId}-${n.id}`,
@@ -102,8 +135,4 @@ export async function computeLayout(
       type: 'smoothstep',
       animated: false,
     }))
-
-  return { nodes: xyNodes, edges: xyEdges }
 }
-
-export { NODE_HEIGHT, NODE_WIDTH }

--- a/apps/frontend/src/lib/whiteboard-layout.ts
+++ b/apps/frontend/src/lib/whiteboard-layout.ts
@@ -82,6 +82,8 @@ export async function computeLayout(
       id: elkNode.id,
       type: 'mindmapNode',
       position: { x: elkNode.x ?? 0, y: elkNode.y ?? 0 },
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
       data: {
         ...original,
         hasChildren,

--- a/apps/frontend/src/pages/WhiteboardPage.tsx
+++ b/apps/frontend/src/pages/WhiteboardPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { WhiteboardCanvas } from '@/components/whiteboard/WhiteboardCanvas'
 import { WhiteboardHeader } from '@/components/whiteboard/WhiteboardHeader'
@@ -7,18 +7,23 @@ import {
   useCreateWhiteboardNode,
   useDeleteWhiteboardNode,
   useUpdateWhiteboardNode,
+  useWhiteboardAsk,
   useWhiteboardNodes,
 } from '@/hooks/use-whiteboard'
+import { eventBus } from '@/lib/event-bus'
 
 export default function WhiteboardPage() {
   const { projectId = '' } = useParams()
   const { data: project } = useProject(projectId)
-  const { data: nodes = [] } = useWhiteboardNodes(projectId)
+  const { data: nodes = [], refetch: refetchNodes } = useWhiteboardNodes(projectId)
   const createNode = useCreateWhiteboardNode(projectId)
   const updateNode = useUpdateWhiteboardNode(projectId)
   const deleteNode = useDeleteWhiteboardNode(projectId)
+  const askAI = useWhiteboardAsk(projectId)
 
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set())
+  const [askingNodeId, setAskingNodeId] = useState<string | null>(null)
+  const pendingIssueIdRef = useRef<string | null>(null)
 
   // Sync collapsed state from server data
   const collapsedKey = nodes.map(n => `${n.id}:${n.isCollapsed}`).join(',')
@@ -30,6 +35,27 @@ export default function WhiteboardPage() {
     setCollapsedIds(collapsed)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapsedKey])
+
+  // Subscribe to SSE for the bound whiteboard issue to detect AI completion
+  useEffect(() => {
+    const issueId = pendingIssueIdRef.current
+    if (!issueId) return
+
+    const unsub = eventBus.subscribe(issueId, {
+      onLog: () => {},
+      onLogUpdated: () => {},
+      onLogRemoved: () => {},
+      onState: () => {},
+      onDone: () => {
+        pendingIssueIdRef.current = null
+        setAskingNodeId(null)
+        // Refetch nodes after AI completes
+        const timer = setTimeout(refetchNodes, 1000)
+        return () => clearTimeout(timer)
+      },
+    })
+    return unsub
+  }, [askingNodeId, refetchNodes])
 
   const onCreateRoot = useCallback(() => {
     createNode.mutate({ label: project?.name ?? 'Root' })
@@ -57,6 +83,27 @@ export default function WhiteboardPage() {
     updateNode.mutate({ nodeId, isCollapsed })
   }, [updateNode])
 
+  // Handle wb:ask-ai custom event from MindmapNode
+  useEffect(() => {
+    function handleAskAI(e: Event) {
+      const { nodeId, action, prompt } = (e as CustomEvent).detail
+      setAskingNodeId(nodeId)
+      askAI.mutate(
+        { nodeId, action, prompt },
+        {
+          onSuccess: (data) => {
+            pendingIssueIdRef.current = data.issueId
+          },
+          onError: () => {
+            setAskingNodeId(null)
+          },
+        },
+      )
+    }
+    window.addEventListener('wb:ask-ai', handleAskAI)
+    return () => window.removeEventListener('wb:ask-ai', handleAskAI)
+  }, [askAI])
+
   return (
     <div className="flex h-dvh flex-col">
       <WhiteboardHeader
@@ -69,6 +116,7 @@ export default function WhiteboardPage() {
         <WhiteboardCanvas
           flatNodes={nodes}
           collapsedIds={collapsedIds}
+          askingNodeId={askingNodeId}
           onAddChild={onAddChild}
           onUpdateNode={onUpdateNode}
           onDeleteNode={onDeleteNode}

--- a/apps/frontend/src/pages/WhiteboardPage.tsx
+++ b/apps/frontend/src/pages/WhiteboardPage.tsx
@@ -38,8 +38,18 @@ export default function WhiteboardPage() {
 
   // Subscribe to SSE for the bound whiteboard issue to detect AI completion
   // Uses state (not ref) so changes trigger re-render and new subscription
+  // Includes a 5-minute fallback timeout in case the done event is missed
   useEffect(() => {
     if (!pendingIssueId) return
+
+    const clearLoading = () => {
+      setPendingIssueId(null)
+      setAskingNodeId(null)
+      setTimeout(refetchNodes, 1000)
+    }
+
+    // Fallback: clear loading after 5 min if done event is missed (SSE drop)
+    const fallbackTimer = setTimeout(clearLoading, 5 * 60 * 1000)
 
     const unsub = eventBus.subscribe(pendingIssueId, {
       onLog: () => {},
@@ -47,14 +57,14 @@ export default function WhiteboardPage() {
       onLogRemoved: () => {},
       onState: () => {},
       onDone: () => {
-        setPendingIssueId(null)
-        setAskingNodeId(null)
-        // Refetch nodes after AI completes
-        const timer = setTimeout(refetchNodes, 1000)
-        return () => clearTimeout(timer)
+        clearTimeout(fallbackTimer)
+        clearLoading()
       },
     })
-    return unsub
+    return () => {
+      clearTimeout(fallbackTimer)
+      unsub()
+    }
   }, [pendingIssueId, refetchNodes])
 
   const onCreateRoot = useCallback(() => {

--- a/apps/frontend/src/pages/WhiteboardPage.tsx
+++ b/apps/frontend/src/pages/WhiteboardPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { WhiteboardCanvas } from '@/components/whiteboard/WhiteboardCanvas'
 import { WhiteboardHeader } from '@/components/whiteboard/WhiteboardHeader'
@@ -23,7 +23,7 @@ export default function WhiteboardPage() {
 
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set())
   const [askingNodeId, setAskingNodeId] = useState<string | null>(null)
-  const pendingIssueIdRef = useRef<string | null>(null)
+  const [pendingIssueId, setPendingIssueId] = useState<string | null>(null)
 
   // Sync collapsed state from server data
   const collapsedKey = nodes.map(n => `${n.id}:${n.isCollapsed}`).join(',')
@@ -37,17 +37,17 @@ export default function WhiteboardPage() {
   }, [collapsedKey])
 
   // Subscribe to SSE for the bound whiteboard issue to detect AI completion
+  // Uses state (not ref) so changes trigger re-render and new subscription
   useEffect(() => {
-    const issueId = pendingIssueIdRef.current
-    if (!issueId) return
+    if (!pendingIssueId) return
 
-    const unsub = eventBus.subscribe(issueId, {
+    const unsub = eventBus.subscribe(pendingIssueId, {
       onLog: () => {},
       onLogUpdated: () => {},
       onLogRemoved: () => {},
       onState: () => {},
       onDone: () => {
-        pendingIssueIdRef.current = null
+        setPendingIssueId(null)
         setAskingNodeId(null)
         // Refetch nodes after AI completes
         const timer = setTimeout(refetchNodes, 1000)
@@ -55,7 +55,7 @@ export default function WhiteboardPage() {
       },
     })
     return unsub
-  }, [askingNodeId, refetchNodes])
+  }, [pendingIssueId, refetchNodes])
 
   const onCreateRoot = useCallback(() => {
     createNode.mutate({ label: project?.name ?? 'Root' })
@@ -92,7 +92,7 @@ export default function WhiteboardPage() {
         { nodeId, action, prompt },
         {
           onSuccess: (data) => {
-            pendingIssueIdRef.current = data.issueId
+            setPendingIssueId(data.issueId)
           },
           onError: () => {
             setAskingNodeId(null)


### PR DESCRIPTION
## Summary

- Add node-level AI conversation to the whiteboard via bound issue follow-up
- `POST /whiteboard/ask` API: auto-creates whiteboard issue, constructs context-enriched prompts, sends execute/follow-up
- AskAIPopover component with 4 quick actions (explore, explain, simplify, examples) + free-form input
- SSE subscription detects AI completion and refreshes nodes

### How it works
1. User clicks sparkle icon on any node → AskAIPopover opens
2. User selects action or types custom question
3. Backend creates/reuses a visible whiteboard issue (tag=`whiteboard`)
4. Prompt includes node path context (root → current) + node content + action
5. Engine processes the request (same flow as regular issue follow-up)
6. Frontend detects `done` SSE event → refreshes whiteboard nodes
7. User can view full AI conversation history in the whiteboard issue on kanban

## Test plan
- [x] Lint passes
- [x] Backend tests pass (492)
- [x] Frontend tests pass (49)
- [x] Frontend build succeeds
- [ ] Manual: click Ask AI on a node, select "Deep explore"
- [ ] Manual: verify whiteboard issue is created on kanban board
- [ ] Manual: verify loading spinner shows during AI processing
- [ ] Manual: type custom question in Ask AI input