### PR TITLE
feat: chat only-mode filter (user / assistant / thinking)

### DIFF
--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -24,6 +24,7 @@ import { useInvalidatePendingMessages, usePendingMessages } from '@/hooks/use-pe
 import { formatFileSize } from '@/lib/format'
 import { kanbanApi } from '@/lib/kanban-api'
 import { STATUS_MAP } from '@/lib/statuses'
+import { useChatFilterStore } from '@/stores/chat-filter-store'
 import type { Issue, NormalizedLogEntry } from '@/types/kanban'
 import { ChatInput } from './ChatInput'
 import { IssueDetail } from './IssueDetail'
@@ -58,6 +59,12 @@ function deriveWorkingStep(logs: NormalizedLogEntry[]): string | null {
 
 // ---------- exported hook (for title bars that need isThinking) ----------
 
+const ONLY_MODE_TYPE_LIST: readonly string[] = [
+  'user-message',
+  'assistant-message',
+  'thinking',
+]
+
 export function useSessionState(
   projectId: string,
   issueId: string | null,
@@ -67,6 +74,9 @@ export function useSessionState(
   const isTodo = issue?.statusId === 'todo'
   const isDone = issue?.statusId === 'done'
   const streamEnabled = hasSession || isTodo || isDone
+
+  const onlyMode = useChatFilterStore(s => s.onlyMode)
+  const streamTypes = onlyMode ? ONLY_MODE_TYPE_LIST : undefined
 
   const {
     logs,
@@ -82,6 +92,7 @@ export function useSessionState(
     issueId: streamEnabled ? issueId : null,
     sessionStatus: issue?.sessionStatus ?? null,
     enabled: !!(issueId && streamEnabled),
+    types: streamTypes,
   })
 
   // Merge SSE-derived status with React Query status for resilience.

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -1,6 +1,7 @@
 import {
   Eraser,
   FileText,
+  Filter,
   FolderOpen,
   Image as ImageIcon,
   Loader2,
@@ -42,6 +43,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { useChangesSummary } from '@/hooks/use-changes-summary'
 import { useClearIssueSession, useEngineAvailability, useEngineSettings, useFollowUpIssue } from '@/hooks/use-kanban'
 import { formatFileSize, formatModelName } from '@/lib/format'
+import { useChatFilterStore } from '@/stores/chat-filter-store'
 import { useFileBrowserStore } from '@/stores/file-browser-store'
 import type { BusyAction, EngineModel, SessionStatus } from '@/types/kanban'
 
@@ -96,6 +98,8 @@ export function ChatInput({
   onPendingEditConsumed?: () => void
 }) {
   const { t } = useTranslation()
+  const onlyMode = useChatFilterStore(s => s.onlyMode)
+  const toggleOnlyMode = useChatFilterStore(s => s.toggleOnlyMode)
   const draftKey = issueId ? `bkd:draft:${issueId}` : null
   // Ref tracks current issueId so async callbacks (handleSend) can compare
   // against the live value rather than the stale closure capture.
@@ -734,6 +738,15 @@ export function ChatInput({
               onClick={onRefreshLogs}
             >
               <RefreshCw className="size-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              title={onlyMode ? t('chat.onlyModeActive') : t('chat.onlyMode')}
+              onClick={toggleOnlyMode}
+              className={onlyMode ? 'bg-primary/[0.08] ring-1 ring-primary/20 text-foreground' : ''}
+            >
+              <Filter className="size-4" />
             </Button>
           </div>
 

--- a/apps/frontend/src/hooks/use-issue-stream.ts
+++ b/apps/frontend/src/hooks/use-issue-stream.ts
@@ -10,6 +10,12 @@ interface UseIssueStreamOptions {
   issueId: string | null
   sessionStatus?: SessionStatus | null
   enabled?: boolean
+  /**
+   * Server-side entry-type filter. When set, the initial fetch and
+   * load-older pagination use /logs/filter/types/..., and incoming SSE
+   * events are filtered client-side to the same set.
+   */
+  types?: readonly string[]
 }
 
 interface UseIssueStreamReturn {
@@ -81,7 +87,16 @@ export function useIssueStream({
   issueId,
   sessionStatus: externalStatus,
   enabled = true,
+  types,
 }: UseIssueStreamOptions): UseIssueStreamReturn {
+  // Stable identity: re-memoizes only when the set of types actually changes.
+  const typesKey = types && types.length > 0 ? types.toSorted().join(',') : ''
+  const typesFilter = useMemo(
+    () => (typesKey ? typesKey.split(',') : undefined),
+    [typesKey],
+  )
+  const typesSetRef = useRef<Set<string> | null>(null)
+  typesSetRef.current = typesFilter ? new Set(typesFilter) : null
   // Live logs: initial load + SSE entries, capped at MAX_LIVE_LOGS
   const [liveLogs, setLiveLogs] = useState<NormalizedLogEntry[]>([])
   // Older logs: loaded via "Load More", no cap (user-initiated)
@@ -292,7 +307,7 @@ export function useIssueStream({
     setIsLoadingOlder(true)
 
     kanbanApi
-      .getIssueLogs(projectId, issueId, { before: olderCursorRef.current })
+      .getIssueLogs(projectId, issueId, { before: olderCursorRef.current, types: typesFilter })
       .then((data) => {
         if (!data.logs.length) {
           setHasOlderLogs(false)
@@ -318,7 +333,7 @@ export function useIssueStream({
       .finally(() => {
         setIsLoadingOlder(false)
       })
-  }, [projectId, issueId, isLoadingOlder])
+  }, [projectId, issueId, isLoadingOlder, typesFilter])
 
   useEffect(() => {
     if (!issueId || !enabled) {
@@ -328,13 +343,13 @@ export function useIssueStream({
       return
     }
 
-    const scope = `${projectId}:${issueId}`
+    const scope = `${projectId}:${issueId}:${typesKey}`
     if (streamScopeRef.current !== scope) {
       streamScopeRef.current = scope
       setSessionStatus(externalStatus ?? null)
       clearLogs()
     }
-  }, [projectId, issueId, enabled, clearLogs, externalStatus])
+  }, [projectId, issueId, enabled, clearLogs, externalStatus, typesKey])
 
   useEffect(() => {
     if (!issueId || !enabled) return
@@ -352,11 +367,11 @@ export function useIssueStream({
   useEffect(() => {
     if (!issueId || !enabled) return
 
-    const scope = `${projectId}:${issueId}`
+    const scope = `${projectId}:${issueId}:${typesKey}`
     let cancelled = false
 
     kanbanApi
-      .getIssueLogs(projectId, issueId)
+      .getIssueLogs(projectId, issueId, typesFilter ? { types: typesFilter } : undefined)
       .then((data) => {
         if (cancelled || streamScopeRef.current !== scope) return
 
@@ -405,7 +420,9 @@ export function useIssueStream({
     // race: the HTTP response can overwrite SSE entries that arrived between
     // the request and response, making messages appear/disappear/reappear.
     // refreshCounter is included so that refreshLogs() can trigger a re-fetch.
-  }, [projectId, issueId, enabled, markSeen, _refreshCounter])
+    // typesKey / typesFilter are included so that toggling the server-side
+    // filter invalidates both scope and this effect.
+  }, [projectId, issueId, enabled, markSeen, _refreshCounter, typesKey, typesFilter])
 
   // Subscribe to live SSE events for this issue.
   useEffect(() => {
@@ -420,9 +437,16 @@ export function useIssueStream({
         // Always allow error messages through even after done (race: stderr
         // entries may arrive after the terminal state event)
         if (doneReceivedRef.current && entry.entryType !== 'error-message') return
+        // Respect server-side types filter: drop SSE events whose type is not
+        // in the active filter set. Without this, live events would bypass the
+        // filter and contaminate the 500-entry live cap with hidden entries.
+        const allowed = typesSetRef.current
+        if (allowed && !allowed.has(entry.entryType)) return
         appendEntry(entry)
       },
       onLogUpdated: (entry) => {
+        const allowed = typesSetRef.current
+        if (allowed && !allowed.has(entry.entryType)) return
         upsertEntry(entry)
       },
       onLogRemoved: (messageIds) => {

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -189,7 +189,7 @@
     "clearSession": "Clear session ID",
     "clearSessionConfirmTitle": "Clear session ID?",
     "clearSessionConfirmDescription": "This will clear the CLI session ID so the next run starts fresh. Use this when the session has grown so large that resume triggers \"Prompt is too long\". The issue history remains intact.",
-    "clearSessionAction": "Clear session"
+    "clearSessionAction": "Reset session ID"
   },
   "diff": {
     "changes": "Changes",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -181,6 +181,8 @@
     "pluginSearch": "Search plugins...",
     "noPlugins": "No matching plugins",
     "refreshLogs": "Refresh logs",
+    "onlyMode": "Only mode (user / assistant / thinking)",
+    "onlyModeActive": "Only mode is on — hiding tool calls and system messages",
     "worktree": "Worktree",
     "worktreeBranch": "Branch",
     "worktreePath": "Path",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -188,7 +188,7 @@
     "clearSession": "清空 Session ID",
     "clearSessionConfirmTitle": "清空 Session ID？",
     "clearSessionConfirmDescription": "这将清空 CLI 的 session ID，下次执行时会开启全新会话。当会话过大导致 resume 时出现 \"Prompt is too long\" 时使用。Issue 历史记录会保留。",
-    "clearSessionAction": "清空会话"
+    "clearSessionAction": "重置 Session ID"
   },
   "diff": {
     "changes": "更改",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -180,6 +180,8 @@
     "pluginSearch": "搜索插件...",
     "noPlugins": "没有匹配的插件",
     "refreshLogs": "刷新日志",
+    "onlyMode": "精简模式（仅用户 / 助手 / 思考）",
+    "onlyModeActive": "精简模式已开启 — 隐藏工具调用与系统消息",
     "worktree": "工作树",
     "worktreeBranch": "分支",
     "worktreePath": "路径",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -381,16 +381,19 @@ export const kanbanApi = {
   getIssueLogs: (
     projectId: string,
     issueId: string,
-    opts?: { before?: string, cursor?: string, limit?: number },
+    opts?: { before?: string, cursor?: string, limit?: number, types?: readonly string[] },
   ) => {
     const params = new URLSearchParams()
     if (opts?.before) params.set('before', opts.before)
     if (opts?.cursor) params.set('cursor', opts.cursor)
     if (opts?.limit) params.set('limit', String(opts.limit))
     const qs = params.toString()
-    return get<IssueLogsResponse>(
-      `/api/projects/${projectId}/issues/${issueId}/logs${qs ? `?${qs}` : ''}`,
-    )
+    const base = `/api/projects/${projectId}/issues/${issueId}/logs`
+    const filterSegment =
+      opts?.types && opts.types.length > 0
+        ? `/filter/types/${opts.types.join(',')}`
+        : ''
+    return get<IssueLogsResponse>(`${base}${filterSegment}${qs ? `?${qs}` : ''}`)
   },
   getSlashCommands: (projectId: string, issueId: string) =>
     get<CategorizedCommands>(`/api/projects/${projectId}/issues/${issueId}/slash-commands`),

--- a/apps/frontend/src/stores/chat-filter-store.ts
+++ b/apps/frontend/src/stores/chat-filter-store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+
+interface ChatFilterStore {
+  onlyMode: boolean
+  setOnlyMode: (value: boolean) => void
+  toggleOnlyMode: () => void
+}
+
+const STORAGE_KEY = 'bkd-chat-only-mode'
+
+function loadOnlyMode(): boolean {
+  if (typeof window === 'undefined') return false
+  return localStorage.getItem(STORAGE_KEY) === 'true'
+}
+
+export const useChatFilterStore = create<ChatFilterStore>((set, get) => ({
+  onlyMode: loadOnlyMode(),
+
+  setOnlyMode: (value) => {
+    localStorage.setItem(STORAGE_KEY, String(value))
+    set({ onlyMode: value })
+  },
+
+  toggleOnlyMode: () => {
+    const next = !get().onlyMode
+    localStorage.setItem(STORAGE_KEY, String(next))
+    set({ onlyMode: next })
+  },
+}))


### PR DESCRIPTION
## Summary

- Adds a Filter toggle next to the refresh button in the chat input. When active, the chat view shows only `user-message`, `assistant-message`, and `thinking` entries — `tool-use` and `system-message` are hidden.
- Filtering is server-side via the existing `/api/projects/:projectId/issues/:id/logs/filter/types/<comma>` route, so pagination (`before` / `cursor` / `limit`) and the 500-entry live-log cap are respected.
- SSE events are also filtered client-side in `useIssueStream`, preventing hidden entries from evicting visible ones from the live window.
- State persists in `localStorage` via a new `useChatFilterStore` (zustand).
- `useIssueStream` includes the filter in its scope key — toggling clears and re-fetches.

## Files

- `apps/frontend/src/stores/chat-filter-store.ts` (new) — `onlyMode` store
- `apps/frontend/src/lib/kanban-api.ts` — `getIssueLogs` accepts `types?: readonly string[]`, switches URL to the filter route
- `apps/frontend/src/hooks/use-issue-stream.ts` — accepts `types`, forwards to initial fetch + `loadOlderLogs`, filters SSE events
- `apps/frontend/src/components/issue-detail/ChatBody.tsx` — `useSessionState` reads store, passes types to stream
- `apps/frontend/src/components/issue-detail/ChatInput.tsx` — Filter icon button with active state
- `apps/frontend/src/i18n/{en,zh}.json` — `chat.onlyMode` / `chat.onlyModeActive`

No backend changes — uses the existing log filter route.

## Test plan

- [ ] Toggle Filter button on an issue with mixed message types; only user / assistant / thinking entries render
- [ ] With filter on, click "Load older" — older batches contain only filtered types (no hidden tool-use pages)
- [ ] With filter on, trigger new activity (run / follow-up) — live SSE assistant / thinking entries appear, tool-use events do not
- [ ] Toggle filter off — full log restored, pagination resumes from correct cursor
- [ ] Reload page — filter state persists