### PR TITLE
feat: complete whiteboard Phase 3 — AI auto-parse, content editor, generate issues

### DIFF
--- a/apps/api/src/openapi/routes.ts
+++ b/apps/api/src/openapi/routes.ts
@@ -25,10 +25,13 @@ import {
   ExecuteIssueResponseSchema,
   ExecuteIssueSchema,
   FollowUpSchema,
+  GeneratedIssueItemSchema,
+  GenerateIssuesFromNodesSchema,
   IssueChangesResponseSchema,
   IssueLogsResponseSchema,
   IssueSchema,
   NoteSchema,
+  ParseWhiteboardResponseSchema,
   ProbeResultSchema,
   ProcessCapacitySchema,
   ProcessInfoSchema,
@@ -1126,6 +1129,34 @@ export const whiteboardAsk = createRoute({
   responses: {
     200: successResponse(WhiteboardAskResponseSchema, 'AI request submitted'),
     404: errorResponse('Project or node not found'),
+    500: errorResponse('Internal error'),
+  },
+})
+
+export const parseWhiteboardResponse = createRoute({
+  method: 'post',
+  path: '/parse-response',
+  tags: ['Whiteboard'],
+  summary: 'Parse latest AI assistant-message and create child nodes',
+  operationId: 'parseWhiteboardResponse',
+  request: { body: { content: { 'application/json': { schema: ParseWhiteboardResponseSchema } } } },
+  responses: {
+    200: successResponse(z.array(WhiteboardNodeSchema), 'Created child nodes'),
+    404: errorResponse('Project, node, or issue not found'),
+    500: errorResponse('Internal error'),
+  },
+})
+
+export const generateIssuesFromNodes = createRoute({
+  method: 'post',
+  path: '/generate-issues',
+  tags: ['Whiteboard'],
+  summary: 'Generate recommended issues from selected whiteboard nodes',
+  operationId: 'generateIssuesFromNodes',
+  request: { body: { content: { 'application/json': { schema: GenerateIssuesFromNodesSchema } } } },
+  responses: {
+    200: successResponse(z.array(GeneratedIssueItemSchema), 'Recommended issues'),
+    404: errorResponse('Project not found'),
     500: errorResponse('Internal error'),
   },
 })

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -510,3 +510,18 @@ export const WhiteboardAskResponseSchema = z.object({
   executionId: z.string().optional(),
   queued: z.boolean().optional(),
 }).openapi('WhiteboardAskResponse')
+
+export const ParseWhiteboardResponseSchema = z.object({
+  nodeId: z.string(),
+  issueId: z.string(),
+}).openapi('ParseWhiteboardResponse')
+
+export const GenerateIssuesFromNodesSchema = z.object({
+  nodeIds: z.array(z.string()).min(1).max(50),
+}).openapi('GenerateIssuesFromNodes')
+
+export const GeneratedIssueItemSchema = z.object({
+  nodeId: z.string(),
+  title: z.string(),
+  prompt: z.string(),
+}).openapi('GeneratedIssueItem')

--- a/apps/api/src/routes/whiteboard.ts
+++ b/apps/api/src/routes/whiteboard.ts
@@ -4,7 +4,7 @@ import { and, desc, eq, inArray, max } from 'drizzle-orm'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { db } from '@/db'
 import { findProject, getAppSetting, getDefaultEngine, getEngineDefaultModel } from '@/db/helpers'
-import { issues as issuesTable, whiteboardNodes } from '@/db/schema'
+import { issueLogs, issues as issuesTable, whiteboardNodes } from '@/db/schema'
 import { issueEngine } from '@/engines/issue/engine'
 import type { EngineType } from '@/engines/types'
 import { parseProjectEnvVars } from '@/routes/issues/_shared'
@@ -437,5 +437,214 @@ whiteboardRoutes.openapi(R.whiteboardAsk, async (c) => {
     return c.json({ success: false, error: 'Failed to process whiteboard AI request' }, 500 as const)
   }
 })
+
+// POST /parse-response — parse latest assistant-message and create child nodes
+whiteboardRoutes.openapi(R.parseWhiteboardResponse, async (c) => {
+  try {
+    const projectId = c.req.param('projectId')!
+    const project = await findProject(projectId)
+    if (!project) {
+      return c.json({ success: false, error: 'Project not found' }, 404 as const)
+    }
+
+    const { nodeId, issueId } = c.req.valid('json')
+
+    // Verify parent node belongs to this project
+    const [parentNode] = await db
+      .select()
+      .from(whiteboardNodes)
+      .where(and(
+        eq(whiteboardNodes.id, nodeId),
+        eq(whiteboardNodes.projectId, project.id),
+        notDeleted,
+      ))
+    if (!parentNode) {
+      return c.json({ success: false, error: 'Node not found' }, 404 as const)
+    }
+
+    // Verify the issue belongs to this project
+    const [issue] = await db
+      .select({ id: issuesTable.id })
+      .from(issuesTable)
+      .where(and(
+        eq(issuesTable.id, issueId),
+        eq(issuesTable.projectId, project.id),
+        eq(issuesTable.isDeleted, 0),
+      ))
+    if (!issue) {
+      return c.json({ success: false, error: 'Issue not found' }, 404 as const)
+    }
+
+    // Fetch the latest assistant-message for this issue
+    const [latestLog] = await db
+      .select({ content: issueLogs.content })
+      .from(issueLogs)
+      .where(and(
+        eq(issueLogs.issueId, issueId),
+        eq(issueLogs.entryType, 'assistant-message'),
+      ))
+      .orderBy(desc(issueLogs.createdAt))
+      .limit(1)
+
+    if (!latestLog) {
+      return c.json({ success: false, error: 'No assistant message found for this issue' }, 404 as const)
+    }
+
+    // Parse markdown ## headings into sections
+    const sections = parseMarkdownSections(latestLog.content)
+    if (sections.length === 0) {
+      return c.json({ success: true, data: [] }, 200 as const)
+    }
+
+    // Determine sort orders for new children (append after existing children)
+    const existingChildren = await db
+      .select({ sortOrder: whiteboardNodes.sortOrder })
+      .from(whiteboardNodes)
+      .where(and(
+        eq(whiteboardNodes.parentId, nodeId),
+        notDeleted,
+      ))
+      .orderBy(desc(whiteboardNodes.sortOrder))
+      .limit(1)
+
+    let lastSortOrder = existingChildren[0]?.sortOrder ?? null
+
+    // Insert children in order
+    const created: (typeof whiteboardNodes.$inferSelect)[] = []
+    for (const section of sections) {
+      const sortOrder = generateKeyBetween(lastSortOrder, null)
+      lastSortOrder = sortOrder
+      const [row] = await db
+        .insert(whiteboardNodes)
+        .values({
+          projectId: project.id,
+          parentId: nodeId,
+          label: section.heading,
+          content: section.body,
+          sortOrder,
+        })
+        .returning()
+      if (row) created.push(row)
+    }
+
+    return c.json({ success: true, data: created.map(deserializeRow) }, 200 as const)
+  } catch (err) {
+    logger.error({ err }, 'whiteboard_parse_response_failed')
+    return c.json({ success: false, error: 'Failed to parse whiteboard response' }, 500 as const)
+  }
+})
+
+// POST /generate-issues — recommend issues from selected nodes
+whiteboardRoutes.openapi(R.generateIssuesFromNodes, async (c) => {
+  try {
+    const projectId = c.req.param('projectId')!
+    const project = await findProject(projectId)
+    if (!project) {
+      return c.json({ success: false, error: 'Project not found' }, 404 as const)
+    }
+
+    const { nodeIds } = c.req.valid('json')
+
+    // Fetch all project nodes to resolve descendants
+    const allNodes = await db
+      .select()
+      .from(whiteboardNodes)
+      .where(and(eq(whiteboardNodes.projectId, project.id), notDeleted))
+
+    const nodeMap = new Map(allNodes.map(n => [n.id, n]))
+
+    // Build children map
+    const childrenMap = new Map<string, string[]>()
+    for (const n of allNodes) {
+      if (n.parentId) {
+        const list = childrenMap.get(n.parentId)
+        if (list) list.push(n.id)
+        else childrenMap.set(n.parentId, [n.id])
+      }
+    }
+
+    // For each requested nodeId, collect itself + all descendants
+    const recommendations: Array<{ nodeId: string, title: string, prompt: string }> = []
+
+    for (const nodeId of nodeIds) {
+      const node = nodeMap.get(nodeId)
+      if (!node) continue
+
+      // Collect descendant labels for context
+      const descendants: string[] = []
+      const visited = new Set<string>()
+      const queue = [...(childrenMap.get(nodeId) ?? [])]
+      while (queue.length > 0) {
+        const cid = queue.pop()!
+        if (visited.has(cid)) continue
+        visited.add(cid)
+        const child = nodeMap.get(cid)
+        if (child) {
+          descendants.push(child.label || 'Untitled')
+          queue.push(...(childrenMap.get(cid) ?? []))
+        }
+      }
+
+      // Build ancestor path for context
+      const path: string[] = []
+      const visitedPath = new Set<string>()
+      let current: typeof node | undefined = node
+      while (current && !visitedPath.has(current.id)) {
+        visitedPath.add(current.id)
+        path.unshift(current.label || 'Untitled')
+        current = current.parentId ? nodeMap.get(current.parentId) : undefined
+      }
+
+      const title = node.label || 'Untitled'
+      const contextParts = [
+        `Topic: ${path.join(' > ')}`,
+        node.content ? `Context: ${node.content}` : '',
+        descendants.length > 0 ? `Related subtopics: ${descendants.slice(0, 10).join(', ')}` : '',
+      ].filter(Boolean)
+
+      const prompt = [
+        ...contextParts,
+        '',
+        `Implement: ${title}`,
+      ].join('\n')
+
+      recommendations.push({ nodeId, title, prompt })
+    }
+
+    return c.json({ success: true, data: recommendations }, 200 as const)
+  } catch (err) {
+    logger.error({ err }, 'whiteboard_generate_issues_failed')
+    return c.json({ success: false, error: 'Failed to generate issues' }, 500 as const)
+  }
+})
+
+/**
+ * Parse markdown text with ## headings into heading+body sections.
+ * Each `## Heading` line starts a new section; the body is the text
+ * between this heading and the next.
+ */
+function parseMarkdownSections(text: string): Array<{ heading: string, body: string }> {
+  const lines = text.split('\n')
+  const sections: Array<{ heading: string, body: string }> = []
+  let current: { heading: string, bodyLines: string[] } | null = null
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^## (\S.*)$/)
+    if (headingMatch) {
+      if (current) {
+        sections.push({ heading: current.heading, body: current.bodyLines.join('\n').trim() })
+      }
+      current = { heading: headingMatch[1].trim(), bodyLines: [] }
+    } else if (current) {
+      current.bodyLines.push(line)
+    }
+  }
+
+  if (current) {
+    sections.push({ heading: current.heading, body: current.bodyLines.join('\n').trim() })
+  }
+
+  return sections.filter(s => s.heading.length > 0)
+}
 
 export default whiteboardRoutes

--- a/apps/frontend/src/components/whiteboard/AskAIPopover.tsx
+++ b/apps/frontend/src/components/whiteboard/AskAIPopover.tsx
@@ -1,5 +1,5 @@
 import { BookOpen, Lightbulb, MessageSquare, Search, Sparkles, Zap } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
@@ -7,17 +7,63 @@ type AskAction = 'explore' | 'explain' | 'simplify' | 'examples' | 'custom'
 
 interface AskAIPopoverProps {
   nodeId: string
+  nodeLabel?: string
+  parentLabel?: string
+  childLabels?: string[]
   isLoading: boolean
   onAsk: (nodeId: string, action: AskAction, prompt?: string) => void
 }
 
-export function AskAIPopover({ nodeId, isLoading, onAsk }: AskAIPopoverProps) {
+/** Generate up to 3 heuristic follow-up questions from node context. */
+function buildSuggestedQuestions(
+  nodeLabel: string,
+  parentLabel: string | undefined,
+  childLabels: string[],
+): string[] {
+  const questions: string[] = []
+  const label = nodeLabel || 'this topic'
+
+  if (childLabels.length > 0) {
+    const first = childLabels[0]!
+    questions.push(`How does ${first} relate to ${label}?`)
+    if (childLabels.length > 1) {
+      const second = childLabels[1]!
+      questions.push(`What are the details of ${second}?`)
+    }
+  }
+  if (parentLabel) {
+    questions.push(`Can you expand on ${label} within the context of ${parentLabel}?`)
+  } else {
+    questions.push(`Can you expand on ${label}?`)
+  }
+
+  return questions.slice(0, 3)
+}
+
+export function AskAIPopover({
+  nodeId,
+  nodeLabel = '',
+  parentLabel,
+  childLabels = [],
+  isLoading,
+  onAsk,
+}: AskAIPopoverProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [customPrompt, setCustomPrompt] = useState('')
 
+  const suggestedQuestions = useMemo(
+    () => buildSuggestedQuestions(nodeLabel, parentLabel, childLabels),
+    [nodeLabel, parentLabel, childLabels],
+  )
+
   const handleAction = useCallback((action: AskAction) => {
     onAsk(nodeId, action)
+    setOpen(false)
+  }, [nodeId, onAsk])
+
+  const handleSuggestedQuestion = useCallback((question: string) => {
+    onAsk(nodeId, 'custom', question)
     setOpen(false)
   }, [nodeId, onAsk])
 
@@ -90,6 +136,27 @@ export function AskAIPopover({ nodeId, isLoading, onAsk }: AskAIPopoverProps) {
             </button>
           </div>
         </div>
+
+        {suggestedQuestions.length > 0 && (
+          <div className="border-t p-3">
+            <p className="text-xs font-medium text-muted-foreground mb-2">
+              {t('whiteboard.suggestedQuestions')}
+            </p>
+            <div className="flex flex-col gap-1">
+              {suggestedQuestions.map(q => (
+                <button
+                  key={q}
+                  type="button"
+                  className="rounded-md px-2.5 py-1.5 text-xs text-left hover:bg-accent text-muted-foreground hover:text-foreground leading-snug"
+                  onClick={() => handleSuggestedQuestion(q)}
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
         <div className="border-t px-3 py-2.5">
           <div className="flex items-center gap-2">
             <MessageSquare className="h-3.5 w-3.5 text-muted-foreground shrink-0" />

--- a/apps/frontend/src/components/whiteboard/GenerateIssuesDialog.tsx
+++ b/apps/frontend/src/components/whiteboard/GenerateIssuesDialog.tsx
@@ -1,0 +1,127 @@
+import { Loader2 } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useCreateIssue } from '@/hooks/use-kanban'
+
+interface GeneratedIssueItem {
+  nodeId: string
+  title: string
+  prompt: string
+}
+
+interface GenerateIssuesDialogProps {
+  projectId: string
+  items: GeneratedIssueItem[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated?: (count: number) => void
+}
+
+export function GenerateIssuesDialog({
+  projectId,
+  items,
+  open,
+  onOpenChange,
+  onCreated,
+}: GenerateIssuesDialogProps) {
+  const { t } = useTranslation()
+  const createIssue = useCreateIssue(projectId)
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(items.map(i => i.nodeId)))
+  const [creating, setCreating] = useState(false)
+
+  // Reset selection when items change
+  const itemKey = items.map(i => i.nodeId).join(',')
+  const [lastKey, setLastKey] = useState(itemKey)
+  if (itemKey !== lastKey) {
+    setLastKey(itemKey)
+    setSelected(new Set(items.map(i => i.nodeId)))
+  }
+
+  const toggleItem = useCallback((nodeId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(nodeId)) next.delete(nodeId)
+      else next.add(nodeId)
+      return next
+    })
+  }, [])
+
+  const handleCreate = useCallback(async () => {
+    const toCreate = items.filter(i => selected.has(i.nodeId))
+    if (toCreate.length === 0) return
+    setCreating(true)
+    try {
+      await Promise.all(
+        toCreate.map(item =>
+          createIssue.mutateAsync({
+            title: item.title,
+            statusId: 'todo',
+          }),
+        ),
+      )
+      onCreated?.(toCreate.length)
+      onOpenChange(false)
+    } finally {
+      setCreating(false)
+    }
+  }, [items, selected, createIssue, onCreated, onOpenChange])
+
+  const selectedCount = selected.size
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('whiteboard.generateIssuesTitle')}</DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm text-muted-foreground">
+          {t('whiteboard.generateIssuesDesc')}
+        </p>
+
+        <div className="mt-2 flex flex-col gap-2 max-h-80 overflow-y-auto pr-1">
+          {items.map(item => (
+            <label
+              key={item.nodeId}
+              className="flex items-start gap-3 rounded-md border p-3 cursor-pointer hover:bg-accent/50 transition-colors"
+            >
+              <input
+                type="checkbox"
+                className="mt-0.5 shrink-0"
+                checked={selected.has(item.nodeId)}
+                onChange={() => toggleItem(item.nodeId)}
+              />
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">{item.title}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">{item.prompt}</p>
+              </div>
+            </label>
+          ))}
+          {items.length === 0 && (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              {t('whiteboard.generateIssuesEmpty')}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleCreate} disabled={creating || selectedCount === 0}>
+            {creating && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            {t('whiteboard.createNIssues', { count: selectedCount })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/frontend/src/components/whiteboard/GenerateIssuesDialog.tsx
+++ b/apps/frontend/src/components/whiteboard/GenerateIssuesDialog.tsx
@@ -62,7 +62,7 @@ export function GenerateIssuesDialog({
       await Promise.all(
         toCreate.map(item =>
           createIssue.mutateAsync({
-            title: item.title,
+            title: item.prompt,
             statusId: 'todo',
           }),
         ),

--- a/apps/frontend/src/components/whiteboard/MindmapNode.tsx
+++ b/apps/frontend/src/components/whiteboard/MindmapNode.tsx
@@ -14,6 +14,8 @@ interface MindmapNodeData {
   hasChildren: boolean
   isCollapsed: boolean
   parentId: string | null
+  parentLabel: string | null
+  childLabels: string[]
   askingNodeId: string | null
   [key: string]: unknown
 }
@@ -27,6 +29,8 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState(false)
   const [editLabel, setEditLabel] = useState(data.label)
+  const [isEditingContent, setIsEditingContent] = useState(false)
+  const [editContent, setEditContent] = useState(data.content)
 
   const onLabelBlur = useCallback(() => {
     setIsEditing(false)
@@ -69,6 +73,22 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
       detail: { nodeId: data.id },
     }))
   }, [data.id])
+
+  const onContentBlur = useCallback(() => {
+    setIsEditingContent(false)
+    if (editContent !== data.content) {
+      window.dispatchEvent(new CustomEvent('wb:update-node', {
+        detail: { nodeId: data.id, content: editContent },
+      }))
+    }
+  }, [data.id, data.content, editContent])
+
+  const onContentKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setEditContent(data.content)
+      setIsEditingContent(false)
+    }
+  }, [data.content])
 
   const onAskAI = useCallback((nodeId: string, action: string, prompt?: string) => {
     window.dispatchEvent(new CustomEvent('wb:ask-ai', {
@@ -114,12 +134,29 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
             )}
       </div>
 
-      {/* Content preview */}
-      {data.content && (
-        <p className="mt-1.5 text-xs text-muted-foreground line-clamp-2">
-          {data.content}
-        </p>
-      )}
+      {/* Content area — click to edit */}
+      {isEditingContent
+        ? (
+            <textarea
+              className="mt-1.5 w-full resize-none bg-transparent text-xs text-muted-foreground outline-none border rounded px-1 py-0.5 min-h-[56px]"
+              value={editContent}
+              onChange={e => setEditContent(e.target.value)}
+              onBlur={onContentBlur}
+              onKeyDown={onContentKeyDown}
+              autoFocus
+            />
+          )
+        : (
+            <p
+              className="mt-1.5 text-xs text-muted-foreground line-clamp-3 cursor-text min-h-[1rem]"
+              onClick={() => {
+                setIsEditingContent(true); setEditContent(data.content)
+              }}
+              title={t('whiteboard.editContent')}
+            >
+              {data.content || <span className="opacity-40">{t('whiteboard.contentPlaceholder')}</span>}
+            </p>
+          )}
 
       {/* Toolbar */}
       <div
@@ -137,6 +174,9 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
         </Button>
         <AskAIPopover
           nodeId={data.id}
+          nodeLabel={data.label}
+          parentLabel={data.parentLabel ?? undefined}
+          childLabels={data.childLabels}
           isLoading={data.askingNodeId === data.id}
           onAsk={onAskAI}
         />

--- a/apps/frontend/src/components/whiteboard/MindmapNode.tsx
+++ b/apps/frontend/src/components/whiteboard/MindmapNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position } from '@xyflow/react'
-import { ChevronRight, Plus, Trash2 } from 'lucide-react'
+import { ChevronRight, ListTodo, Plus, Trash2 } from 'lucide-react'
 import { memo, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
@@ -95,6 +95,13 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
       detail: { nodeId, action, prompt },
     }))
   }, [])
+
+  const onGenerateIssues = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    window.dispatchEvent(new CustomEvent('wb:generate-issues', {
+      detail: { nodeIds: [data.id] },
+    }))
+  }, [data.id])
 
   return (
     <div
@@ -195,6 +202,15 @@ export const MindmapNode = memo(({ data, selected }: MindmapNodeProps) => {
             />
           </Button>
         )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onGenerateIssues}
+          title={t('whiteboard.generateIssues')}
+        >
+          <ListTodo className="h-3.5 w-3.5" />
+        </Button>
         {data.parentId !== null && (
           <Button
             variant="ghost"

--- a/apps/frontend/src/components/whiteboard/WhiteboardHeader.tsx
+++ b/apps/frontend/src/components/whiteboard/WhiteboardHeader.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft, Plus } from 'lucide-react'
+import { ArrowLeft, Plus, Sparkles } from 'lucide-react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
@@ -13,6 +14,21 @@ interface WhiteboardHeaderProps {
 export function WhiteboardHeader({ projectId, projectName, onCreateRoot, hasNodes }: WhiteboardHeaderProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const [topic, setTopic] = useState('')
+
+  const handleGenerate = useCallback(() => {
+    const trimmed = topic.trim()
+    if (!trimmed) return
+    window.dispatchEvent(new CustomEvent('wb:generate-tree', { detail: { topic: trimmed } }))
+    setTopic('')
+  }, [topic])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleGenerate()
+    }
+  }, [handleGenerate])
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-3 border-b px-4">
@@ -29,6 +45,26 @@ export function WhiteboardHeader({ projectId, projectName, onCreateRoot, hasNode
         <span className="text-sm font-medium truncate">{projectName}</span>
         <span className="text-xs text-muted-foreground">/</span>
         <span className="text-sm text-muted-foreground">{t('whiteboard.title')}</span>
+      </div>
+      <div className="mx-4 flex flex-1 max-w-sm items-center gap-2 rounded-md border bg-background px-3 py-1">
+        <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <input
+          type="text"
+          className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          placeholder={t('whiteboard.generatePlaceholder')}
+          value={topic}
+          onChange={e => setTopic(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        {topic.trim() && (
+          <button
+            type="button"
+            className="text-xs font-medium text-primary hover:underline"
+            onClick={handleGenerate}
+          >
+            {t('whiteboard.generate')}
+          </button>
+        )}
       </div>
       <div className="ml-auto flex items-center gap-2">
         {!hasNodes && (

--- a/apps/frontend/src/hooks/use-whiteboard.ts
+++ b/apps/frontend/src/hooks/use-whiteboard.ts
@@ -126,3 +126,19 @@ export function useWhiteboardAsk(projectId: string) {
     onSettled: () => qc.invalidateQueries({ queryKey: whiteboardKeys.all(projectId) }),
   })
 }
+
+export function useParseWhiteboardResponse(projectId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: { nodeId: string, issueId: string }) =>
+      kanbanApi.parseWhiteboardResponse(projectId, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: whiteboardKeys.all(projectId) }),
+  })
+}
+
+export function useGenerateIssuesFromNodes(projectId: string) {
+  return useMutation({
+    mutationFn: (data: { nodeIds: string[] }) =>
+      kanbanApi.generateIssuesFromNodes(projectId, data),
+  })
+}

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -572,7 +572,16 @@
     "actionExplain": "Explain",
     "actionSimplify": "Simplify",
     "actionExamples": "Examples",
-    "askPlaceholder": "Ask anything..."
+    "askPlaceholder": "Ask anything...",
+    "suggestedQuestions": "Suggested questions",
+    "editContent": "Click to edit content",
+    "contentPlaceholder": "Add notes...",
+    "generatePlaceholder": "Generate mindmap from topic...",
+    "generate": "Generate",
+    "generateIssuesTitle": "Create Issues from Nodes",
+    "generateIssuesDesc": "Select which nodes to convert into issues on the board.",
+    "generateIssuesEmpty": "No nodes selected.",
+    "createNIssues": "Create {{count}} issue(s)"
   },
   "auth": {
     "login": "Login",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -581,7 +581,8 @@
     "generateIssuesTitle": "Create Issues from Nodes",
     "generateIssuesDesc": "Select which nodes to convert into issues on the board.",
     "generateIssuesEmpty": "No nodes selected.",
-    "createNIssues": "Create {{count}} issue(s)"
+    "createNIssues": "Create {{count}} issue(s)",
+    "generateIssues": "Generate issues"
   },
   "auth": {
     "login": "Login",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -581,7 +581,8 @@
     "generateIssuesTitle": "从节点创建任务",
     "generateIssuesDesc": "选择要转换为看板任务的节点。",
     "generateIssuesEmpty": "未选择任何节点。",
-    "createNIssues": "创建 {{count}} 个任务"
+    "createNIssues": "创建 {{count}} 个任务",
+    "generateIssues": "生成任务"
   },
   "auth": {
     "login": "登录",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -572,7 +572,16 @@
     "actionExplain": "解释",
     "actionSimplify": "简化",
     "actionExamples": "示例",
-    "askPlaceholder": "随便问点什么..."
+    "askPlaceholder": "随便问点什么...",
+    "suggestedQuestions": "推荐问题",
+    "editContent": "点击编辑内容",
+    "contentPlaceholder": "添加备注...",
+    "generatePlaceholder": "从主题生成思维导图...",
+    "generate": "生成",
+    "generateIssuesTitle": "从节点创建任务",
+    "generateIssuesDesc": "选择要转换为看板任务的节点。",
+    "generateIssuesEmpty": "未选择任何节点。",
+    "createNIssues": "创建 {{count}} 个任务"
   },
   "auth": {
     "login": "登录",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -683,6 +683,13 @@ export const kanbanApi = {
     `/api/projects/${projectId}/whiteboard/ask`,
     data,
   ),
+  parseWhiteboardResponse: (projectId: string, data: { nodeId: string, issueId: string }) =>
+    post<WhiteboardNode[]>(`/api/projects/${projectId}/whiteboard/parse-response`, data),
+  generateIssuesFromNodes: (projectId: string, data: { nodeIds: string[] }) =>
+    post<Array<{ nodeId: string, title: string, prompt: string }>>(
+      `/api/projects/${projectId}/whiteboard/generate-issues`,
+      data,
+    ),
 
   // Cron
   getCronJobs: () => get<CronJob[]>('/api/cron'),

--- a/apps/frontend/src/lib/whiteboard-layout.ts
+++ b/apps/frontend/src/lib/whiteboard-layout.ts
@@ -26,20 +26,27 @@ export function buildInitialNodes(
   }
 
   const childrenMap = buildChildrenMap(flatNodes)
+  const nodeMap = new Map(flatNodes.map(n => [n.id, n]))
   const visibleNodes = collectVisibleNodes(childrenMap, collapsedIds)
   const visibleIds = new Set(visibleNodes.map(n => n.id))
 
-  const xyNodes: Node[] = visibleNodes.map(n => ({
-    id: n.id,
-    type: 'mindmapNode',
-    position: { x: 0, y: 0 },
-    data: {
-      ...n,
-      hasChildren: (childrenMap.get(n.id)?.length ?? 0) > 0,
-      isCollapsed: collapsedIds.has(n.id),
-      askingNodeId: askingNodeId ?? null,
-    },
-  }))
+  const xyNodes: Node[] = visibleNodes.map((n) => {
+    const children = childrenMap.get(n.id) ?? []
+    const parent = n.parentId ? nodeMap.get(n.parentId) : undefined
+    return {
+      id: n.id,
+      type: 'mindmapNode',
+      position: { x: 0, y: 0 },
+      data: {
+        ...n,
+        hasChildren: children.length > 0,
+        isCollapsed: collapsedIds.has(n.id),
+        askingNodeId: askingNodeId ?? null,
+        parentLabel: parent?.label ?? null,
+        childLabels: children.map(c => c.label).filter(Boolean),
+      },
+    }
+  })
 
   const xyEdges = buildEdges(visibleNodes, visibleIds)
 

--- a/apps/frontend/src/pages/WhiteboardPage.tsx
+++ b/apps/frontend/src/pages/WhiteboardPage.tsx
@@ -34,8 +34,8 @@ export default function WhiteboardPage() {
 
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set())
   const [askingNodeId, setAskingNodeId] = useState<string | null>(null)
-  // pendingParse tracks {issueId, nodeId} so we can call parse-response after AI done
-  const [pendingParse, setPendingParse] = useState<{ issueId: string, nodeId: string } | null>(null)
+  // pendingParses tracks nodeId per issueId so concurrent asks don't overwrite each other
+  const pendingParsesRef = useRef(new Map<string, string>())
   const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
   const [generatedItems, setGeneratedItems] = useState<GeneratedIssueItem[]>([])
   // Track selected node IDs for generate-issues (last node the user right-clicked via event)
@@ -52,18 +52,28 @@ export default function WhiteboardPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapsedKey])
 
-  // Subscribe to SSE for the bound whiteboard issue to detect AI completion,
-  // then auto-call parse-response to create child nodes.
-  // Includes a 5-minute fallback timeout in case the done event is missed.
+  // Subscribe to SSE for all pending whiteboard issue completions.
+  // When AI completes, auto-call parse-response to create child nodes.
   useEffect(() => {
-    if (!pendingParse) return
+    if (!askingNodeId) return
 
-    const { issueId, nodeId } = pendingParse
+    const parsesMap = pendingParsesRef.current
+    // Find the issueId that this node is waiting on
+    let activeIssueId: string | null = null
+    for (const [iid, nid] of parsesMap) {
+      if (nid === askingNodeId) {
+        activeIssueId = iid; break
+      }
+    }
+    if (!activeIssueId) return
+
+    const issueId = activeIssueId
 
     const clearLoading = (runParse = false) => {
-      setPendingParse(null)
+      const nodeId = parsesMap.get(issueId)
+      parsesMap.delete(issueId)
       setAskingNodeId(null)
-      if (runParse) {
+      if (runParse && nodeId) {
         parseResponse.mutate(
           { nodeId, issueId },
           { onSettled: () => setTimeout(refetchNodes, 500) },
@@ -73,7 +83,6 @@ export default function WhiteboardPage() {
       }
     }
 
-    // Fallback: clear loading after 5 min if done event is missed (SSE drop)
     const fallbackTimer = setTimeout(clearLoading, 5 * 60 * 1000, false)
 
     const unsub = eventBus.subscribe(issueId, {
@@ -92,7 +101,7 @@ export default function WhiteboardPage() {
     }
   // parseResponse intentionally excluded — stable mutation ref
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingParse, refetchNodes])
+  }, [askingNodeId, refetchNodes])
 
   const onCreateRoot = useCallback(() => {
     createNode.mutate({ label: project?.name ?? 'Root' })
@@ -129,12 +138,7 @@ export default function WhiteboardPage() {
         { nodeId, action, prompt },
         {
           onSuccess: (data) => {
-            // Only auto-parse for explore/examples actions that produce ## sections
-            if (action === 'explore' || action === 'examples') {
-              setPendingParse({ issueId: data.issueId, nodeId })
-            } else {
-              setPendingParse({ issueId: data.issueId, nodeId })
-            }
+            pendingParsesRef.current.set(data.issueId, nodeId)
           },
           onError: () => {
             setAskingNodeId(null)
@@ -158,7 +162,7 @@ export default function WhiteboardPage() {
           { nodeId: rootNode.id, action: 'custom', prompt: `Generate a comprehensive mindmap about: ${topic}. Use ## headings for each main subtopic, with a brief description paragraph under each.` },
           {
             onSuccess: (data) => {
-              setPendingParse({ issueId: data.issueId, nodeId: rootNode.id })
+              pendingParsesRef.current.set(data.issueId, rootNode.id)
             },
             onError: () => setAskingNodeId(null),
           },
@@ -174,7 +178,7 @@ export default function WhiteboardPage() {
                 { nodeId: newNode.id, action: 'custom', prompt: `Generate a comprehensive mindmap about: ${topic}. Use ## headings for each main subtopic, with a brief description paragraph under each.` },
                 {
                   onSuccess: (data) => {
-                    setPendingParse({ issueId: data.issueId, nodeId: newNode.id })
+                    pendingParsesRef.current.set(data.issueId, newNode.id)
                   },
                   onError: () => setAskingNodeId(null),
                 },

--- a/apps/frontend/src/pages/WhiteboardPage.tsx
+++ b/apps/frontend/src/pages/WhiteboardPage.tsx
@@ -1,16 +1,25 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { GenerateIssuesDialog } from '@/components/whiteboard/GenerateIssuesDialog'
 import { WhiteboardCanvas } from '@/components/whiteboard/WhiteboardCanvas'
 import { WhiteboardHeader } from '@/components/whiteboard/WhiteboardHeader'
 import { useProject } from '@/hooks/use-kanban'
 import {
   useCreateWhiteboardNode,
   useDeleteWhiteboardNode,
+  useGenerateIssuesFromNodes,
+  useParseWhiteboardResponse,
   useUpdateWhiteboardNode,
   useWhiteboardAsk,
   useWhiteboardNodes,
 } from '@/hooks/use-whiteboard'
 import { eventBus } from '@/lib/event-bus'
+
+interface GeneratedIssueItem {
+  nodeId: string
+  title: string
+  prompt: string
+}
 
 export default function WhiteboardPage() {
   const { projectId = '' } = useParams()
@@ -20,10 +29,17 @@ export default function WhiteboardPage() {
   const updateNode = useUpdateWhiteboardNode(projectId)
   const deleteNode = useDeleteWhiteboardNode(projectId)
   const askAI = useWhiteboardAsk(projectId)
+  const parseResponse = useParseWhiteboardResponse(projectId)
+  const generateIssues = useGenerateIssuesFromNodes(projectId)
 
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set())
   const [askingNodeId, setAskingNodeId] = useState<string | null>(null)
-  const [pendingIssueId, setPendingIssueId] = useState<string | null>(null)
+  // pendingParse tracks {issueId, nodeId} so we can call parse-response after AI done
+  const [pendingParse, setPendingParse] = useState<{ issueId: string, nodeId: string } | null>(null)
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
+  const [generatedItems, setGeneratedItems] = useState<GeneratedIssueItem[]>([])
+  // Track selected node IDs for generate-issues (last node the user right-clicked via event)
+  const pendingGenerateNodeIds = useRef<string[]>([])
 
   // Sync collapsed state from server data
   const collapsedKey = nodes.map(n => `${n.id}:${n.isCollapsed}`).join(',')
@@ -36,36 +52,47 @@ export default function WhiteboardPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapsedKey])
 
-  // Subscribe to SSE for the bound whiteboard issue to detect AI completion
-  // Uses state (not ref) so changes trigger re-render and new subscription
-  // Includes a 5-minute fallback timeout in case the done event is missed
+  // Subscribe to SSE for the bound whiteboard issue to detect AI completion,
+  // then auto-call parse-response to create child nodes.
+  // Includes a 5-minute fallback timeout in case the done event is missed.
   useEffect(() => {
-    if (!pendingIssueId) return
+    if (!pendingParse) return
 
-    const clearLoading = () => {
-      setPendingIssueId(null)
+    const { issueId, nodeId } = pendingParse
+
+    const clearLoading = (runParse = false) => {
+      setPendingParse(null)
       setAskingNodeId(null)
-      setTimeout(refetchNodes, 1000)
+      if (runParse) {
+        parseResponse.mutate(
+          { nodeId, issueId },
+          { onSettled: () => setTimeout(refetchNodes, 500) },
+        )
+      } else {
+        setTimeout(refetchNodes, 1000)
+      }
     }
 
     // Fallback: clear loading after 5 min if done event is missed (SSE drop)
-    const fallbackTimer = setTimeout(clearLoading, 5 * 60 * 1000)
+    const fallbackTimer = setTimeout(clearLoading, 5 * 60 * 1000, false)
 
-    const unsub = eventBus.subscribe(pendingIssueId, {
+    const unsub = eventBus.subscribe(issueId, {
       onLog: () => {},
       onLogUpdated: () => {},
       onLogRemoved: () => {},
       onState: () => {},
       onDone: () => {
         clearTimeout(fallbackTimer)
-        clearLoading()
+        clearLoading(true)
       },
     })
     return () => {
       clearTimeout(fallbackTimer)
       unsub()
     }
-  }, [pendingIssueId, refetchNodes])
+  // parseResponse intentionally excluded — stable mutation ref
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingParse, refetchNodes])
 
   const onCreateRoot = useCallback(() => {
     createNode.mutate({ label: project?.name ?? 'Root' })
@@ -102,7 +129,12 @@ export default function WhiteboardPage() {
         { nodeId, action, prompt },
         {
           onSuccess: (data) => {
-            setPendingIssueId(data.issueId)
+            // Only auto-parse for explore/examples actions that produce ## sections
+            if (action === 'explore' || action === 'examples') {
+              setPendingParse({ issueId: data.issueId, nodeId })
+            } else {
+              setPendingParse({ issueId: data.issueId, nodeId })
+            }
           },
           onError: () => {
             setAskingNodeId(null)
@@ -113,6 +145,67 @@ export default function WhiteboardPage() {
     window.addEventListener('wb:ask-ai', handleAskAI)
     return () => window.removeEventListener('wb:ask-ai', handleAskAI)
   }, [askAI])
+
+  // Handle wb:generate-tree event from WhiteboardHeader
+  useEffect(() => {
+    function handleGenerateTree(e: Event) {
+      const { topic } = (e as CustomEvent).detail as { topic: string }
+      // Find or use root node; if none, create root first then ask
+      const rootNode = nodes.find(n => !n.parentId)
+      if (rootNode) {
+        setAskingNodeId(rootNode.id)
+        askAI.mutate(
+          { nodeId: rootNode.id, action: 'custom', prompt: `Generate a comprehensive mindmap about: ${topic}. Use ## headings for each main subtopic, with a brief description paragraph under each.` },
+          {
+            onSuccess: (data) => {
+              setPendingParse({ issueId: data.issueId, nodeId: rootNode.id })
+            },
+            onError: () => setAskingNodeId(null),
+          },
+        )
+      } else {
+        // Create root node with the topic label, then ask
+        createNode.mutate(
+          { label: topic },
+          {
+            onSuccess: (newNode) => {
+              setAskingNodeId(newNode.id)
+              askAI.mutate(
+                { nodeId: newNode.id, action: 'custom', prompt: `Generate a comprehensive mindmap about: ${topic}. Use ## headings for each main subtopic, with a brief description paragraph under each.` },
+                {
+                  onSuccess: (data) => {
+                    setPendingParse({ issueId: data.issueId, nodeId: newNode.id })
+                  },
+                  onError: () => setAskingNodeId(null),
+                },
+              )
+            },
+          },
+        )
+      }
+    }
+    window.addEventListener('wb:generate-tree', handleGenerateTree)
+    return () => window.removeEventListener('wb:generate-tree', handleGenerateTree)
+  }, [askAI, createNode, nodes])
+
+  // Handle wb:generate-issues event (can be dispatched from node context menu in future)
+  useEffect(() => {
+    function handleGenerateIssues(e: Event) {
+      const { nodeIds } = (e as CustomEvent).detail as { nodeIds: string[] }
+      pendingGenerateNodeIds.current = nodeIds
+      generateIssues.mutate(
+        { nodeIds },
+        {
+          onSuccess: (items) => {
+            setGeneratedItems(items)
+            setGenerateDialogOpen(true)
+          },
+        },
+      )
+    }
+    window.addEventListener('wb:generate-issues', handleGenerateIssues)
+    return () => window.removeEventListener('wb:generate-issues', handleGenerateIssues)
+  }, [generateIssues])
 
   return (
     <div className="flex h-dvh flex-col">
@@ -133,6 +226,16 @@ export default function WhiteboardPage() {
           onToggleCollapse={onToggleCollapse}
         />
       </div>
+      <GenerateIssuesDialog
+        projectId={projectId}
+        items={generatedItems}
+        open={generateDialogOpen}
+        onOpenChange={setGenerateDialogOpen}
+        onCreated={(count) => {
+          void count
+          setGenerateDialogOpen(false)
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Complete all remaining whiteboard features:

### AI response auto-parse into child nodes
- `POST /whiteboard/parse-response` parses `##` headings from the latest assistant-message and batch-creates child nodes
- Frontend automatically calls this on SSE done event — AI response → nodes with zero manual effort

### Node inline content editor
- Click content area on any node to edit in-place (textarea)
- Blur saves via `wb:update-node` event

### Global mindmap generation from topic
- Text input in WhiteboardHeader — enter a topic to generate an entire mindmap tree
- Sends structured prompt to AI via the existing ask endpoint

### Auto-generated recommended questions
- Heuristic-based question suggestions in AskAIPopover (from node/parent/children labels)
- Click to ask directly

### Generate issues from whiteboard (Phase 3)
- `POST /whiteboard/generate-issues` builds structured title+prompt from selected node subtrees
- GenerateIssuesDialog component with checkboxes for user confirmation
- Batch creates issues on the kanban board

## Test plan
- [x] Lint passes (warnings only)
- [x] Backend tests pass (492)
- [x] Frontend build succeeds
- [ ] Manual: ask AI on node → verify child nodes auto-created from response
- [ ] Manual: edit node content inline
- [ ] Manual: enter topic in header → verify full tree generated
- [ ] Manual: select nodes → generate issues → verify on kanban