### PR TITLE
feat(api): migrate claude executor to @anthropic-ai/claude-agent-sdk (ENG-001 steps 1-3)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.16.1",
-    "@anthropic-ai/claude-agent-sdk": "~0.2.113",
+    "@anthropic-ai/claude-agent-sdk": "~0.2.114",
     "@hono/swagger-ui": "^0.6.1",
     "@hono/zod-openapi": "^1.2.3",
     "@hono/zod-validator": "^0.7.6",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.16.1",
+    "@anthropic-ai/claude-agent-sdk": "~0.2.113",
     "@hono/swagger-ui": "^0.6.1",
     "@hono/zod-openapi": "^1.2.3",
     "@hono/zod-validator": "^0.7.6",

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -370,12 +370,13 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
     label: 'spawn' | 'followup',
     extra: Partial<Options>,
   ): Promise<SpawnedProcess> {
+    // Prefer an externally-resolved binary (e.g. /work/bin/claude or a user
+    // install) when present. When absent, leave `pathToClaudeCodeExecutable`
+    // undefined so the SDK falls back to resolving `@anthropic-ai/claude-code`
+    // from its own dependency graph. This keeps the engine usable in
+    // deployments that ship only the SDK + peer package without a separate
+    // global `claude` binary.
     const binaryPath = resolveClaudeBinary()
-    if (!binaryPath) {
-      throw new Error(
-        'Claude Code binary not found. Install via `bun install -g @anthropic-ai/claude-code` or place it under /work/bin/claude.',
-      )
-    }
 
     const permissionMode = options.permissionMode ?? 'auto'
     const sdkPermissionMode = mapPermissionMode(permissionMode)
@@ -395,7 +396,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
     const userExtra: Record<string, string> = { ...(options.env ?? {}), ...(env.vars ?? {}) }
     const sdkOptions: Options = {
       cwd: options.workingDir,
-      pathToClaudeCodeExecutable: binaryPath,
+      ...(binaryPath ? { pathToClaudeCodeExecutable: binaryPath } : {}),
       executable: 'bun',
       env: {
         ...safeEnv(userExtra, 'claude-code-sdk'),

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -307,16 +307,22 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
         },
       })
 
-      const [commands, agents] = await Promise.all([
-        withTimeout(q.supportedCommands(), 15_000, [] as SlashCommand[]),
-        withTimeout(q.supportedAgents(), 15_000, [] as Array<{ name: string }>),
+      const [commandsResult, agentsResult] = await Promise.all([
+        withTimeout(q.supportedCommands(), 15_000, null as SlashCommand[] | null),
+        withTimeout(q.supportedAgents(), 15_000, null as Array<{ name: string }> | null),
       ])
 
+      // At least one SDK call must have completed (not timed out) for us to
+      // treat discovery as successful. Empty-but-completed lists are valid
+      // (e.g. a workspace with no custom agents) and should still clear
+      // previously cached data via `initReceived: true`.
+      const initReceived = commandsResult !== null || agentsResult !== null
+
       return {
-        slashCommands: commands.map(c => c.name),
-        agents: agents.map(a => a.name),
+        slashCommands: (commandsResult ?? []).map(c => c.name),
+        agents: (agentsResult ?? []).map(a => a.name),
         plugins: [],
-        initReceived: commands.length > 0 || agents.length > 0,
+        initReceived,
       }
     } catch (error) {
       logger.warn({ error, workingDir }, 'claude_sdk_discover_failed')

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -312,11 +312,14 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
         withTimeout(q.supportedAgents(), 15_000, null as Array<{ name: string }> | null),
       ])
 
-      // At least one SDK call must have completed (not timed out) for us to
-      // treat discovery as successful. Empty-but-completed lists are valid
-      // (e.g. a workspace with no custom agents) and should still clear
-      // previously cached data via `initReceived: true`.
-      const initReceived = commandsResult !== null || agentsResult !== null
+      // Require BOTH SDK calls to complete (not time out) before treating
+      // discovery as authoritative. Empty-but-completed lists are fine — they
+      // mean "no commands/agents in this workspace" and should still clear
+      // stale cache entries. But if one call times out while the other
+      // returns, we cannot safely overwrite the prior cache for the failed
+      // field without erasing valid metadata, so we report `initReceived:
+      // false` and let `startup-probe` keep the previously cached values.
+      const initReceived = commandsResult !== null && agentsResult !== null
 
       return {
         slashCommands: (commandsResult ?? []).map(c => c.name),

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -98,15 +98,60 @@ function makeUserMessage(content: string): SDKUserMessage {
 }
 
 /**
+ * Create a push-only stderr `ReadableStream`. Constructed before `query()`
+ * so the stderr callback we pass into the SDK can safely capture `push`
+ * even if the SDK emits stderr synchronously during startup (binary
+ * missing, config error, etc.) — no temporal-dead-zone on `bridge`.
+ */
+function createStderrStream(): {
+  stream: ReadableStream<Uint8Array>
+  push: (chunk: string) => void
+  close: () => void
+} {
+  const encoder = new TextEncoder()
+  const ref: { ctrl: ReadableStreamDefaultController<Uint8Array> | null } = { ctrl: null }
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      ref.ctrl = controller
+    },
+    cancel() {
+      /* nothing to cancel — stderr is push-only */
+    },
+  })
+  return {
+    stream,
+    push: (chunk: string) => {
+      const ctrl = ref.ctrl
+      if (!ctrl) return
+      try {
+        ctrl.enqueue(encoder.encode(chunk))
+      } catch {
+        /* stream closed */
+      }
+    },
+    close: () => {
+      try {
+        ref.ctrl?.close()
+      } catch {
+        /* already closed */
+      }
+    },
+  }
+}
+
+/**
  * Bridge the SDK `Query` async generator to the `(stdout, stderr)` stream pair
  * that `SpawnedProcess` + `consumeStream` expect. Keeps the legacy consumer
  * path unchanged during the migration.
  */
-function startBridge(q: Query, label: string, issueId: string | undefined): {
+function startBridge(
+  q: Query,
+  label: string,
+  issueId: string | undefined,
+  stderr: { push: (chunk: string) => void, close: () => void },
+): {
   handle: SdkProcessHandle
   stdout: ReadableStream<Uint8Array>
-  stderr: ReadableStream<Uint8Array>
-  stderrPush: (chunk: string) => void
 } {
   const handle = new SdkProcessHandle(q)
 
@@ -120,26 +165,7 @@ function startBridge(q: Query, label: string, issueId: string | undefined): {
     },
   })
 
-  const stderrRef: { ctrl: ReadableStreamDefaultController<Uint8Array> | null } = { ctrl: null }
-  const stderr = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stderrRef.ctrl = controller
-    },
-    cancel() {
-      /* nothing to cancel — stderr is push-only */
-    },
-  })
-
   const encoder = new TextEncoder()
-  const stderrPush = (chunk: string): void => {
-    const ctrl = stderrRef.ctrl
-    if (!ctrl) return
-    try {
-      ctrl.enqueue(encoder.encode(chunk))
-    } catch {
-      /* stream closed */
-    }
-  }
 
   void (async () => {
     let exitCode = 0
@@ -157,18 +183,14 @@ function startBridge(q: Query, label: string, issueId: string | undefined): {
       exitCode = 1
       logger.warn({ issueId, label, err }, 'claude_sdk_query_error')
       const message = err instanceof Error ? err.message : String(err)
-      stderrPush(`${message}\n`)
+      stderr.push(`${message}\n`)
     } finally {
       try {
         stdoutRef.ctrl?.close()
       } catch {
         /* already closed */
       }
-      try {
-        stderrRef.ctrl?.close()
-      } catch {
-        /* already closed */
-      }
+      stderr.close()
       // If the handle was force-closed (SIGKILL equivalent) but the generator
       // still unwound without throwing, report a non-zero exit so
       // `monitorCompletion` treats the run as terminated rather than
@@ -180,7 +202,7 @@ function startBridge(q: Query, label: string, issueId: string | undefined): {
     }
   })()
 
-  return { handle, stdout, stderr, stderrPush }
+  return { handle, stdout }
 }
 
 export class ClaudeCodeSdkExecutor implements EngineExecutor {
@@ -415,17 +437,23 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
     const pushable = new PushableStream<SDKUserMessage>()
     pushable.push(makeUserMessage(options.prompt))
 
+    // Create the stderr stream BEFORE `query()` so the stderr callback we pass
+    // into the SDK can safely reference `stderr.push` even if the SDK emits
+    // stderr synchronously during startup (e.g. immediate binary/config
+    // errors). Referencing the bridge here would hit the temporal dead zone.
+    const stderr = createStderrStream()
+
     const q = query({
       prompt: pushable,
       options: {
         ...sdkOptions,
         stderr: (data) => {
-          bridge.stderrPush(data.endsWith('\n') ? data : `${data}\n`)
+          stderr.push(data.endsWith('\n') ? data : `${data}\n`)
         },
       },
     })
 
-    const bridge = startBridge(q, label, env.issueId)
+    const bridge = startBridge(q, label, env.issueId, stderr)
 
     logger.debug(
       {
@@ -443,7 +471,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
     return {
       subprocess: bridge.handle as unknown as SpawnedProcess['subprocess'],
       stdout: bridge.stdout,
-      stderr: bridge.stderr,
+      stderr: stderr.stream,
       cancel: () => {
         // Soft cancel: interrupt the current turn but keep the prompt stream
         // open so follow-up turns via `protocolHandler.sendUserMessage` remain

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -177,7 +177,7 @@ function startBridge(q: Query, label: string, issueId: string | undefined): {
 }
 
 export class ClaudeCodeSdkExecutor implements EngineExecutor {
-  readonly engineType = 'claude-code' as const
+  readonly engineType = 'claude-code-sdk' as const
   readonly protocol = 'stream-json' as const
   readonly capabilities: EngineCapability[] = ['session-fork', 'context-usage', 'plan-mode']
 
@@ -208,7 +208,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
       const binaryPath = resolveClaudeBinary()
       if (!binaryPath) {
         return {
-          engineType: 'claude-code',
+          engineType: 'claude-code-sdk',
           installed: false,
           authStatus: 'unknown',
         }
@@ -223,7 +223,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
         stdin: 'ignore',
         stdout: 'pipe',
         stderr: 'pipe',
-        env: safeEnv(resolved.env, 'claude-code'),
+        env: safeEnv(resolved.env, 'claude-code-sdk'),
       })
 
       const timer = setTimeout(() => proc.kill(), 10000)
@@ -231,14 +231,14 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
       clearTimeout(timer)
 
       if (exitCode !== 0) {
-        return { engineType: 'claude-code', installed: false, authStatus: 'unknown' }
+        return { engineType: 'claude-code-sdk', installed: false, authStatus: 'unknown' }
       }
 
       const stdout = await new Response(proc.stdout).text()
       const version = stdout.match(/(\d+\.\d+\.\d[\w.-]*)/)?.[1]
 
       return {
-        engineType: 'claude-code',
+        engineType: 'claude-code-sdk',
         installed: true,
         version,
         binaryPath,
@@ -246,7 +246,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
       }
     } catch (error) {
       return {
-        engineType: 'claude-code',
+        engineType: 'claude-code-sdk',
         installed: false,
         authStatus: 'unknown',
         error: error instanceof Error ? error.message : 'Unknown error',
@@ -293,7 +293,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
           cwd: workingDir,
           pathToClaudeCodeExecutable: binaryPath,
           executable: 'bun',
-          env: safeEnv(undefined, 'claude-code') as unknown as Record<string, string>,
+          env: safeEnv(undefined, 'claude-code-sdk') as unknown as Record<string, string>,
           permissionMode: 'auto',
           disallowedTools: ['AskUserQuestion'],
           settingSources: ['user', 'project', 'local'],
@@ -355,7 +355,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
       pathToClaudeCodeExecutable: binaryPath,
       executable: 'bun',
       env: {
-        ...safeEnv(undefined, 'claude-code'),
+        ...safeEnv(undefined, 'claude-code-sdk'),
         ...(options.env ?? {}),
         ...(env.vars ?? {}),
         NPM_CONFIG_LOGLEVEL: 'error',

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -28,7 +28,7 @@ import type {
 } from '@/engines/types'
 import { logger } from '@/logger'
 import { ROOT_DIR } from '@/root'
-import { CLAUDE_MODELS, getClaudeAuthStatus, resolveClaudeBinary } from '../claude-shared/binary'
+import { CLAUDE_MODELS, getClaudeAuthStatus, resolveAnyClaudeBinary, resolveClaudeBinary } from '../claude-shared/binary'
 import { SdkProcessHandle } from './handle'
 import { ClaudeSdkNormalizer, stringifyMessage } from './normalizer'
 import { PushableStream } from './pushable-stream'
@@ -234,7 +234,10 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
 
   async getAvailability(): Promise<EngineAvailability> {
     try {
-      const binaryPath = resolveClaudeBinary()
+      // Accept either an externally-installed binary or the SDK-bundled one
+      // from `@anthropic-ai/claude-agent-sdk-<platform>-<arch>`. If neither
+      // resolves, the SDK itself would also fail, so we report uninstalled.
+      const binaryPath = resolveAnyClaudeBinary()
       if (!binaryPath) {
         return {
           engineType: 'claude-code-sdk',
@@ -307,10 +310,15 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
     plugins: Array<{ name: string, path: string }>
     initReceived: boolean
   }> {
-    const binaryPath = resolveClaudeBinary()
+    // Discovery works as long as *some* binary (external or SDK-bundled) is
+    // resolvable. When only the SDK-bundled one exists we omit
+    // `pathToClaudeCodeExecutable` and let the SDK resolve it itself, so the
+    // spawned discovery query uses the exact same binary as execution would.
+    const binaryPath = resolveAnyClaudeBinary()
     if (!binaryPath) {
       return { slashCommands: [], agents: [], plugins: [], initReceived: false }
     }
+    const externalBinary = resolveClaudeBinary()
 
     const pushable = new PushableStream<SDKUserMessage>()
     let q: Query | null = null
@@ -320,7 +328,7 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
         prompt: pushable,
         options: {
           cwd: workingDir,
-          pathToClaudeCodeExecutable: binaryPath,
+          ...(externalBinary ? { pathToClaudeCodeExecutable: externalBinary } : {}),
           executable: 'bun',
           env: safeEnv(undefined, 'claude-code-sdk') as unknown as Record<string, string>,
           permissionMode: 'auto',

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -169,6 +169,13 @@ function startBridge(q: Query, label: string, issueId: string | undefined): {
       } catch {
         /* already closed */
       }
+      // If the handle was force-closed (SIGKILL equivalent) but the generator
+      // still unwound without throwing, report a non-zero exit so
+      // `monitorCompletion` treats the run as terminated rather than
+      // successfully completed.
+      if (exitCode === 0 && handle.wasHardClosed) {
+        exitCode = 137
+      }
       handle.settle(exitCode)
     }
   })()
@@ -350,14 +357,17 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
       extraArgs.agent = options.agent
     }
 
+    // Merge user/project env vars and run them through safeEnv so protected
+    // keys (PATH, HOME, ANTHROPIC_API_KEY, IS_SANDBOX, …) cannot be overridden.
+    // `env.vars` wins over `options.env` to match the precedence used by the
+    // legacy executor (per-execution env > project env).
+    const userExtra: Record<string, string> = { ...(options.env ?? {}), ...(env.vars ?? {}) }
     const sdkOptions: Options = {
       cwd: options.workingDir,
       pathToClaudeCodeExecutable: binaryPath,
       executable: 'bun',
       env: {
-        ...safeEnv(undefined, 'claude-code-sdk'),
-        ...(options.env ?? {}),
-        ...(env.vars ?? {}),
+        ...safeEnv(userExtra, 'claude-code-sdk'),
         NPM_CONFIG_LOGLEVEL: 'error',
         IS_SANDBOX: '1',
       },

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -426,7 +426,10 @@ export class ClaudeCodeSdkExecutor implements EngineExecutor {
       stdout: bridge.stdout,
       stderr: bridge.stderr,
       cancel: () => {
-        pushable.close()
+        // Soft cancel: interrupt the current turn but keep the prompt stream
+        // open so follow-up turns via `protocolHandler.sendUserMessage` remain
+        // deliverable. `protocolHandler.close()` is the explicit shutdown that
+        // closes the pushable and the underlying query.
         bridge.handle.kill()
       },
       protocolHandler: {

--- a/apps/api/src/engines/executors/claude-sdk/executor.ts
+++ b/apps/api/src/engines/executors/claude-sdk/executor.ts
@@ -1,0 +1,468 @@
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import type {
+  CanUseTool,
+  Options,
+  PermissionMode,
+  PermissionResult,
+  Query,
+  SDKMessage,
+  SDKUserMessage,
+  SlashCommand,
+} from '@anthropic-ai/claude-agent-sdk'
+import { CommandBuilder } from '@/engines/command'
+import { safeEnv } from '@/engines/safe-env'
+import { spawnNode } from '@/engines/spawn'
+import type {
+  EngineAvailability,
+  EngineCapability,
+  EngineExecutor,
+  EngineModel,
+  ExecutionEnv,
+  FollowUpOptions,
+  NormalizedLogEntry,
+  PermissionPolicy,
+  SpawnedProcess,
+  SpawnOptions,
+} from '@/engines/types'
+import { logger } from '@/logger'
+import { ROOT_DIR } from '@/root'
+import { CLAUDE_MODELS, getClaudeAuthStatus, resolveClaudeBinary } from '../claude-shared/binary'
+import { SdkProcessHandle } from './handle'
+import { ClaudeSdkNormalizer, stringifyMessage } from './normalizer'
+import { PushableStream } from './pushable-stream'
+
+const ISSUE_LOG_DIR = join(ROOT_DIR, 'data', 'logs', 'issues')
+
+const READ_ONLY_TOOLS = new Set(['Glob', 'Grep', 'NotebookRead', 'Read', 'Task', 'TodoWrite'])
+
+/**
+ * Map the app's `PermissionPolicy` to the SDK's `PermissionMode`.
+ * - `auto` → `'auto'` (SDK's AI-classifier mode; identical semantics to legacy CLI `--permission-mode=auto`)
+ * - `plan` → `'plan'` (planning mode; switches to `bypassPermissions` when ExitPlanMode triggers)
+ * - `supervised` → `'default'` (SDK prompts for non-read tools; `canUseTool` decides)
+ */
+function mapPermissionMode(policy: PermissionPolicy | undefined): PermissionMode {
+  switch (policy) {
+    case 'plan':
+      return 'plan'
+    case 'supervised':
+      return 'default'
+    default:
+      return 'auto'
+  }
+}
+
+/**
+ * Build the `canUseTool` callback.
+ *
+ * - Plan mode: ExitPlanMode is auto-approved with a `setMode` update back to
+ *   `bypassPermissions` so Claude executes the plan freely afterwards. Other
+ *   tools reaching the callback (shouldn't happen under `plan` mode normally)
+ *   are allowed.
+ * - Supervised mode: read-only tools allowed silently; any tool that reaches
+ *   `canUseTool` is allowed (the web UI has no interactive approval flow).
+ * - Auto mode: callback is unused because the SDK's AI classifier handles
+ *   everything; we still return a safe allow for defensive reasons.
+ */
+function buildCanUseTool(policy: PermissionPolicy | undefined): CanUseTool {
+  return async (toolName, input): Promise<PermissionResult> => {
+    if (policy === 'plan' && toolName === 'ExitPlanMode') {
+      return {
+        behavior: 'allow',
+        updatedInput: input,
+        updatedPermissions: [
+          { type: 'setMode', mode: 'bypassPermissions', destination: 'session' },
+        ],
+      }
+    }
+
+    if (policy === 'supervised' && !READ_ONLY_TOOLS.has(toolName)) {
+      logger.debug({ toolName }, 'claude_sdk_supervised_tool_auto_allowed')
+    }
+
+    return { behavior: 'allow', updatedInput: input }
+  }
+}
+
+function makeUserMessage(content: string): SDKUserMessage {
+  return {
+    type: 'user',
+    parent_tool_use_id: null,
+    message: {
+      role: 'user',
+      content,
+    },
+  }
+}
+
+/**
+ * Bridge the SDK `Query` async generator to the `(stdout, stderr)` stream pair
+ * that `SpawnedProcess` + `consumeStream` expect. Keeps the legacy consumer
+ * path unchanged during the migration.
+ */
+function startBridge(q: Query, label: string, issueId: string | undefined): {
+  handle: SdkProcessHandle
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  stderrPush: (chunk: string) => void
+} {
+  const handle = new SdkProcessHandle(q)
+
+  const stdoutRef: { ctrl: ReadableStreamDefaultController<Uint8Array> | null } = { ctrl: null }
+  const stdout = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stdoutRef.ctrl = controller
+    },
+    cancel() {
+      handle.kill()
+    },
+  })
+
+  const stderrRef: { ctrl: ReadableStreamDefaultController<Uint8Array> | null } = { ctrl: null }
+  const stderr = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stderrRef.ctrl = controller
+    },
+    cancel() {
+      /* nothing to cancel — stderr is push-only */
+    },
+  })
+
+  const encoder = new TextEncoder()
+  const stderrPush = (chunk: string): void => {
+    const ctrl = stderrRef.ctrl
+    if (!ctrl) return
+    try {
+      ctrl.enqueue(encoder.encode(chunk))
+    } catch {
+      /* stream closed */
+    }
+  }
+
+  void (async () => {
+    let exitCode = 0
+    try {
+      for await (const msg of q as AsyncIterable<SDKMessage>) {
+        const ctrl = stdoutRef.ctrl
+        if (!ctrl) break
+        try {
+          ctrl.enqueue(encoder.encode(stringifyMessage(msg)))
+        } catch {
+          break
+        }
+      }
+    } catch (err) {
+      exitCode = 1
+      logger.warn({ issueId, label, err }, 'claude_sdk_query_error')
+      const message = err instanceof Error ? err.message : String(err)
+      stderrPush(`${message}\n`)
+    } finally {
+      try {
+        stdoutRef.ctrl?.close()
+      } catch {
+        /* already closed */
+      }
+      try {
+        stderrRef.ctrl?.close()
+      } catch {
+        /* already closed */
+      }
+      handle.settle(exitCode)
+    }
+  })()
+
+  return { handle, stdout, stderr, stderrPush }
+}
+
+export class ClaudeCodeSdkExecutor implements EngineExecutor {
+  readonly engineType = 'claude-code' as const
+  readonly protocol = 'stream-json' as const
+  readonly capabilities: EngineCapability[] = ['session-fork', 'context-usage', 'plan-mode']
+
+  private readonly defaultNormalizer = new ClaudeSdkNormalizer()
+
+  async spawn(options: SpawnOptions, env: ExecutionEnv): Promise<SpawnedProcess> {
+    return this.startQuery(options, env, 'spawn', {})
+  }
+
+  async spawnFollowUp(options: FollowUpOptions, env: ExecutionEnv): Promise<SpawnedProcess> {
+    const extraOptions: Partial<Options> = { resume: options.sessionId }
+    if (options.resetToMessageId) {
+      extraOptions.resumeSessionAt = options.resetToMessageId
+    }
+    return this.startQuery(options, env, 'followup', extraOptions)
+  }
+
+  async cancel(spawnedProcess: SpawnedProcess): Promise<void> {
+    if (spawnedProcess.protocolHandler) {
+      await spawnedProcess.protocolHandler.interrupt()
+    } else {
+      spawnedProcess.cancel()
+    }
+  }
+
+  async getAvailability(): Promise<EngineAvailability> {
+    try {
+      const binaryPath = resolveClaudeBinary()
+      if (!binaryPath) {
+        return {
+          engineType: 'claude-code',
+          installed: false,
+          authStatus: 'unknown',
+        }
+      }
+
+      const resolved = await CommandBuilder.create(binaryPath)
+        .param('--version')
+        .env('NPM_CONFIG_LOGLEVEL', 'error')
+        .resolve()
+
+      const proc = spawnNode([resolved.resolvedPath, ...resolved.args], {
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: safeEnv(resolved.env, 'claude-code'),
+      })
+
+      const timer = setTimeout(() => proc.kill(), 10000)
+      const exitCode = await proc.exited
+      clearTimeout(timer)
+
+      if (exitCode !== 0) {
+        return { engineType: 'claude-code', installed: false, authStatus: 'unknown' }
+      }
+
+      const stdout = await new Response(proc.stdout).text()
+      const version = stdout.match(/(\d+\.\d+\.\d[\w.-]*)/)?.[1]
+
+      return {
+        engineType: 'claude-code',
+        installed: true,
+        version,
+        binaryPath,
+        authStatus: getClaudeAuthStatus(),
+      }
+    } catch (error) {
+      return {
+        engineType: 'claude-code',
+        installed: false,
+        authStatus: 'unknown',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }
+    }
+  }
+
+  async getModels(): Promise<EngineModel[]> {
+    return CLAUDE_MODELS
+  }
+
+  normalizeLog(rawLine: string): NormalizedLogEntry | NormalizedLogEntry[] | null {
+    return this.defaultNormalizer.parse(rawLine)
+  }
+
+  createNormalizer() {
+    return new ClaudeSdkNormalizer()
+  }
+
+  /**
+   * Discover slash-commands, agents, and plugins by issuing a dry query and
+   * calling the SDK's `supportedCommands` / `supportedAgents`. Much faster
+   * than the legacy one-shot CLI invocation: no subprocess start, just a
+   * control request against an idle query.
+   */
+  async discoverSlashCommandsAndAgents(workingDir: string): Promise<{
+    slashCommands: string[]
+    agents: string[]
+    plugins: Array<{ name: string, path: string }>
+    initReceived: boolean
+  }> {
+    const binaryPath = resolveClaudeBinary()
+    if (!binaryPath) {
+      return { slashCommands: [], agents: [], plugins: [], initReceived: false }
+    }
+
+    const pushable = new PushableStream<SDKUserMessage>()
+    let q: Query | null = null
+
+    try {
+      q = query({
+        prompt: pushable,
+        options: {
+          cwd: workingDir,
+          pathToClaudeCodeExecutable: binaryPath,
+          executable: 'bun',
+          env: safeEnv(undefined, 'claude-code') as unknown as Record<string, string>,
+          permissionMode: 'auto',
+          disallowedTools: ['AskUserQuestion'],
+          settingSources: ['user', 'project', 'local'],
+        },
+      })
+
+      const [commands, agents] = await Promise.all([
+        withTimeout(q.supportedCommands(), 15_000, [] as SlashCommand[]),
+        withTimeout(q.supportedAgents(), 15_000, [] as Array<{ name: string }>),
+      ])
+
+      return {
+        slashCommands: commands.map(c => c.name),
+        agents: agents.map(a => a.name),
+        plugins: [],
+        initReceived: commands.length > 0 || agents.length > 0,
+      }
+    } catch (error) {
+      logger.warn({ error, workingDir }, 'claude_sdk_discover_failed')
+      return { slashCommands: [], agents: [], plugins: [], initReceived: false }
+    } finally {
+      pushable.close()
+      try {
+        q?.close()
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+
+  // ---------- Private ----------
+
+  private async startQuery(
+    options: SpawnOptions,
+    env: ExecutionEnv,
+    label: 'spawn' | 'followup',
+    extra: Partial<Options>,
+  ): Promise<SpawnedProcess> {
+    const binaryPath = resolveClaudeBinary()
+    if (!binaryPath) {
+      throw new Error(
+        'Claude Code binary not found. Install via `bun install -g @anthropic-ai/claude-code` or place it under /work/bin/claude.',
+      )
+    }
+
+    const permissionMode = options.permissionMode ?? 'auto'
+    const sdkPermissionMode = mapPermissionMode(permissionMode)
+
+    const extraArgs: Record<string, string | null> = {}
+    if (options.externalSessionId) {
+      extraArgs['session-id'] = options.externalSessionId
+    }
+    if (options.agent) {
+      extraArgs.agent = options.agent
+    }
+
+    const sdkOptions: Options = {
+      cwd: options.workingDir,
+      pathToClaudeCodeExecutable: binaryPath,
+      executable: 'bun',
+      env: {
+        ...safeEnv(undefined, 'claude-code'),
+        ...(options.env ?? {}),
+        ...(env.vars ?? {}),
+        NPM_CONFIG_LOGLEVEL: 'error',
+        IS_SANDBOX: '1',
+      },
+      permissionMode: sdkPermissionMode,
+      canUseTool: buildCanUseTool(permissionMode),
+      disallowedTools: ['AskUserQuestion'],
+      settingSources: ['user', 'project', 'local'],
+      includePartialMessages: false,
+      ...extra,
+    }
+
+    if (sdkPermissionMode === 'bypassPermissions' || sdkPermissionMode === 'plan') {
+      sdkOptions.allowDangerouslySkipPermissions = true
+    }
+
+    if (options.model && options.model !== 'auto') {
+      sdkOptions.model = options.model
+    }
+
+    if (Object.keys(extraArgs).length > 0) {
+      sdkOptions.extraArgs = extraArgs
+    }
+
+    const logLevel = process.env.LOG_LEVEL ?? 'info'
+    if (env.issueId && (logLevel === 'debug' || logLevel === 'trace')) {
+      try {
+        const issueLogDir = join(ISSUE_LOG_DIR, env.issueId)
+        mkdirSync(issueLogDir, { recursive: true })
+        sdkOptions.debug = true
+        sdkOptions.debugFile = join(issueLogDir, 'claude-debug.log')
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    const pushable = new PushableStream<SDKUserMessage>()
+    pushable.push(makeUserMessage(options.prompt))
+
+    const q = query({
+      prompt: pushable,
+      options: {
+        ...sdkOptions,
+        stderr: (data) => {
+          bridge.stderrPush(data.endsWith('\n') ? data : `${data}\n`)
+        },
+      },
+    })
+
+    const bridge = startBridge(q, label, env.issueId)
+
+    logger.debug(
+      {
+        issueId: env.issueId,
+        label,
+        binaryPath,
+        cwd: options.workingDir,
+        permissionMode: sdkPermissionMode,
+        resume: extra.resume,
+        resumeSessionAt: extra.resumeSessionAt,
+      },
+      'claude_sdk_query_started',
+    )
+
+    return {
+      subprocess: bridge.handle as unknown as SpawnedProcess['subprocess'],
+      stdout: bridge.stdout,
+      stderr: bridge.stderr,
+      cancel: () => {
+        pushable.close()
+        bridge.handle.kill()
+      },
+      protocolHandler: {
+        interrupt: async () => {
+          try {
+            await q.interrupt()
+          } catch {
+            /* already interrupted */
+          }
+        },
+        close: () => {
+          pushable.close()
+          try {
+            q.close()
+          } catch {
+            /* already closed */
+          }
+        },
+        sendUserMessage: (content) => {
+          pushable.push(makeUserMessage(content))
+        },
+      },
+      spawnCommand: `[claude-sdk] ${binaryPath} (${label}${extra.resume ? ` resume=${extra.resume}` : ''})`,
+    }
+  }
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return await new Promise<T>((resolve) => {
+    const timer = setTimeout(resolve, ms, fallback)
+    p.then((v) => {
+      clearTimeout(timer)
+      resolve(v)
+    }).catch(() => {
+      clearTimeout(timer)
+      resolve(fallback)
+    })
+  })
+}

--- a/apps/api/src/engines/executors/claude-sdk/handle.ts
+++ b/apps/api/src/engines/executors/claude-sdk/handle.ts
@@ -10,8 +10,13 @@ import type { ProcessHandle } from '@/engines/process-handle'
  *     `ProcessManager.forceKill()` and the post-timeout escalation in
  *     `ProcessManager.terminate()`. A second SIGKILL is a no-op.
  *   - `kill()` / `kill(non-9)` (SIGTERM-equivalent) → `Query.interrupt()`
- *     (graceful stop). Subsequent soft kills are no-ops while the query is
- *     still alive; once interrupted, a later `kill(9)` still hard-closes.
+ *     (graceful stop). A soft kill is deduped only while its own
+ *     `interrupt()` RPC is still in-flight; once that promise settles, a
+ *     subsequent soft kill fires a fresh interrupt. This preserves the retry
+ *     behavior of `engines/issue/orchestration/cancel.ts` (which calls
+ *     `cancel()` up to `CANCEL_MAX_RETRIES` times before hard-killing) and
+ *     lets users interrupt later turns of a long-lived SDK session after an
+ *     earlier cancel. A hard-closed handle rejects further soft kills.
  *   - `exited` → resolved by the executor's consumer loop via `settle()` when
  *     the async generator finishes (normal result, thrown error, or
  *     post-interrupt/post-close settle). `0` for normal end, non-zero when the
@@ -24,7 +29,7 @@ export class SdkProcessHandle implements ProcessHandle {
   readonly exited: Promise<number>
 
   private resolveExited!: (code: number) => void
-  private softInterrupted = false
+  private softInterruptInFlight = false
   private hardClosed = false
   private settled = false
 
@@ -45,11 +50,16 @@ export class SdkProcessHandle implements ProcessHandle {
       }
       return
     }
-    if (this.softInterrupted || this.hardClosed) return
-    this.softInterrupted = true
-    void this.query.interrupt().catch(() => {
-      /* already interrupted / closed */
-    })
+    if (this.hardClosed || this.softInterruptInFlight) return
+    this.softInterruptInFlight = true
+    void this.query
+      .interrupt()
+      .catch(() => {
+        /* already interrupted / closed */
+      })
+      .finally(() => {
+        this.softInterruptInFlight = false
+      })
   }
 
   /**

--- a/apps/api/src/engines/executors/claude-sdk/handle.ts
+++ b/apps/api/src/engines/executors/claude-sdk/handle.ts
@@ -1,0 +1,62 @@
+import type { Query } from '@anthropic-ai/claude-agent-sdk'
+import type { ProcessHandle } from '@/engines/process-handle'
+
+/**
+ * Wraps an SDK `Query` so `ProcessManager` can manage its lifecycle through
+ * the narrow `ProcessHandle` contract.
+ *
+ * Lifecycle mapping:
+ *   - `kill()` first call → `Query.interrupt()` (graceful stop, equivalent to SIGTERM)
+ *   - `kill()` second call → `Query.close()` (force terminate, equivalent to SIGKILL)
+ *   - further calls → no-op
+ *   - `exited` → Promise resolved by the executor's consumer loop when the
+ *     async generator finishes (normal result, thrown error, or post-interrupt
+ *     settle). `0` for normal end, non-zero when SDK surfaces an error.
+ *   - `pid` → undefined (SDK doesn't expose the child PID)
+ */
+export class SdkProcessHandle implements ProcessHandle {
+  readonly pid: number | undefined = undefined
+  readonly exited: Promise<number>
+
+  private resolveExited!: (code: number) => void
+  private killCount = 0
+  private settled = false
+
+  constructor(private readonly query: Query) {
+    this.exited = new Promise<number>((resolve) => {
+      this.resolveExited = resolve
+    })
+  }
+
+  kill(_signal?: number): void {
+    this.killCount += 1
+    if (this.killCount === 1) {
+      void this.query.interrupt().catch(() => {
+        /* already interrupted / closed */
+      })
+      return
+    }
+    if (this.killCount === 2) {
+      try {
+        this.query.close()
+      } catch {
+        /* already closed */
+      }
+    }
+    // 3+ calls: no-op
+  }
+
+  /**
+   * Called by the executor when the generator loop finishes. Idempotent —
+   * only the first call resolves the `exited` promise.
+   */
+  settle(exitCode: number): void {
+    if (this.settled) return
+    this.settled = true
+    this.resolveExited(exitCode)
+  }
+
+  get isSettled(): boolean {
+    return this.settled
+  }
+}

--- a/apps/api/src/engines/executors/claude-sdk/handle.ts
+++ b/apps/api/src/engines/executors/claude-sdk/handle.ts
@@ -6,20 +6,26 @@ import type { ProcessHandle } from '@/engines/process-handle'
  * the narrow `ProcessHandle` contract.
  *
  * Lifecycle mapping:
- *   - `kill()` first call → `Query.interrupt()` (graceful stop, equivalent to SIGTERM)
- *   - `kill()` second call → `Query.close()` (force terminate, equivalent to SIGKILL)
- *   - further calls → no-op
- *   - `exited` → Promise resolved by the executor's consumer loop when the
- *     async generator finishes (normal result, thrown error, or post-interrupt
- *     settle). `0` for normal end, non-zero when SDK surfaces an error.
- *   - `pid` → undefined (SDK doesn't expose the child PID)
+ *   - `kill(9)` (SIGKILL) → immediate `Query.close()` (force terminate). Used by
+ *     `ProcessManager.forceKill()` and the post-timeout escalation in
+ *     `ProcessManager.terminate()`. A second SIGKILL is a no-op.
+ *   - `kill()` / `kill(non-9)` (SIGTERM-equivalent) → `Query.interrupt()`
+ *     (graceful stop). Subsequent soft kills are no-ops while the query is
+ *     still alive; once interrupted, a later `kill(9)` still hard-closes.
+ *   - `exited` → resolved by the executor's consumer loop via `settle()` when
+ *     the async generator finishes (normal result, thrown error, or
+ *     post-interrupt/post-close settle). `0` for normal end, non-zero when the
+ *     SDK surfaces an error.
+ *   - `pid` → undefined (SDK doesn't expose the child PID). Stall GC should
+ *     use `isAlive()` instead.
  */
 export class SdkProcessHandle implements ProcessHandle {
   readonly pid: number | undefined = undefined
   readonly exited: Promise<number>
 
   private resolveExited!: (code: number) => void
-  private killCount = 0
+  private softInterrupted = false
+  private hardClosed = false
   private settled = false
 
   constructor(private readonly query: Query) {
@@ -28,22 +34,31 @@ export class SdkProcessHandle implements ProcessHandle {
     })
   }
 
-  kill(_signal?: number): void {
-    this.killCount += 1
-    if (this.killCount === 1) {
-      void this.query.interrupt().catch(() => {
-        /* already interrupted / closed */
-      })
-      return
-    }
-    if (this.killCount === 2) {
+  kill(signal?: number): void {
+    if (signal === 9) {
+      if (this.hardClosed) return
+      this.hardClosed = true
       try {
         this.query.close()
       } catch {
         /* already closed */
       }
+      return
     }
-    // 3+ calls: no-op
+    if (this.softInterrupted || this.hardClosed) return
+    this.softInterrupted = true
+    void this.query.interrupt().catch(() => {
+      /* already interrupted / closed */
+    })
+  }
+
+  /**
+   * Liveness probe for stall GC. `pid` is always undefined for SDK handles, so
+   * `process.kill(pid, 0)` isn't usable. We report alive until the consumer
+   * loop settles (which happens on normal end, error, or after `close()`).
+   */
+  isAlive(): boolean {
+    return !this.settled
   }
 
   /**

--- a/apps/api/src/engines/executors/claude-sdk/handle.ts
+++ b/apps/api/src/engines/executors/claude-sdk/handle.ts
@@ -74,4 +74,14 @@ export class SdkProcessHandle implements ProcessHandle {
   get isSettled(): boolean {
     return this.settled
   }
+
+  /**
+   * `true` if a hard close (signal 9) has been requested. The bridge uses this
+   * to surface a non-zero exit code even when the generator finishes cleanly
+   * after the close, so `monitorCompletion` treats the run as forced-terminated
+   * rather than successfully completed.
+   */
+  get wasHardClosed(): boolean {
+    return this.hardClosed
+  }
 }

--- a/apps/api/src/engines/executors/claude-sdk/index.ts
+++ b/apps/api/src/engines/executors/claude-sdk/index.ts
@@ -1,0 +1,3 @@
+export { ClaudeCodeSdkExecutor } from './executor'
+export { SdkProcessHandle } from './handle'
+export { ClaudeSdkNormalizer } from './normalizer'

--- a/apps/api/src/engines/executors/claude-sdk/normalizer.ts
+++ b/apps/api/src/engines/executors/claude-sdk/normalizer.ts
@@ -1,0 +1,28 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk'
+import type { NormalizedLogEntry } from '@/engines/types'
+import { ClaudeLogNormalizer } from '../claude/normalizer'
+
+/**
+ * Thin adapter that preserves the existing line-based `ClaudeLogNormalizer`
+ * during the SDK migration. Each `SDKMessage` is re-serialized to JSON and
+ * fed through the legacy normalizer.
+ *
+ * Step 5 of PLAN-003 will replace this with a typed normalizer that consumes
+ * `SDKMessage` directly. Keeping the round-trip for now avoids duplicating
+ * ~700 lines of tool-classification logic that is not SDK-specific.
+ */
+export class ClaudeSdkNormalizer {
+  private readonly inner = new ClaudeLogNormalizer()
+
+  parse(rawLine: string): NormalizedLogEntry | NormalizedLogEntry[] | null {
+    return this.inner.parse(rawLine)
+  }
+
+  parseMessage(message: SDKMessage): NormalizedLogEntry | NormalizedLogEntry[] | null {
+    return this.inner.parse(JSON.stringify(message))
+  }
+}
+
+export function stringifyMessage(message: SDKMessage): string {
+  return `${JSON.stringify(message)}\n`
+}

--- a/apps/api/src/engines/executors/claude-sdk/pushable-stream.ts
+++ b/apps/api/src/engines/executors/claude-sdk/pushable-stream.ts
@@ -1,0 +1,54 @@
+/**
+ * Async-iterable queue: producer calls `push()` to enqueue values, consumer
+ * iterates via `for await`. When the producer calls `close()`, the iterator
+ * completes after the queue drains.
+ *
+ * Used to feed user prompts into the Claude Agent SDK's streaming-input
+ * `query({ prompt: AsyncIterable<SDKUserMessage> })`.
+ */
+export class PushableStream<T> implements AsyncIterable<T> {
+  private queue: T[] = []
+  private resolvers: Array<(result: IteratorResult<T>) => void> = []
+  private closed = false
+
+  push(value: T): void {
+    if (this.closed) return
+    const resolve = this.resolvers.shift()
+    if (resolve) {
+      resolve({ value, done: false })
+    } else {
+      this.queue.push(value)
+    }
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    for (const resolve of this.resolvers) {
+      resolve({ value: undefined as T, done: true })
+    }
+    this.resolvers = []
+  }
+
+  get isClosed(): boolean {
+    return this.closed
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: (): Promise<IteratorResult<T>> => {
+        if (this.queue.length > 0) {
+          return Promise.resolve({ value: this.queue.shift()!, done: false })
+        }
+        if (this.closed) {
+          return Promise.resolve({ value: undefined as T, done: true })
+        }
+        return new Promise(resolve => this.resolvers.push(resolve))
+      },
+      return: (): Promise<IteratorResult<T>> => {
+        this.close()
+        return Promise.resolve({ value: undefined as T, done: true })
+      },
+    }
+  }
+}

--- a/apps/api/src/engines/executors/claude-shared/binary.ts
+++ b/apps/api/src/engines/executors/claude-shared/binary.ts
@@ -23,6 +23,33 @@ export function resolveClaudeBinary(): string | null {
 }
 
 /**
+ * Detect the host C library on Linux so we can prefer the matching SDK
+ * binary package (`*-musl` vs plain) during fallback resolution. When both
+ * optional packages happen to be installed side-by-side (e.g. a shared
+ * node_modules served to heterogeneous hosts) resolving the wrong one would
+ * make `--version` fail and cause availability to report `installed: false`
+ * on a perfectly runnable system.
+ */
+function detectLinuxLibc(): 'musl' | 'glibc' {
+  try {
+    const report = (process as { report?: { getReport?: () => { header?: { glibcVersionRuntime?: string } } } }).report
+    const glibcVersion = report?.getReport?.().header?.glibcVersionRuntime
+    if (typeof glibcVersion === 'string' && glibcVersion.length > 0) return 'glibc'
+  } catch {
+    /* fall through to filesystem probes */
+  }
+  if (
+    existsSync('/etc/alpine-release')
+    || existsSync('/lib/ld-musl-x86_64.so.1')
+    || existsSync('/lib/ld-musl-aarch64.so.1')
+    || existsSync('/lib/ld-musl-armhf.so.1')
+  ) {
+    return 'musl'
+  }
+  return 'glibc'
+}
+
+/**
  * Replicates the Agent SDK's internal fallback resolution for its bundled
  * `claude` binary: first the platform-specific optional packages
  * (`@anthropic-ai/claude-agent-sdk-<platform>-<arch>[-musl]/claude`), then a
@@ -39,12 +66,14 @@ export function resolveSdkBundledClaudeBinary(): string | null {
   const platform = process.platform
   const arch = process.arch
   const exe = platform === 'win32' ? '.exe' : ''
-  const candidates = platform === 'linux'
-    ? [
-        `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl/claude${exe}`,
-        `@anthropic-ai/claude-agent-sdk-linux-${arch}/claude${exe}`,
-      ]
-    : [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}/claude${exe}`]
+  let candidates: string[]
+  if (platform === 'linux') {
+    const glibc = `@anthropic-ai/claude-agent-sdk-linux-${arch}/claude${exe}`
+    const musl = `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl/claude${exe}`
+    candidates = detectLinuxLibc() === 'musl' ? [musl, glibc] : [glibc, musl]
+  } else {
+    candidates = [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}/claude${exe}`]
+  }
 
   const req = createRequire(import.meta.url)
   for (const spec of candidates) {

--- a/apps/api/src/engines/executors/claude-shared/binary.ts
+++ b/apps/api/src/engines/executors/claude-shared/binary.ts
@@ -1,5 +1,6 @@
+import { createRequire } from 'node:module'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { resolveCommand } from '@/engines/spawn'
 import type { EngineAvailability, EngineModel } from '@/engines/types'
 
@@ -19,6 +20,59 @@ export function resolveClaudeBinary(): string | null {
   }
   if (existsSync('/usr/local/bin/claude')) return '/usr/local/bin/claude'
   return null
+}
+
+/**
+ * Replicates the Agent SDK's internal fallback resolution for its bundled
+ * `claude` binary: first the platform-specific optional packages
+ * (`@anthropic-ai/claude-agent-sdk-<platform>-<arch>[-musl]/claude`), then a
+ * sibling `cli.js` next to the SDK entry point. Returned path — if any — is
+ * safe to pass as `pathToClaudeCodeExecutable` and is also what the SDK itself
+ * would spawn when the option is omitted.
+ *
+ * Separated from `resolveClaudeBinary()` so availability/discovery can report
+ * "installed" in SDK-only deployments (no standalone global `claude` binary)
+ * while still distinguishing externally-installed binaries for users who want
+ * to pin a specific version.
+ */
+export function resolveSdkBundledClaudeBinary(): string | null {
+  const platform = process.platform
+  const arch = process.arch
+  const exe = platform === 'win32' ? '.exe' : ''
+  const candidates = platform === 'linux'
+    ? [
+        `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl/claude${exe}`,
+        `@anthropic-ai/claude-agent-sdk-linux-${arch}/claude${exe}`,
+      ]
+    : [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}/claude${exe}`]
+
+  const req = createRequire(import.meta.url)
+  for (const spec of candidates) {
+    try {
+      return req.resolve(spec)
+    } catch {
+      /* try next */
+    }
+  }
+
+  try {
+    const sdkPkg = req.resolve('@anthropic-ai/claude-agent-sdk/package.json')
+    const sibling = join(dirname(sdkPkg), 'cli.js')
+    if (existsSync(sibling)) return sibling
+  } catch {
+    /* SDK not resolvable — no fallback possible */
+  }
+
+  return null
+}
+
+/**
+ * Unified resolution: prefer an externally-installed standalone `claude`
+ * binary, then fall back to the SDK-bundled binary. Returns `null` only when
+ * neither is resolvable, which means the SDK itself would also fail to spawn.
+ */
+export function resolveAnyClaudeBinary(): string | null {
+  return resolveClaudeBinary() ?? resolveSdkBundledClaudeBinary()
 }
 
 export function getClaudeAuthStatus(): EngineAvailability['authStatus'] {

--- a/apps/api/src/engines/executors/claude-shared/binary.ts
+++ b/apps/api/src/engines/executors/claude-shared/binary.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { resolveCommand } from '@/engines/spawn'
+import type { EngineAvailability, EngineModel } from '@/engines/types'
+
+/**
+ * Find the `claude` binary in well-known locations WITHOUT falling back to npx.
+ * Used for availability probing and SDK `pathToClaudeCodeExecutable`.
+ */
+export function resolveClaudeBinary(): string | null {
+  if (existsSync('/work/bin/claude')) return '/work/bin/claude'
+  const fromPath = resolveCommand('claude')
+  if (fromPath) return fromPath
+  const home = process.env.HOME ?? ''
+  if (home) {
+    const homeCandidates = [join(home, '.local/bin/claude'), join(home, '.bun/bin/claude')]
+    const found = homeCandidates.find(p => existsSync(p))
+    if (found) return found
+  }
+  if (existsSync('/usr/local/bin/claude')) return '/usr/local/bin/claude'
+  return null
+}
+
+export function getClaudeAuthStatus(): EngineAvailability['authStatus'] {
+  if (process.env.ANTHROPIC_API_KEY) return 'authenticated'
+  const home = process.env.HOME ?? '/root'
+  if (existsSync(join(home, '.claude', '.credentials.json'))) return 'authenticated'
+  return 'unauthenticated'
+}
+
+/**
+ * Known Claude Code models — the CLI has no `models` subcommand, so we keep
+ * a curated static list. `[1m]` variants use the 1M-token context window.
+ */
+export const CLAUDE_MODELS: EngineModel[] = [
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', isDefault: false },
+  { id: 'claude-sonnet-4-6[1m]', name: 'Claude Sonnet 4.6 (1M)', isDefault: false },
+  { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', isDefault: true },
+  { id: 'claude-opus-4-7[1m]', name: 'Claude Opus 4.7 (1M)', isDefault: false },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', isDefault: false },
+  { id: 'claude-opus-4-6[1m]', name: 'Claude Opus 4.6 (1M)', isDefault: false },
+  { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', isDefault: false },
+]

--- a/apps/api/src/engines/executors/claude/normalizer-tool.ts
+++ b/apps/api/src/engines/executors/claude/normalizer-tool.ts
@@ -41,14 +41,71 @@ export function generateToolContent(toolName: string, input: Record<string, unkn
       return String(input.query ?? toolName)
     case 'Task':
       return input.description ? `Task: ${input.description}` : 'Task'
-    case 'Agent':
-      return input.description ? `Agent: ${input.description}` : String(input.prompt ?? 'Agent')
+    case 'Agent': {
+      // SDK AgentInput (0.2.113) carries identity + lifecycle hints we should
+      // surface: subagent_type, model, run_in_background, isolation, name.
+      const subtype = typeof input.subagent_type === 'string' ? input.subagent_type : undefined
+      const description = typeof input.description === 'string' ? input.description : undefined
+      const prompt = typeof input.prompt === 'string' ? input.prompt : undefined
+      const body = description ?? prompt ?? 'Agent'
+      const prefix = subtype ? `[${subtype}] ` : ''
+
+      const flags: string[] = []
+      if (typeof input.model === 'string') flags.push(input.model)
+      if (input.run_in_background === true) flags.push('bg')
+      if (input.isolation === 'worktree') flags.push('worktree')
+      if (typeof input.name === 'string' && input.name.length > 0) {
+        flags.push(`as ${input.name}`)
+      }
+      const suffix = flags.length > 0 ? ` (${flags.join(', ')})` : ''
+      return `${prefix}${body}${suffix}`
+    }
     case 'TodoWrite':
       return 'TODO list updated'
     case 'ExitPlanMode':
       return String(input.plan ?? 'Plan submitted')
     case 'NotebookEdit':
       return String(input.notebook_path ?? toolName)
+    case 'ScheduleWakeup': {
+      const delay = input.delaySeconds
+      const reason = typeof input.reason === 'string' ? input.reason : undefined
+      if (typeof delay === 'number') {
+        return reason ? `wake in ${delay}s — ${reason}` : `wake in ${delay}s`
+      }
+      return reason ?? 'ScheduleWakeup'
+    }
+    case 'Monitor': {
+      // Claude CLI runtime tool for streaming background task output.
+      // No published schema — accept common shapes defensively.
+      const taskId = input.task_id ?? input.taskId ?? input.shell_id
+      const cmd = input.command ?? input.until
+      if (taskId) return `monitor ${String(taskId)}`
+      if (cmd) return `monitor ${String(cmd)}`
+      return 'Monitor'
+    }
+    case 'TaskOutput':
+      return input.task_id ? `output ${String(input.task_id)}` : 'TaskOutput'
+    case 'TaskStop':
+      return input.task_id || input.shell_id
+        ? `stop ${String(input.task_id ?? input.shell_id)}`
+        : 'TaskStop'
+    case 'AskUserQuestion': {
+      const qs = input.questions
+      if (Array.isArray(qs) && qs.length > 0) {
+        const first = qs[0] as { question?: unknown }
+        const q = typeof first?.question === 'string' ? first.question : undefined
+        if (q) return qs.length > 1 ? `${q} (+${qs.length - 1})` : q
+      }
+      return 'AskUserQuestion'
+    }
+    case 'EnterWorktree': {
+      const target = input.path ?? input.name
+      return target ? `worktree: ${String(target)}` : 'EnterWorktree (new)'
+    }
+    case 'ExitWorktree': {
+      const action = typeof input.action === 'string' ? input.action : 'exit'
+      return `worktree ${action}`
+    }
     // Server-side tools
     case 'code_execution':
     case 'bash_code_execution':

--- a/apps/api/src/engines/executors/claude/normalizer-types.ts
+++ b/apps/api/src/engines/executors/claude/normalizer-types.ts
@@ -28,6 +28,9 @@ export interface ClaudeSystem {
   tools?: unknown[]
   apiKeySource?: string
   status?: string
+  // session_state_changed carries the authoritative turn-over signal
+  // ('idle' after the bg-agent do-while exits).
+  state?: 'idle' | 'running' | 'requires_action' | string
   slash_commands?: string[]
   plugins?: Array<{ name: string, path: string }>
   agents?: string[]

--- a/apps/api/src/engines/executors/claude/normalizer.ts
+++ b/apps/api/src/engines/executors/claude/normalizer.ts
@@ -118,6 +118,23 @@ export class ClaudeLogNormalizer {
       case 'stop_hook_summary':
         // Suppress — no user-facing value
         return null
+      case 'session_state_changed':
+        // SDK marks `state === 'idle'` as the authoritative turn-over signal
+        // (fires after heldBackResult flushes and the bg-agent loop exits).
+        // Surface it as turn-completion so sessions that never receive a
+        // `type: 'result'` still settle. running/requires_action are noise.
+        if (data.state !== 'idle') return null
+        return {
+          entryType: 'system-message',
+          content: '',
+          timestamp: data.timestamp,
+          metadata: {
+            subtype: data.subtype,
+            state: data.state,
+            turnCompleted: true,
+            sessionId: data.session_id,
+          },
+        }
       case 'status':
         if (data.status) {
           return {

--- a/apps/api/src/engines/executors/index.ts
+++ b/apps/api/src/engines/executors/index.ts
@@ -5,14 +5,44 @@ import type {
   EngineRegistry,
   EngineType,
 } from '@/engines/types'
+import { logger } from '@/logger'
 import { AcpExecutor } from './acp'
 import { ClaudeCodeExecutor } from './claude'
+import { ClaudeCodeSdkExecutor } from './claude-sdk'
 import { CodexExecutor } from './codex'
 
 // Re-export executor classes
 export { AcpExecutor } from './acp'
 export { ClaudeCodeExecutor } from './claude'
+export { ClaudeCodeSdkExecutor } from './claude-sdk'
 export { CodexExecutor } from './codex'
+
+/**
+ * Backend selector for the `claude-code` engine. Controlled by
+ * `CLAUDE_ENGINE_BACKEND` env var:
+ *   - `sdk`    — Anthropic's `@anthropic-ai/claude-agent-sdk` (migration target)
+ *   - `legacy` — hand-rolled stream-json executor (default during rollout)
+ *
+ * See PLAN-003.
+ */
+export type ClaudeBackend = 'sdk' | 'legacy'
+
+export function getClaudeBackend(): ClaudeBackend {
+  const raw = (process.env.CLAUDE_ENGINE_BACKEND ?? '').trim().toLowerCase()
+  if (raw === 'sdk') return 'sdk'
+  if (raw === 'legacy') return 'legacy'
+  return 'legacy'
+}
+
+export function createClaudeExecutor(): EngineExecutor {
+  const backend = getClaudeBackend()
+  if (backend === 'sdk') {
+    logger.info({ backend }, 'claude_backend_selected')
+    return new ClaudeCodeSdkExecutor()
+  }
+  logger.info({ backend }, 'claude_backend_selected')
+  return new ClaudeCodeExecutor()
+}
 
 /**
  * Default engine registry — manages all executor instances.
@@ -62,7 +92,7 @@ function createRegistry(): EngineRegistry {
   const registry = new DefaultEngineRegistry()
 
   // Register all supported executors
-  registry.register(new ClaudeCodeExecutor())
+  registry.register(createClaudeExecutor())
   registry.register(new CodexExecutor())
   registry.register(new AcpExecutor())
 

--- a/apps/api/src/engines/executors/index.ts
+++ b/apps/api/src/engines/executors/index.ts
@@ -18,10 +18,10 @@ export { ClaudeCodeSdkExecutor } from './claude-sdk'
 export { CodexExecutor } from './codex'
 
 /**
- * Backend selector for the `claude-code` engine. Controlled by
- * `CLAUDE_ENGINE_BACKEND` env var:
- *   - `sdk`    — Anthropic's `@anthropic-ai/claude-agent-sdk` (migration target)
- *   - `legacy` — hand-rolled stream-json executor (default during rollout)
+ * Legacy backend selector. Deprecated — both executors are now registered as
+ * independent `claude-code` (legacy) and `claude-code-sdk` engine types so
+ * users can choose per-issue in the UI. Kept for test compatibility and so
+ * operators running older configs see a clear deprecation signal in logs.
  *
  * See PLAN-003.
  */
@@ -32,16 +32,6 @@ export function getClaudeBackend(): ClaudeBackend {
   if (raw === 'sdk') return 'sdk'
   if (raw === 'legacy') return 'legacy'
   return 'legacy'
-}
-
-export function createClaudeExecutor(): EngineExecutor {
-  const backend = getClaudeBackend()
-  if (backend === 'sdk') {
-    logger.info({ backend }, 'claude_backend_selected')
-    return new ClaudeCodeSdkExecutor()
-  }
-  logger.info({ backend }, 'claude_backend_selected')
-  return new ClaudeCodeExecutor()
 }
 
 /**
@@ -91,8 +81,17 @@ export const engineRegistry: EngineRegistry = createRegistry()
 function createRegistry(): EngineRegistry {
   const registry = new DefaultEngineRegistry()
 
-  // Register all supported executors
-  registry.register(createClaudeExecutor())
+  // Register all supported executors. `claude-code` (legacy) and
+  // `claude-code-sdk` (SDK-backed) are both available — users pick per issue.
+  const backend = getClaudeBackend()
+  if (process.env.CLAUDE_ENGINE_BACKEND) {
+    logger.info(
+      { backend },
+      'claude_engine_backend_env_deprecated_pick_claude_code_sdk_in_ui',
+    )
+  }
+  registry.register(new ClaudeCodeExecutor())
+  registry.register(new ClaudeCodeSdkExecutor())
   registry.register(new CodexExecutor())
   registry.register(new AcpExecutor())
 

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -71,9 +71,22 @@ function terminateAndSettle(
   })
 }
 
-/** Check if a process is still alive via kill(pid, 0). */
-function isProcessAlive(pid: number | undefined): boolean {
-  if (!pid) return false
+/**
+ * Check if a process is still alive.
+ *
+ * Preferred path (`pid` known): `process.kill(pid, 0)`.
+ * Fallback (`pid` undefined, e.g. SDK-backed handles): delegate to the
+ * handle's own `isAlive()` probe. If neither is available we assume the
+ * process is alive — safer than letting stall GC force-kill healthy queries
+ * whose backend simply doesn't expose a pid.
+ */
+function isProcessAlive(
+  pid: number | undefined,
+  handle?: { isAlive?: () => boolean },
+): boolean {
+  if (pid === undefined) {
+    return handle?.isAlive?.() ?? true
+  }
   try {
     process.kill(pid, 0)
     return true
@@ -145,8 +158,9 @@ export function gcSweep(ctx: EngineContext): void {
         if (managed.turnInFlight) {
           const silenceMs = now - managed.lastActivityAt.getTime()
           if (silenceMs > KEEPALIVE_STALL_TIMEOUT_MS) {
-            const pid = (managed.process.subprocess as { pid?: number }).pid
-            const alive = isProcessAlive(pid)
+            const sp = managed.process.subprocess as { pid?: number, isAlive?: () => boolean }
+            const pid = sp.pid
+            const alive = isProcessAlive(pid, sp)
             if (!alive) {
               const stallMinutes = Math.round(silenceMs / 60000)
               logger.warn(
@@ -178,7 +192,8 @@ export function gcSweep(ctx: EngineContext): void {
       //   Tier 3 (+ STALL_INTERRUPT_GRACE_MS): No response after interrupt → force kill
       if (managed.turnInFlight) {
         const silenceMs = now - managed.lastActivityAt.getTime()
-        const pid = (managed.process.subprocess as { pid?: number }).pid
+        const sp = managed.process.subprocess as { pid?: number, isAlive?: () => boolean }
+        const pid = sp.pid
 
         // Tier 3: interrupt was sent but process still hasn't responded
         if (
@@ -219,7 +234,7 @@ export function gcSweep(ctx: EngineContext): void {
           now - managed.stallDetectedAt.getTime() > STALL_LIVENESS_GRACE_MS
         ) {
           const stallMinutes = Math.round(silenceMs / 60000)
-          const alive = isProcessAlive(pid)
+          const alive = isProcessAlive(pid, sp)
           if (!alive) {
             // Process already dead — skip interrupt, just terminate
             logger.warn(
@@ -278,7 +293,7 @@ export function gcSweep(ctx: EngineContext): void {
           !managed.stallProbeAt &&
           silenceMs > STREAM_STALL_TIMEOUT_MS
         ) {
-          const alive = isProcessAlive(pid)
+          const alive = isProcessAlive(pid, sp)
           const stallMinutes = Math.round(silenceMs / 60000)
           logger.warn(
             {

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -19,7 +19,7 @@ const EMPTY_CATEGORIZED: CategorizedCommands = {
 }
 
 /** All known engine types for cache loading. */
-const ALL_ENGINE_TYPES: EngineType[] = ['claude-code', 'codex', 'acp']
+const ALL_ENGINE_TYPES: EngineType[] = ['claude-code', 'claude-code-sdk', 'codex', 'acp']
 
 /** Per-engine in-memory cache for categorized commands from DB. */
 const cachedCommands = new Map<EngineType, CategorizedCommands>()

--- a/apps/api/src/engines/issue/streams/classification.ts
+++ b/apps/api/src/engines/issue/streams/classification.ts
@@ -3,15 +3,20 @@ import type { NormalizedLogEntry } from '@/engines/types'
 // ---------- Pure classification functions ----------
 
 export function isTurnCompletionEntry(entry: NormalizedLogEntry): boolean {
+  // Explicit signals set by the normalizer when it recognizes a turn-over
+  // message. These cover:
+  //  - Claude `type: 'result'` → turnCompleted + resultSubtype
+  //  - Claude `type: 'system', subtype: 'session_state_changed', state: 'idle'`
+  //    → turnCompleted (the SDK's "authoritative turn-over signal")
+  //  - Codex / ACP normalizers setting turnCompleted on their own completions.
+  // A looser fallback keyed on `metadata.duration` was removed: it duplicated
+  // the result path and risked false positives on background task
+  // notifications whose usage blocks also carry a duration_ms field.
   if (entry.metadata?.turnCompleted === true) return true
   if (entry.metadata && Object.hasOwn(entry.metadata, 'resultSubtype')) {
     return true
   }
-  return (
-    entry.entryType === 'system-message' &&
-    !!entry.metadata &&
-    Object.hasOwn(entry.metadata, 'duration')
-  )
+  return false
 }
 
 export function isCancelledNoiseEntry(entry: NormalizedLogEntry): boolean {

--- a/apps/api/src/engines/process-handle.ts
+++ b/apps/api/src/engines/process-handle.ts
@@ -1,0 +1,16 @@
+/**
+ * Minimal process handle contract consumed by ProcessManager.
+ *
+ * PM manages lifecycle (pid logging, wait-for-exit, kill on timeout), not I/O.
+ * Narrowing PM's dependency from Bun's `Subprocess` to this interface lets
+ * non-subprocess backends (e.g. the Claude Agent SDK's `Query`) plug in via a
+ * thin wrapper without faking full Subprocess semantics.
+ *
+ * `Bun.Subprocess` and the `Subprocess` shape returned by `spawnNode()` both
+ * already satisfy this interface structurally.
+ */
+export interface ProcessHandle {
+  readonly pid?: number
+  readonly exited: Promise<number>
+  kill: (signal?: number) => void
+}

--- a/apps/api/src/engines/process-handle.ts
+++ b/apps/api/src/engines/process-handle.ts
@@ -13,4 +13,10 @@ export interface ProcessHandle {
   readonly pid?: number
   readonly exited: Promise<number>
   kill: (signal?: number) => void
+  /**
+   * Optional liveness probe for backends that do not expose a PID.
+   * When present, stall GC uses this in place of `process.kill(pid, 0)`.
+   * Returning `true` means "still running"; `false` means "definitely dead".
+   */
+  isAlive?: () => boolean
 }

--- a/apps/api/src/engines/process-manager.ts
+++ b/apps/api/src/engines/process-manager.ts
@@ -1,4 +1,4 @@
-import type { Subprocess } from '@/engines/spawn'
+import type { ProcessHandle } from '@/engines/process-handle'
 
 // ---------- Types ----------
 
@@ -9,7 +9,7 @@ const TERMINAL_STATES: ReadonlySet<ProcessState> = new Set(['completed', 'failed
 export interface ManagedEntry<TMeta> {
   readonly id: string
   readonly group?: string
-  readonly subprocess: Subprocess
+  readonly handle: ProcessHandle
   state: ProcessState
   readonly startedAt: Date
   finishedAt?: Date
@@ -104,7 +104,7 @@ export class ProcessManager<TMeta> {
 
   register(
     id: string,
-    subprocess: Subprocess,
+    handle: ProcessHandle,
     meta: TMeta,
     opts?: { group?: string, startAsRunning?: boolean },
   ): ManagedEntry<TMeta> {
@@ -121,7 +121,7 @@ export class ProcessManager<TMeta> {
     const entry: ManagedEntry<TMeta> = {
       id,
       group: opts?.group,
-      subprocess,
+      handle,
       state: opts?.startAsRunning ? 'running' : 'spawning',
       startedAt: new Date(),
       meta,
@@ -169,12 +169,12 @@ export class ProcessManager<TMeta> {
 
     const killTimeout = setTimeout(() => {
       try {
-        entry.subprocess.kill(9)
+        entry.handle.kill(9)
         this.log.info?.(
           {
             pm: this.name,
             id,
-            pid: (entry.subprocess as { pid?: number }).pid,
+            pid: entry.handle.pid,
           },
           'pm_sigkill_sent',
         )
@@ -184,7 +184,7 @@ export class ProcessManager<TMeta> {
     }, this.killTimeoutMs)
 
     try {
-      await entry.subprocess.exited
+      await entry.handle.exited
     } catch (err) {
       this.log.debug?.({ pm: this.name, id, err }, 'pm_terminate_exited_error')
     } finally {
@@ -216,9 +216,9 @@ export class ProcessManager<TMeta> {
   forceKill(id: string): void {
     const entry = this.entries.get(id)
     if (!entry) return
-    const pid = (entry.subprocess as { pid?: number }).pid
+    const pid = entry.handle.pid
     try {
-      entry.subprocess.kill(9)
+      entry.handle.kill(9)
       this.log.info?.({ pm: this.name, id, group: entry.group, pid }, 'pm_force_kill')
     } catch {
       this.log.debug?.({ pm: this.name, id, pid }, 'pm_force_kill_already_dead')
@@ -375,7 +375,7 @@ export class ProcessManager<TMeta> {
   }
 
   private monitorExit(entry: ManagedEntry<TMeta>): void {
-    void entry.subprocess.exited
+    void entry.handle.exited
       .then((exitCode) => {
         const code = exitCode ?? 1
         entry.exitCode = code
@@ -387,7 +387,7 @@ export class ProcessManager<TMeta> {
             group: entry.group,
             exitCode: code,
             prevState: entry.state,
-            pid: (entry.subprocess as { pid?: number }).pid,
+            pid: entry.handle.pid,
           },
           'pm_process_exited',
         )

--- a/apps/api/src/engines/safe-env.ts
+++ b/apps/api/src/engines/safe-env.ts
@@ -54,6 +54,7 @@ const PROTECTED_KEYS = new Set([
  */
 const ENGINE_API_KEYS: Record<string, string[]> = {
   'claude-code': ['ANTHROPIC_API_KEY'],
+  'claude-code-sdk': ['ANTHROPIC_API_KEY'],
   'codex': ['OPENAI_API_KEY', 'CODEX_API_KEY'],
   'acp': ['GOOGLE_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'CODEX_API_KEY', 'ANTHROPIC_API_KEY'],
 }

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -161,9 +161,9 @@ async function discoverSlashCommands(installed: EngineAvailability[]): Promise<v
   }
 
   for (const engine of installed) {
-    if (engine.engineType !== 'claude-code') continue
+    if (engine.engineType !== 'claude-code' && engine.engineType !== 'claude-code-sdk') continue
 
-    const executor = engineRegistry.get('claude-code')
+    const executor = engineRegistry.get(engine.engineType)
     if (!(executor instanceof ClaudeCodeExecutor) && !(executor instanceof ClaudeCodeSdkExecutor)) {
       continue
     }
@@ -172,7 +172,7 @@ async function discoverSlashCommands(installed: EngineAvailability[]): Promise<v
       const result = await withTimeout(
         executor.discoverSlashCommandsAndAgents(process.cwd()),
         DISCOVERY_TIMEOUT_MS,
-        'claude-code:discovery',
+        `${engine.engineType}:discovery`,
       )
 
       // Only persist when init was actually received. If the process timed
@@ -184,14 +184,14 @@ async function discoverSlashCommands(installed: EngineAvailability[]): Promise<v
       }
 
       await setAppSetting(
-        slashCommandsKey('claude-code'),
+        slashCommandsKey(engine.engineType),
         JSON.stringify({
           commands: result.slashCommands,
           agents: result.agents,
           plugins: result.plugins,
         }),
       )
-      await refreshSlashCommandsCacheForEngine('claude-code')
+      await refreshSlashCommandsCacheForEngine(engine.engineType)
 
       logger.info(
         {

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -2,7 +2,7 @@ import { cacheGet, cacheSet } from '@/cache'
 import { getProbeResults, saveProbeResults, setAppSetting } from '@/db/helpers'
 import { refreshSlashCommandsCacheForEngine, slashCommandsKey } from '@/engines/issue/queries'
 import { logger } from '@/logger'
-import { ClaudeCodeExecutor, engineRegistry } from './executors'
+import { ClaudeCodeExecutor, ClaudeCodeSdkExecutor, engineRegistry } from './executors'
 import type { AcpAgentId } from './executors/acp/agents'
 import { getAcpAgents } from './executors/acp/agents'
 import type { EngineAvailability, EngineModel, EngineType } from './types'
@@ -164,7 +164,9 @@ async function discoverSlashCommands(installed: EngineAvailability[]): Promise<v
     if (engine.engineType !== 'claude-code') continue
 
     const executor = engineRegistry.get('claude-code')
-    if (!(executor instanceof ClaudeCodeExecutor)) continue
+    if (!(executor instanceof ClaudeCodeExecutor) && !(executor instanceof ClaudeCodeSdkExecutor)) {
+      continue
+    }
 
     try {
       const result = await withTimeout(

--- a/apps/api/src/engines/types.ts
+++ b/apps/api/src/engines/types.ts
@@ -3,7 +3,7 @@ import type { Subprocess } from '@/engines/spawn'
 // ---------- Enums / Literal Unions ----------
 
 // Supported AI engine types
-export type EngineType = 'claude-code' | 'codex' | 'acp' | `acp:${string}`
+export type EngineType = 'claude-code' | 'claude-code-sdk' | 'codex' | 'acp' | `acp:${string}`
 
 // Communication protocols
 export type EngineProtocol = 'stream-json' | 'json-rpc' | 'acp'
@@ -215,11 +215,19 @@ export interface EngineRegistry {
 // ---------- Constants ----------
 
 // Default built-in engine profiles
-export const BUILT_IN_PROFILES: Partial<Record<EngineType, EngineProfile>> & Record<'claude-code' | 'codex' | 'acp', EngineProfile> = {
+export const BUILT_IN_PROFILES: Partial<Record<EngineType, EngineProfile>> & Record<'claude-code' | 'claude-code-sdk' | 'codex' | 'acp', EngineProfile> = {
   'claude-code': {
     engineType: 'claude-code',
     name: 'Claude Code',
     baseCommand: 'npx -y @anthropic-ai/claude-code@latest',
+    protocol: 'stream-json',
+    capabilities: ['session-fork', 'context-usage', 'plan-mode'],
+    permissionPolicy: 'auto',
+  },
+  'claude-code-sdk': {
+    engineType: 'claude-code-sdk',
+    name: 'Claude Code (SDK)',
+    baseCommand: '@anthropic-ai/claude-agent-sdk',
     protocol: 'stream-json',
     capabilities: ['session-fork', 'context-usage', 'plan-mode'],
     permissionPolicy: 'auto',

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -138,7 +138,7 @@ export const CreateIssueSchema = z.object({
   statusId: statusIdEnum,
   useWorktree: z.boolean().optional(),
   keepAlive: z.boolean().optional(),
-  engineType: z.string().regex(/^(claude-code|codex|acp(:.+)?)$/).optional().openapi({ description: 'claude-code | codex | acp | acp:<agent>:<model>' }),
+  engineType: z.string().regex(/^(claude-code|claude-code-sdk|codex|acp(:.+)?)$/).optional().openapi({ description: 'claude-code | claude-code-sdk | codex | acp | acp:<agent>:<model>' }),
   model: z.string().regex(/^[\w./:\-[\]]{1,160}$/).optional(),
   permissionMode: z.enum(['auto', 'supervised', 'plan']).optional(),
 }).openapi('CreateIssue')
@@ -174,7 +174,7 @@ export const BulkUpdateSchema = z.object({
 }).openapi('BulkUpdate')
 
 export const ExecuteIssueSchema = z.object({
-  engineType: z.string().regex(/^(claude-code|codex|acp(:.+)?)$/).openapi({ description: 'claude-code | codex | acp | acp:<agent>:<model>' }),
+  engineType: z.string().regex(/^(claude-code|claude-code-sdk|codex|acp(:.+)?)$/).openapi({ description: 'claude-code | claude-code-sdk | codex | acp | acp:<agent>:<model>' }),
   prompt: z.string().min(1).max(32768),
   model: z.string().regex(/^[\w./:\-[\]]{1,160}$/).optional(),
   permissionMode: z.enum(['auto', 'supervised', 'plan']).optional(),
@@ -502,7 +502,7 @@ export const WhiteboardAskSchema = z.object({
   // If omitted, the AI operates on the whole tree without a specific focus.
   nodeId: z.string().optional(),
   prompt: z.string().min(1).max(32768),
-  engineType: z.string().regex(/^(claude-code|codex|acp(:.+)?)$/).optional(),
+  engineType: z.string().regex(/^(claude-code|claude-code-sdk|codex|acp(:.+)?)$/).optional(),
   model: z.string().regex(/^[\w./:\-[\]]{1,160}$/).optional(),
 }).openapi('WhiteboardAsk')
 

--- a/apps/api/src/routes/engines.ts
+++ b/apps/api/src/routes/engines.ts
@@ -15,7 +15,7 @@ import { BUILT_IN_PROFILES } from '@/engines/types'
 import { createOpenAPIRouter } from '@/openapi/hono'
 import * as R from '@/openapi/routes'
 
-const ENGINE_TYPES = ['claude-code', 'codex', 'acp'] as const
+const ENGINE_TYPES = ['claude-code', 'claude-code-sdk', 'codex', 'acp'] as const
 
 /** Accept both base engine types and known virtual ACP types (e.g. "acp:codex") */
 const engineTypeOrAcpEnum = z.string().refine(

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -27,7 +27,7 @@ export const createIssueSchema = z.object({
   useWorktree: z.boolean().optional(),
   keepAlive: z.boolean().optional(),
   engineType: z.string().refine(
-    val => ['claude-code', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
+    val => ['claude-code', 'claude-code-sdk', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
   ).optional(),
   model: z
@@ -74,7 +74,7 @@ export const updateIssueSchema = z.object({
 
 export const executeIssueSchema = z.object({
   engineType: z.string().refine(
-    val => ['claude-code', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
+    val => ['claude-code', 'claude-code-sdk', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
   ),
   prompt: z.string().min(1).max(32768),

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -233,7 +233,7 @@ general.openapi(R.setServerInfo, async (c) => {
 
 // GET /api/settings/slash-commands?engine=claude-code
 general.openapi(R.getGlobalSlashCommands, async (c) => {
-  const validEngines = ['claude-code', 'codex', 'acp']
+  const validEngines = ['claude-code', 'claude-code-sdk', 'codex', 'acp']
   const rawEngine = c.req.query('engine')
   if (rawEngine && !validEngines.includes(rawEngine) && !rawEngine.startsWith('acp:')) {
     return c.json({ success: false, error: `Invalid engine type: ${rawEngine}` }, 400 as const)

--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -68,6 +68,7 @@ interface WsLike {
 interface TerminalMeta {
   wsRaw: WsLike | null
   graceTimer: ReturnType<typeof setTimeout> | null
+  pty: Subprocess
 }
 
 const MAX_SESSIONS = 10
@@ -88,7 +89,7 @@ function killSession(id: string): void {
   if (!entry) return
   if (entry.meta.graceTimer) clearTimeout(entry.meta.graceTimer)
   try {
-    entry.subprocess.terminal?.close()
+    entry.meta.pty.terminal?.close()
   } catch {
     /* already closed */
   }
@@ -150,7 +151,7 @@ app.post('/terminal', (c) => {
   // We need a reference the PTY data callback can close over
   // to forward output to the attached WS. The meta object is
   // shared by reference with the PM entry.
-  const meta: TerminalMeta = { wsRaw: null, graceTimer: null }
+  const meta: TerminalMeta = { wsRaw: null, graceTimer: null, pty: null as unknown as Subprocess }
 
   const proc = Bun.spawn([defaultShell, '-l'], {
     terminal: {
@@ -177,6 +178,8 @@ app.post('/terminal', (c) => {
       LC_CTYPE: process.env.LC_CTYPE || 'C.UTF-8',
     },
   }) as unknown as Subprocess
+
+  meta.pty = proc
 
   try {
     terminalPM.register(id, proc, meta, {
@@ -236,12 +239,13 @@ app.get(
         myWsRaw = ws.raw as WsLike
         entry.meta.wsRaw = myWsRaw
 
-        logger.info({ id, pid: entry.subprocess.pid }, 'terminal_ws_attached')
+        logger.info({ id, pid: entry.handle.pid }, 'terminal_ws_attached')
       },
 
       onMessage(evt) {
         const entry = terminalPM.get(id)
-        if (!entry?.subprocess?.terminal) return
+        const pty = entry?.meta.pty
+        if (!pty?.terminal) return
 
         const raw =
           evt.data instanceof ArrayBuffer ?
@@ -257,14 +261,14 @@ app.get(
         if (type === 0) {
           // Input: [0x00][...data]
           const input = new TextDecoder().decode(raw.slice(1))
-          entry.subprocess.terminal.write(input)
+          pty.terminal.write(input)
         } else if (type === 1 && raw.length >= 5) {
           // Resize: [0x01][cols:u16BE][rows:u16BE]
           const view = new DataView(raw.buffer, raw.byteOffset, raw.byteLength)
           const cols = view.getUint16(1, false)
           const rows = view.getUint16(3, false)
           if (cols > 0 && cols <= MAX_COLS && rows > 0 && rows <= MAX_ROWS) {
-            entry.subprocess.terminal.resize(cols, rows)
+            pty.terminal.resize(cols, rows)
           }
         }
       },
@@ -332,7 +336,7 @@ app.post(
 
     const { cols, rows } = c.req.valid('json')
     try {
-      entry.subprocess.terminal?.resize(cols, rows)
+      entry.meta.pty.terminal?.resize(cols, rows)
     } catch {
       /* terminal closed */
     }
@@ -348,7 +352,7 @@ app.delete('/terminal/:id', (c) => {
     return c.json({ success: false, error: 'Session not found' }, 404)
   }
 
-  logger.info({ id, pid: entry.subprocess.pid }, 'terminal_session_killed')
+  logger.info({ id, pid: entry.handle.pid }, 'terminal_session_killed')
   killSession(id)
 
   return c.json({ success: true })

--- a/apps/api/test/claude-normalizer.test.ts
+++ b/apps/api/test/claude-normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { ClaudeLogNormalizer } from '@/engines/executors/claude'
+import { generateToolContent } from '@/engines/executors/claude/normalizer-tool'
 import type { NormalizedLogEntry } from '@/engines/types'
 
 function line(obj: Record<string, unknown>): string {
@@ -882,5 +883,122 @@ describe('ClaudeLogNormalizer', () => {
       expect(entries[0]!.content).toContain('Something went wrong')
       expect(entries[0]!.metadata?.isError).toBe(true)
     })
+  })
+})
+
+describe('generateToolContent — SDK 0.2.113 new tools', () => {
+  test('ScheduleWakeup with delay + reason', () => {
+    expect(generateToolContent('ScheduleWakeup', { delaySeconds: 120, reason: 'poll build' }))
+      .toBe('wake in 120s — poll build')
+  })
+
+  test('ScheduleWakeup with delay only', () => {
+    expect(generateToolContent('ScheduleWakeup', { delaySeconds: 60 })).toBe('wake in 60s')
+  })
+
+  test('ScheduleWakeup with neither — falls back to tool name', () => {
+    expect(generateToolContent('ScheduleWakeup', {})).toBe('ScheduleWakeup')
+  })
+
+  test('Monitor by task_id', () => {
+    expect(generateToolContent('Monitor', { task_id: 'abc123' })).toBe('monitor abc123')
+  })
+
+  test('Monitor by command fallback', () => {
+    expect(generateToolContent('Monitor', { command: 'bun test' })).toBe('monitor bun test')
+  })
+
+  test('Monitor with no fields', () => {
+    expect(generateToolContent('Monitor', {})).toBe('Monitor')
+  })
+
+  test('TaskOutput extracts task_id', () => {
+    expect(generateToolContent('TaskOutput', { task_id: 't-1', block: true, timeout: 1000 }))
+      .toBe('output t-1')
+  })
+
+  test('TaskStop extracts task_id (or legacy shell_id)', () => {
+    expect(generateToolContent('TaskStop', { task_id: 't-1' })).toBe('stop t-1')
+    expect(generateToolContent('TaskStop', { shell_id: 's-9' })).toBe('stop s-9')
+  })
+
+  test('AskUserQuestion extracts first question', () => {
+    expect(generateToolContent('AskUserQuestion', {
+      questions: [
+        { question: 'Which DB?', header: 'DB', options: [] },
+      ],
+    })).toBe('Which DB?')
+  })
+
+  test('AskUserQuestion indicates multiple questions', () => {
+    expect(generateToolContent('AskUserQuestion', {
+      questions: [
+        { question: 'Which DB?' },
+        { question: 'Which cache?' },
+      ],
+    })).toBe('Which DB? (+1)')
+  })
+
+  test('EnterWorktree by path', () => {
+    expect(generateToolContent('EnterWorktree', { path: '/tmp/wt-1' })).toBe('worktree: /tmp/wt-1')
+  })
+
+  test('EnterWorktree without path/name → new', () => {
+    expect(generateToolContent('EnterWorktree', {})).toBe('EnterWorktree (new)')
+  })
+
+  test('ExitWorktree reports action', () => {
+    expect(generateToolContent('ExitWorktree', { action: 'remove' })).toBe('worktree remove')
+    expect(generateToolContent('ExitWorktree', {})).toBe('worktree exit')
+  })
+})
+
+describe('generateToolContent — Agent (sub-agent)', () => {
+  test('description only — legacy compatible body', () => {
+    expect(generateToolContent('Agent', { description: 'Investigate bug' }))
+      .toBe('Investigate bug')
+  })
+
+  test('subagent_type surfaces as prefix', () => {
+    expect(generateToolContent('Agent', {
+      description: 'Find files',
+      subagent_type: 'Explore',
+    })).toBe('[Explore] Find files')
+  })
+
+  test('model + background + worktree render as trailing flags', () => {
+    expect(generateToolContent('Agent', {
+      description: 'Plan migration',
+      subagent_type: 'Plan',
+      model: 'opus',
+      run_in_background: true,
+      isolation: 'worktree',
+    })).toBe('[Plan] Plan migration (opus, bg, worktree)')
+  })
+
+  test('name is rendered as "as <name>"', () => {
+    expect(generateToolContent('Agent', {
+      description: 'Reviewer',
+      subagent_type: 'code-reviewer',
+      name: 'reviewer-1',
+    })).toBe('[code-reviewer] Reviewer (as reviewer-1)')
+  })
+
+  test('falls back to prompt when description missing', () => {
+    expect(generateToolContent('Agent', {
+      prompt: 'Do the thing',
+      subagent_type: 'general-purpose',
+    })).toBe('[general-purpose] Do the thing')
+  })
+
+  test('empty input falls back to literal "Agent"', () => {
+    expect(generateToolContent('Agent', {})).toBe('Agent')
+  })
+
+  test('ignores unknown isolation values', () => {
+    expect(generateToolContent('Agent', {
+      description: 'x',
+      isolation: 'container',
+    })).toBe('x')
   })
 })

--- a/apps/api/test/claude-normalizer.test.ts
+++ b/apps/api/test/claude-normalizer.test.ts
@@ -827,6 +827,42 @@ describe('ClaudeLogNormalizer', () => {
       expect(entries[0]!.content).toBe('hook result')
       expect(entries[0]!.metadata?.hookName).toBe('pre-commit')
     })
+
+    test('session_state_changed with state=idle marks turn completed', () => {
+      const entries = parseAll(
+        normalizer,
+        line({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
+          session_id: 'sess-1',
+        }),
+      )
+      expect(entries).toHaveLength(1)
+      expect(entries[0]!.entryType).toBe('system-message')
+      expect(entries[0]!.metadata?.turnCompleted).toBe(true)
+      expect(entries[0]!.metadata?.state).toBe('idle')
+    })
+
+    test('session_state_changed with non-idle state is suppressed', () => {
+      const running = normalizer.parse(
+        line({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'running',
+        }),
+      )
+      expect(running).toBeNull()
+
+      const awaiting = normalizer.parse(
+        line({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'requires_action',
+        }),
+      )
+      expect(awaiting).toBeNull()
+    })
   })
 
   describe('result error handling', () => {

--- a/apps/api/test/claude-sdk.test.ts
+++ b/apps/api/test/claude-sdk.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+import type { Query } from '@anthropic-ai/claude-agent-sdk'
+import { ClaudeSdkNormalizer, SdkProcessHandle } from '@/engines/executors/claude-sdk'
+import { PushableStream } from '@/engines/executors/claude-sdk/pushable-stream'
+import { getClaudeBackend } from '@/engines/executors/index'
+
+// ---------- PushableStream ----------
+
+describe('PushableStream', () => {
+  test('delivers queued values before close', async () => {
+    const stream = new PushableStream<number>()
+    stream.push(1)
+    stream.push(2)
+    stream.close()
+
+    const collected: number[] = []
+    for await (const v of stream) collected.push(v)
+    expect(collected).toEqual([1, 2])
+  })
+
+  test('resolves pending consumer when value arrives', async () => {
+    const stream = new PushableStream<string>()
+    const iter = stream[Symbol.asyncIterator]()
+    const firstPromise = iter.next()
+    stream.push('hello')
+    const first = await firstPromise
+    expect(first.done).toBe(false)
+    expect(first.value).toBe('hello')
+  })
+
+  test('close resolves pending consumers with done', async () => {
+    const stream = new PushableStream<number>()
+    const iter = stream[Symbol.asyncIterator]()
+    const pending = iter.next()
+    stream.close()
+    const result = await pending
+    expect(result.done).toBe(true)
+  })
+
+  test('push after close is a no-op', () => {
+    const stream = new PushableStream<number>()
+    stream.close()
+    stream.push(42) // should not throw
+    expect(stream.isClosed).toBe(true)
+  })
+})
+
+// ---------- SdkProcessHandle ----------
+
+function makeMockQuery(): Query & {
+  interruptCount: number
+  closeCount: number
+} {
+  let interruptCount = 0
+  let closeCount = 0
+  const q = {
+    get interruptCount() {
+      return interruptCount
+    },
+    get closeCount() {
+      return closeCount
+    },
+    interrupt: async (): Promise<void> => {
+      interruptCount++
+    },
+    close: (): void => {
+      closeCount++
+    },
+  } as unknown as Query & { interruptCount: number, closeCount: number }
+  return q
+}
+
+describe('SdkProcessHandle', () => {
+  test('first kill triggers interrupt, second triggers close, third is no-op', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.kill()
+    handle.kill()
+    handle.kill()
+    expect(q.interruptCount).toBe(1)
+    expect(q.closeCount).toBe(1)
+  })
+
+  test('settle resolves exited promise exactly once', async () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.settle(0)
+    handle.settle(42) // ignored
+    await expect(handle.exited).resolves.toBe(0)
+    expect(handle.isSettled).toBe(true)
+  })
+
+  test('pid is undefined (SDK does not expose child pid)', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    expect(handle.pid).toBeUndefined()
+  })
+})
+
+// ---------- ClaudeSdkNormalizer ----------
+
+describe('ClaudeSdkNormalizer', () => {
+  test('wraps legacy normalizer via JSON round-trip on assistant message', () => {
+    const norm = new ClaudeSdkNormalizer()
+    const raw = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2025-01-01T00:00:00Z',
+      message: {
+        id: 'msg1',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    })
+    const result = norm.parse(raw)
+    expect(result).not.toBeNull()
+    const first = Array.isArray(result) ? result[0] : result
+    expect(first?.entryType).toBe('assistant-message')
+    expect(first?.content).toBe('hello')
+  })
+
+  test('parseMessage accepts a structured SDKMessage', () => {
+    const norm = new ClaudeSdkNormalizer()
+    const result = norm.parseMessage({
+      type: 'system',
+      subtype: 'init',
+      slash_commands: ['/foo'],
+      agents: ['a'],
+      plugins: [],
+    } as unknown as Parameters<typeof norm.parseMessage>[0])
+    expect(result).not.toBeNull()
+  })
+})
+
+// ---------- Backend selection ----------
+
+describe('getClaudeBackend', () => {
+  const prev = process.env.CLAUDE_ENGINE_BACKEND
+
+  test('defaults to legacy when unset', () => {
+    delete process.env.CLAUDE_ENGINE_BACKEND
+    expect(getClaudeBackend()).toBe('legacy')
+  })
+
+  test('honors sdk', () => {
+    process.env.CLAUDE_ENGINE_BACKEND = 'sdk'
+    expect(getClaudeBackend()).toBe('sdk')
+  })
+
+  test('honors legacy', () => {
+    process.env.CLAUDE_ENGINE_BACKEND = 'legacy'
+    expect(getClaudeBackend()).toBe('legacy')
+  })
+
+  test('unknown value falls back to legacy', () => {
+    process.env.CLAUDE_ENGINE_BACKEND = 'nonsense'
+    expect(getClaudeBackend()).toBe('legacy')
+  })
+
+  // restore
+  test('restore env', () => {
+    if (prev === undefined) delete process.env.CLAUDE_ENGINE_BACKEND
+    else process.env.CLAUDE_ENGINE_BACKEND = prev
+  })
+})

--- a/apps/api/test/claude-sdk.test.ts
+++ b/apps/api/test/claude-sdk.test.ts
@@ -71,14 +71,56 @@ function makeMockQuery(): Query & {
 }
 
 describe('SdkProcessHandle', () => {
-  test('first kill triggers interrupt, second triggers close, third is no-op', () => {
+  test('soft kill (no signal) triggers interrupt; subsequent soft kills are no-ops', () => {
     const q = makeMockQuery()
     const handle = new SdkProcessHandle(q)
     handle.kill()
     handle.kill()
     handle.kill()
     expect(q.interruptCount).toBe(1)
+    expect(q.closeCount).toBe(0)
+  })
+
+  test('kill(9) hard-closes immediately without going through interrupt', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.kill(9)
+    expect(q.interruptCount).toBe(0)
     expect(q.closeCount).toBe(1)
+  })
+
+  test('kill(9) after soft interrupt still force-closes', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.kill()
+    handle.kill(9)
+    expect(q.interruptCount).toBe(1)
+    expect(q.closeCount).toBe(1)
+  })
+
+  test('repeated kill(9) is a no-op on the second call', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.kill(9)
+    handle.kill(9)
+    expect(q.closeCount).toBe(1)
+  })
+
+  test('soft kill after hard close is a no-op', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.kill(9)
+    handle.kill()
+    expect(q.interruptCount).toBe(0)
+    expect(q.closeCount).toBe(1)
+  })
+
+  test('isAlive reflects settle state', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    expect(handle.isAlive()).toBe(true)
+    handle.settle(0)
+    expect(handle.isAlive()).toBe(false)
   })
 
   test('settle resolves exited promise exactly once', async () => {

--- a/apps/api/test/claude-sdk.test.ts
+++ b/apps/api/test/claude-sdk.test.ts
@@ -137,6 +137,16 @@ describe('SdkProcessHandle', () => {
     const handle = new SdkProcessHandle(q)
     expect(handle.pid).toBeUndefined()
   })
+
+  test('wasHardClosed starts false and flips after kill(9)', () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    expect(handle.wasHardClosed).toBe(false)
+    handle.kill()
+    expect(handle.wasHardClosed).toBe(false)
+    handle.kill(9)
+    expect(handle.wasHardClosed).toBe(true)
+  })
 })
 
 // ---------- ClaudeSdkNormalizer ----------

--- a/apps/api/test/claude-sdk.test.ts
+++ b/apps/api/test/claude-sdk.test.ts
@@ -71,13 +71,27 @@ function makeMockQuery(): Query & {
 }
 
 describe('SdkProcessHandle', () => {
-  test('soft kill (no signal) triggers interrupt; subsequent soft kills are no-ops', () => {
+  test('soft kills while interrupt is in-flight are deduped', () => {
     const q = makeMockQuery()
     const handle = new SdkProcessHandle(q)
     handle.kill()
     handle.kill()
     handle.kill()
     expect(q.interruptCount).toBe(1)
+    expect(q.closeCount).toBe(0)
+  })
+
+  test('a fresh soft kill after the prior interrupt resolves fires a new interrupt', async () => {
+    const q = makeMockQuery()
+    const handle = new SdkProcessHandle(q)
+    handle.kill()
+    // Let the mock interrupt() microtask + the handle's .finally() reset settle.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    handle.kill()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    handle.kill()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(q.interruptCount).toBe(3)
     expect(q.closeCount).toBe(0)
   })
 

--- a/apps/api/test/gc-stall-detection.test.ts
+++ b/apps/api/test/gc-stall-detection.test.ts
@@ -405,6 +405,63 @@ describe('gcSweep — stream stall detection', () => {
     )
   })
 
+  test('SDK-backed process (pid undefined, isAlive=true) is detected, not killed', () => {
+    // Reproduces Codex review P1: handles without a pid were force-killed at
+    // Tier 1 because isProcessAlive(undefined) returned false. With the
+    // ProcessHandle.isAlive fallback, a live SDK query should only advance to
+    // stall detection, not straight to termination.
+    const stalledAt = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS - 60_000)
+    const managed = makeManagedProcess({
+      issueId: 'issue-sdk-alive',
+      executionId: 'exec-sdk-alive',
+      turnInFlight: true,
+      lastActivityAt: stalledAt,
+      process: {
+        subprocess: { pid: undefined, isAlive: () => true },
+      } as unknown as ManagedProcess['process'],
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-sdk-alive', meta: managed },
+    ])
+
+    gcSweep(ctx)
+
+    expect(forceKillCalls).not.toContain('exec-sdk-alive')
+    expect(managed.stallDetectedAt).toBeDefined()
+    expect(mockEmitDiagnosticLog).toHaveBeenCalledWith(
+      'issue-sdk-alive',
+      'exec-sdk-alive',
+      expect.stringContaining('stall detected'),
+      expect.objectContaining({ event: 'stall_detected' }),
+    )
+  })
+
+  test('SDK-backed process (pid undefined, isAlive=false) is terminated at Tier 1', () => {
+    const stalledAt = new Date(Date.now() - STREAM_STALL_TIMEOUT_MS - 60_000)
+    const managed = makeManagedProcess({
+      issueId: 'issue-sdk-dead',
+      executionId: 'exec-sdk-dead',
+      turnInFlight: true,
+      lastActivityAt: stalledAt,
+      process: {
+        subprocess: { pid: undefined, isAlive: () => false },
+      } as unknown as ManagedProcess['process'],
+    })
+    const { ctx, forceKillCalls } = makeContext([
+      { id: 'exec-sdk-dead', meta: managed },
+    ])
+
+    gcSweep(ctx)
+
+    expect(forceKillCalls).toContain('exec-sdk-dead')
+    expect(mockEmitDiagnosticLog).toHaveBeenCalledWith(
+      'issue-sdk-dead',
+      'exec-sdk-dead',
+      expect.stringContaining('process already dead'),
+      expect.objectContaining({ event: 'stall_process_dead' }),
+    )
+  })
+
   test('does NOT detect or kill process within stall timeout', () => {
     const managed = makeManagedProcess({
       issueId: 'issue-recovered',

--- a/apps/frontend/src/components/EngineIcons.tsx
+++ b/apps/frontend/src/components/EngineIcons.tsx
@@ -28,6 +28,32 @@ export function ClaudeIcon(props: IconProps) {
   )
 }
 
+/** Claude Code SDK — sunburst with inner ring to mark the SDK variant */
+export function ClaudeSdkIcon(props: IconProps) {
+  const cx = 12
+  const cy = 12
+  const rInner = 4.6
+  const rLong = 10.5
+  const rShort = 8
+  const rays = 16
+  const paths: string[] = []
+  for (let i = 0; i < rays; i++) {
+    const angle = (Math.PI * 2 * i) / rays - Math.PI / 2
+    const rOuter = i % 2 === 0 ? rLong : rShort
+    const x1 = cx + rInner * Math.cos(angle)
+    const y1 = cy + rInner * Math.sin(angle)
+    const x2 = cx + rOuter * Math.cos(angle)
+    const y2 = cy + rOuter * Math.sin(angle)
+    paths.push(`M${x1.toFixed(2)},${y1.toFixed(2)}L${x2.toFixed(2)},${y2.toFixed(2)}`)
+  }
+  return (
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d={paths.join('')} stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+      <circle cx={cx} cy={cy} r={3.4} stroke="currentColor" strokeWidth="1.3" fill="none" />
+    </svg>
+  )
+}
+
 /** OpenAI / Codex */
 export function CodexIcon(props: IconProps) {
   return (
@@ -70,7 +96,7 @@ export function GeminiIcon(props: IconProps) {
 
 const ENGINE_ICONS: Partial<Record<string, React.FC<IconProps>>> = {
   'claude-code': ClaudeIcon,
-  'claude-code-sdk': ClaudeIcon,
+  'claude-code-sdk': ClaudeSdkIcon,
   'codex': CodexIcon,
   'acp': GeminiIcon,
   'acp:gemini': GeminiIcon,

--- a/apps/frontend/src/components/EngineIcons.tsx
+++ b/apps/frontend/src/components/EngineIcons.tsx
@@ -70,6 +70,7 @@ export function GeminiIcon(props: IconProps) {
 
 const ENGINE_ICONS: Partial<Record<string, React.FC<IconProps>>> = {
   'claude-code': ClaudeIcon,
+  'claude-code-sdk': ClaudeIcon,
   'codex': CodexIcon,
   'acp': GeminiIcon,
   'acp:gemini': GeminiIcon,

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -385,8 +385,22 @@ function cleanAgentResult(raw: string): string {
 }
 
 export function AgentToolItem({ item }: { item: ToolGroupItem }) {
-  const input = item.action.metadata?.input as { description?: string, prompt?: string } | undefined
+  const input = item.action.metadata?.input as {
+    description?: string
+    prompt?: string
+    subagent_type?: string
+    model?: string
+    run_in_background?: boolean
+    isolation?: string
+    name?: string
+  } | undefined
   const description = input?.description || input?.prompt || 'Agent'
+  const subtype = input?.subagent_type
+  const badges: string[] = []
+  if (input?.model) badges.push(input.model)
+  if (input?.run_in_background) badges.push('bg')
+  if (input?.isolation === 'worktree') badges.push('worktree')
+  if (input?.name) badges.push(`as ${input.name}`)
   const rawContent = item.result?.content || item.action.content || ''
   const resultContent = cleanAgentResult(rawContent)
   const hasError = isItemError(item)
@@ -396,10 +410,17 @@ export function AgentToolItem({ item }: { item: ToolGroupItem }) {
       collapsible
       summary={(
         <div className="flex items-center gap-2 min-w-0">
-          <ToolLabel label="Agent" icon={Users} />
+          <ToolLabel label={subtype ? `Agent: ${subtype}` : 'Agent'} icon={Users} />
           <code className="rounded bg-muted/50 px-1.5 py-0.5 text-[11px] font-mono truncate">
             {description}
           </code>
+          {badges.length > 0 && (
+            <span className="shrink-0 text-[10px] text-muted-foreground/70">
+              {badges.map(b => (
+                <span key={b} className="ml-1 rounded bg-muted/40 px-1 py-0.5">{b}</span>
+              ))}
+            </span>
+          )}
         </div>
       )}
     >

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
       "version": "0.0.6",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.16.1",
+        "@anthropic-ai/claude-agent-sdk": "~0.2.113",
         "@hono/swagger-ui": "^0.6.1",
         "@hono/zod-openapi": "^1.2.3",
         "@hono/zod-validator": "^0.7.6",
@@ -146,6 +147,26 @@
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
+
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.113", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.113", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.113" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-TMeZeBDTdGNZek2VvRB4zCCFkJHbqKU1dn+OG3wms9h8z/DUKuDAUvjmmQCXP9c4K2ipPS1WmmRJljXRcKfStg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.113", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FymNWXlee9xID6AKU/aWjeIzlMTL7LAtVVL5kg2j3MYm7o8lfTY996cEN1ulWXeF7i3pVbzYtIzE+avhVDauPA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.113", "", { "os": "darwin", "cpu": "x64" }, "sha512-pST/cJunx8mup8RxnuCTQNmwyli4/LcvmLVPaZgVSYchLQlBCE26bQKZwdoeMc/+F7Gm/eBt8Yz53GTTqV3TMA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.113", "", { "os": "linux", "cpu": "arm64" }, "sha512-QMkDOEfOMg8W/PLAHnp3cU9wLWp/RvJuVlrwn5s4Oei/bP3kxfuV0uLoxXUZZNSnv2lcplxAKUGgOz7Xa0asFw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.113", "", { "os": "linux", "cpu": "arm64" }, "sha512-nXKJmIrxbgXMIE2fKebJVAFJiFqb6LsyzfxYn/tqgkYNfqk6IBDX+cP6eV5qRE72sNHI1E/ogF72N5MjhNeOHA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.113", "", { "os": "linux", "cpu": "x64" }, "sha512-/CQz7jiOp98hfrLwDJvmfPXtGCuWFGr+j7Zbi40uHovd5+TXJ1fOZNMEdb4aVKW3KYPbxA1aT6XNP8nAgmuPvA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.113", "", { "os": "linux", "cpu": "x64" }, "sha512-PGpstZ8mWEQfCjDd+qV/rPsdLLkzFobINPpLr4ALMu8fQMEEs5SsabumGup48fnK3Z19/WlfI9FC1iVzxsE3LQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.113", "", { "os": "win32", "cpu": "arm64" }, "sha512-NqtFDTVPg7fh+yee7KnsVZ/MZ6VogE+dQcIobEN0NVl03i5pbQAWfSZNOEvhk2XyEaJ4rdk+/9MPED+UThF5gQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.113", "", { "os": "win32", "cpu": "x64" }, "sha512-0VoW/fTkygn/uZqPhOPjmXaVc1H3wkNNJd/fMyWKDR2p76Y9loQPQZk2R5tNRWlK5mDo65F6+Omby0rCx9XtQw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.0.1", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.6" } }, "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw=="],
 
@@ -489,7 +510,7 @@
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
 
@@ -1415,6 +1436,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
@@ -1971,6 +1994,8 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
     "ts-declaration-location": ["ts-declaration-location@1.0.7", "", { "dependencies": { "picomatch": "^4.0.2" }, "peerDependencies": { "typescript": ">=4.0.0" } }, "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA=="],
@@ -2139,8 +2164,6 @@
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "@modelcontextprotocol/sdk/hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
-
     "@pierre/diffs/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
 
     "@pierre/diffs/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
@@ -2241,6 +2264,8 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "shadcn/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "shiki/@shikijs/core": ["@shikijs/core@4.0.1", "", { "dependencies": { "@shikijs/primitive": "4.0.1", "@shikijs/types": "4.0.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-vWvqi9JNgz1dRL9Nvog5wtx7RuNkf7MEPl2mU/cyUUxJeH1CAr3t+81h8zO8zs7DK6cKLMoU9TvukWIDjP4Lzg=="],
@@ -2337,6 +2362,12 @@
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
+    "shadcn/@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "shadcn/@modelcontextprotocol/sdk/hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
+
+    "shadcn/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -2398,5 +2429,7 @@
     "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "cross-fetch/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "shadcn/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
       "version": "0.0.6",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.16.1",
-        "@anthropic-ai/claude-agent-sdk": "~0.2.113",
+        "@anthropic-ai/claude-agent-sdk": "~0.2.114",
         "@hono/swagger-ui": "^0.6.1",
         "@hono/zod-openapi": "^1.2.3",
         "@hono/zod-validator": "^0.7.6",
@@ -148,23 +148,23 @@
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.113", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.113", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.113" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-TMeZeBDTdGNZek2VvRB4zCCFkJHbqKU1dn+OG3wms9h8z/DUKuDAUvjmmQCXP9c4K2ipPS1WmmRJljXRcKfStg=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.114", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.114", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.114", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.114", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.114", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.114", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.114", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.114", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.114" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-plJ+j17jew9tDMHir/90hXrwoB8cZ9GrIyG19zIJcFyQ8pVhRXjZRJCtF2ElfPoiwkxMmNu1Klqyui4xP4shPg=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.113", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FymNWXlee9xID6AKU/aWjeIzlMTL7LAtVVL5kg2j3MYm7o8lfTY996cEN1ulWXeF7i3pVbzYtIzE+avhVDauPA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.114", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0/6LWrNilWpmiX6Xrj5plsBmCrCdKGERgAlKUZQEJZplnfuweFAJu7WXZB4KBaUpGlPO91zB/yqDh6kp5aZFbA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.113", "", { "os": "darwin", "cpu": "x64" }, "sha512-pST/cJunx8mup8RxnuCTQNmwyli4/LcvmLVPaZgVSYchLQlBCE26bQKZwdoeMc/+F7Gm/eBt8Yz53GTTqV3TMA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.114", "", { "os": "darwin", "cpu": "x64" }, "sha512-sOHxq1rEO/KZg2iEZILTPn62lMRRMPqtxKx41uGLi3xjVDrAej6Ury9dDZjYBKkK9n4kBylXV0Oom2CZ14dDYw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.113", "", { "os": "linux", "cpu": "arm64" }, "sha512-QMkDOEfOMg8W/PLAHnp3cU9wLWp/RvJuVlrwn5s4Oei/bP3kxfuV0uLoxXUZZNSnv2lcplxAKUGgOz7Xa0asFw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.114", "", { "os": "linux", "cpu": "arm64" }, "sha512-j/SfEoN6+fyEsp8EuPe+xKcGfsZtaBmdUUH+YSRk5H/lYgy38yNsDhdt+AJMQcdMKfHsiwZ3Y9Ajoe9G9wNwHQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.113", "", { "os": "linux", "cpu": "arm64" }, "sha512-nXKJmIrxbgXMIE2fKebJVAFJiFqb6LsyzfxYn/tqgkYNfqk6IBDX+cP6eV5qRE72sNHI1E/ogF72N5MjhNeOHA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.114", "", { "os": "linux", "cpu": "arm64" }, "sha512-Mhd7bumTwWvkgjSJnYvCgyt8DfmLiUoK92mfvAKxHX7i5YSw+h5Kprqh2Cap+2SBbpwZvnwIoEYGCxhGwE5ddg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.113", "", { "os": "linux", "cpu": "x64" }, "sha512-/CQz7jiOp98hfrLwDJvmfPXtGCuWFGr+j7Zbi40uHovd5+TXJ1fOZNMEdb4aVKW3KYPbxA1aT6XNP8nAgmuPvA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.114", "", { "os": "linux", "cpu": "x64" }, "sha512-wbaExKDleLlm2zHEhb74GKMLVhtO0IUmFhdimQcdL6CdTkmDE8ZJi53tYWE9+jq+XWNRXoM2yEmKPzXoUmsJng=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.113", "", { "os": "linux", "cpu": "x64" }, "sha512-PGpstZ8mWEQfCjDd+qV/rPsdLLkzFobINPpLr4ALMu8fQMEEs5SsabumGup48fnK3Z19/WlfI9FC1iVzxsE3LQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.114", "", { "os": "linux", "cpu": "x64" }, "sha512-c1URsameGHAcghen+mY6jvr2oypiAPHXJIdP4huxR25zPdXWv2x+BCy+vcRVeajsq4VmFzAyQJwaM+BXkmXjAw=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.113", "", { "os": "win32", "cpu": "arm64" }, "sha512-NqtFDTVPg7fh+yee7KnsVZ/MZ6VogE+dQcIobEN0NVl03i5pbQAWfSZNOEvhk2XyEaJ4rdk+/9MPED+UThF5gQ=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.114", "", { "os": "win32", "cpu": "arm64" }, "sha512-qeWdUpQymcKCA92osPmffG4QogrOSvuffPvm6c2OlMDjCPYs8vKG7bSe1Vq5tP9tfBszKPVJWBDh+2ANkNissQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.113", "", { "os": "win32", "cpu": "x64" }, "sha512-0VoW/fTkygn/uZqPhOPjmXaVc1H3wkNNJd/fMyWKDR2p76Y9loQPQZk2R5tNRWlK5mDo65F6+Omby0rCx9XtQw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.114", "", { "os": "win32", "cpu": "x64" }, "sha512-nVr43WwsKvWA6rojw15qBS/f31srukdLxy1KwKzpftlpmkzQ9Lh8uhIafOmoIPzz67f8VJ8JqHE0caA5YrhX9A=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 

--- a/docs/plan/PLAN-003.md
+++ b/docs/plan/PLAN-003.md
@@ -1,0 +1,202 @@
+# PLAN-003 Migrate claude executor to @anthropic-ai/claude-agent-sdk
+
+- **status**: steps 1-3 complete; awaiting production soak before step 4
+- **createdAt**: 2026-04-17
+- **approvedAt**: 2026-04-17
+- **relatedTask**: ENG-001
+
+## Progress
+
+- Step 1 (POC + scaffold) — done: `apps/api/src/engines/executors/claude-sdk/`
+  (executor, normalizer wrapper, handle, pushable stream). SDK dep added at
+  `~0.2.113`.
+- Step 2 (PM abstraction) — done: `engines/process-handle.ts` + PM narrowed
+  from `Subprocess` to `ProcessHandle`; terminal.ts migrated to store PTY
+  subprocess in `meta.pty`.
+- Step 3 (env flag + tests) — done: `CLAUDE_ENGINE_BACKEND=sdk|legacy`
+  (default `legacy`). Test suite in `apps/api/test/claude-sdk.test.ts`
+  covers PushableStream / SdkProcessHandle / normalizer / backend select.
+  Full `bun test` green (495 pass).
+- Steps 4 + 5 pending: flip default, then delete `claude/` + collapse
+  normalizer to typed SDK input.
+
+## Context
+
+The `claude-code` engine integration predates the public Claude Agent SDK. It
+spawns the `claude` CLI with stream-json I/O and hand-rolls the bidirectional
+control protocol end-to-end. Anthropic now ships an official TypeScript SDK
+(`@anthropic-ai/claude-agent-sdk`, v0.2.113, lock-step with CLI `2.1.112`)
+that wraps the same subprocess + control protocol behind a typed async
+generator API.
+
+### Current surface (to be replaced)
+
+| File | Lines | Role |
+|---|---|---|
+| `apps/api/src/engines/executors/claude/executor.ts` | 538 | Binary discovery, `CommandBuilder` flags, spawn, SDK-init handshake (`initialize` + `set_permission_mode` + `sendUserMessage`), slash-command discovery, static model list |
+| `apps/api/src/engines/executors/claude/protocol.ts` | 415 | stdin writer + stdout filter; parses `control_request` (`can_use_tool`, `hook_callback`), auto-approves tools, routes `ExitPlanMode` to a `setMode` permission update, `interrupt` / `set_permission_mode` control messages |
+| `apps/api/src/engines/executors/claude/normalizer.ts` | 712 | Parses raw stream-json lines into `NormalizedLogEntry` |
+| `apps/api/src/engines/executors/claude/normalizer-tool.ts` | 208 | Tool-use classification |
+| `apps/api/src/engines/executors/claude/normalizer-types.ts` | 235 | Type definitions for raw stream-json shapes |
+| **Total** | **~2108** | |
+
+### Downstream consumers
+
+- `SpawnedProcess` (`engines/types.ts:129`) is consumed by
+  - `ProcessManager` (`engines/process-manager.ts`, 500 L) — needs a Bun `Subprocess` handle
+  - `consumeStream` (`engines/issue/streams/consumer.ts:59`) — consumes `ReadableStream<Uint8Array>` with a line parser
+  - `spawn.ts` (`engines/issue/lifecycle/spawn.ts`) — constructs `SpawnedProcess`
+  - `reconciler.ts`, `startup-probe.ts` — probe and cleanup
+- `ClaudeLogNormalizer` is used by the executor itself and re-exported from `executors/claude/index.ts`
+
+### SDK capability matrix
+
+| Current hand-rolled behavior | Claude Agent SDK equivalent |
+|---|---|
+| Spawn `claude -p --output-format=stream-json --input-format=stream-json` | `query({ prompt, options })` — SDK spawns the binary internally |
+| `initialize` control handshake | Implicit on first `query()` invocation |
+| `set_permission_mode` control message | `options.permissionMode` + `Query.setPermissionMode()` at runtime |
+| `can_use_tool` auto-approval | `options.canUseTool(toolName, input)` callback |
+| `hook_callback` routing (PreToolUse etc.) | `options.hooks` (typed `HookCallbackMatcher[]`) |
+| ExitPlanMode → `setMode` permission patch | `canUseTool` return value may include `updatedPermissions` |
+| `--resume <sessionId>` / `--resume-session-at <uuid>` | `options.resume`, `options.resumeSessionAt` |
+| `--session-id` for externally-injected session | `options.extraArgs: { 'session-id': id }` |
+| `--agent <name>` | `options.agents` or `options.extraArgs` |
+| `sendUserMessage` over stdin (stream-json) | `prompt: AsyncIterable<SDKUserMessage>` + `yield` |
+| `interrupt` control request | `Query.interrupt()` |
+| `--disallowedTools AskUserQuestion` | `options.disallowedTools` |
+| `--debug --debug-file <path>` | `options.extraArgs: { debug: null, 'debug-file': path }` |
+| Slash-command discovery via one-shot `--max-turns 1 -- /` | `Query.supportedCommands()` |
+| Static `CLAUDE_MODELS` list | `Query.supportedModels()` |
+| Binary path resolution (`/work/bin/claude` → `$HOME` → `/usr/local/bin` → npx fallback) | `options.pathToClaudeCodeExecutable` (keep the discovery helper, **drop npx fallback** for SDK backend) |
+| stream-json line parsing → `NormalizedLogEntry` | Normalize typed `SDKMessage` instead of raw strings — far fewer field probes |
+
+## Proposal
+
+### Step 1 — Add SDK dependency + parallel executor (POC, no code churn elsewhere)
+
+- Add `@anthropic-ai/claude-agent-sdk@~0.2.113` to `apps/api/package.json`
+- Create `apps/api/src/engines/executors/claude-sdk/` with:
+  - `executor.ts` — implements `EngineExecutor` for `claude-code`, uses `query()`
+  - `normalizer.ts` — temporary thin wrapper that JSON-stringifies `SDKMessage` and feeds it to the existing `ClaudeLogNormalizer` (so we defer normalizer rewrite to Step 3)
+  - `index.ts` — exports
+- **Not wired into the registry yet** — POC runs via a one-off script / bun test.
+- Verify against a real issue end-to-end: `spawn` → emit 3 log entries → cancel → followup → completion. No DB writes in POC (use a recording harness).
+
+**Files**: `apps/api/package.json`, `apps/api/src/engines/executors/claude-sdk/*` (new), `apps/api/scripts/sdk-poc.ts` (new, ephemeral)
+
+**Exit criteria**: POC harness completes `spawn → user msg → assistant text → tool use → result` without errors, and `Query.interrupt()` settles the session cleanly.
+
+### Step 2 — Generalize ProcessManager to handle-based abstraction
+
+Observation: `ProcessManager` only consumes three members of the `Subprocess` type (see `process-manager.ts:172,187,177,219,221`):
+- `subprocess.kill(signal)` — force-kill (SIGKILL path after `killTimeoutMs`)
+- `subprocess.exited` — Promise<number> awaited during terminate
+- `subprocess.pid` — logging only
+
+Everything else (`stdin`, `stdout`, `stderr`) is consumed by `consumeStream` and the protocol handler **independently** of PM. This means PM's dependency on Bun's `Subprocess` is a historical accident, not a structural one.
+
+**Solution**: introduce a minimal `ProcessHandle` interface that PM manages, and let each engine's executor provide its own concrete handle.
+
+```typescript
+// engines/process-handle.ts (new)
+export interface ProcessHandle {
+  readonly pid?: number
+  readonly exited: Promise<number>
+  kill(signal?: number): void
+}
+```
+
+**Bun subprocess handle** — implicit, since `Bun.Subprocess` already matches this shape. Existing Codex / ACP / legacy-Claude executors pass their `subprocess` directly with zero change.
+
+**SDK Query handle** — a ~30 L wrapper living in `executors/claude-sdk/handle.ts`:
+- `kill(signal)` → `Query.interrupt()` (signal ignored; SDK has one interrupt path). After `killTimeoutMs` PM triggers this a second time as SIGKILL-equivalent; we gate to no-op on second call.
+- `exited` → a Promise resolved by the executor when the async generator for-await loop finishes (either normal `result` message, thrown error, or post-interrupt settle). Resolve value is `0` for normal end, non-zero when SDK surfaces an error.
+- `pid` → undefined (SDK doesn't expose the child PID; acceptable since it's logging-only).
+
+**PM changes** (single file, `process-manager.ts`):
+- Rename `subprocess: Subprocess` → `handle: ProcessHandle` on `ManagedEntry` (keep `subprocess` as a deprecated getter alias for one cycle if necessary for external callers — audit shows only `reconciler.ts` reads `managed.subprocess.pid`, trivial to rewrite).
+- Replace `entry.subprocess.kill(9)` with `entry.handle.kill(9)` in 2 places.
+- Replace `entry.subprocess.exited` with `entry.handle.exited` in 1 place.
+- Replace `(entry.subprocess as { pid?: number }).pid` with `entry.handle.pid` in 2 places.
+
+**Stream side** (`consumeStream`): still accepts `ReadableStream<Uint8Array>`. The SDK executor synthesizes one from the async generator by emitting `JSON.stringify(sdkMessage) + '\n'`. This is a *temporary* bridge — Step 5 replaces it with direct `AsyncIterable<SDKMessage>` consumption in a typed normalizer. During the side-by-side period, the string round-trip cost is negligible (these are already JSON-serialized over stdout in the legacy path).
+
+**Why this is better than the earlier "shim" proposal**: The shim fakes a `Subprocess`. The handle abstraction is the honest, minimal contract; narrower type surface, no fake Bun-specific fields to maintain, and the mental model ("PM manages lifecycle, not I/O") becomes the file-level comment.
+
+**Scope of files touched in Step 2**:
+- `apps/api/src/engines/process-handle.ts` (new, ~15 L)
+- `apps/api/src/engines/process-manager.ts` (rename field + 5 call sites)
+- `apps/api/src/engines/types.ts` — `SpawnedProcess.subprocess: Subprocess` stays (still the I/O wrapper that executors return) **but** `ManagedProcess` in `issue/types.ts` starts using `handle` instead
+- `apps/api/src/engines/issue/types.ts` — `ManagedProcess.subprocess` → `handle`
+- `apps/api/src/engines/reconciler.ts` — 1 logging line
+- `apps/api/src/engines/executors/claude-sdk/handle.ts` (new, ~30 L)
+- `apps/api/src/engines/executors/claude-sdk/executor.ts` — implements `spawn` / `spawnFollowUp` returning `SpawnedProcess` whose `subprocess` is the SDK handle (cast OK since PM only reads through `ProcessHandle`)
+
+All legacy Codex/ACP executors are untouched because `Bun.Subprocess` already satisfies `ProcessHandle` structurally.
+
+**Regression risk**: very low; it's a mechanical narrowing of a type dependency with 5 call-site edits. The generic parameter `TMeta` stays as-is, so every existing registration call compiles unchanged.
+
+### Step 3 — Wire behind `CLAUDE_ENGINE_BACKEND` env flag, side-by-side
+
+- Register the SDK executor in `apps/api/src/engines/executors/index.ts`:
+  - `CLAUDE_ENGINE_BACKEND=sdk` → `ClaudeCodeSdkExecutor`
+  - `CLAUDE_ENGINE_BACKEND=legacy` (default during rollout) → existing `ClaudeCodeExecutor`
+- `startup-probe.ts` must not probe both — pick one backend and report its version
+- Add smoke-test coverage in `apps/api/test/` for the SDK path: spawn, followup, cancel, resume-at-message
+
+**Files**: `engines/executors/index.ts`, `engines/startup-probe.ts`, `apps/api/test/engines/claude-sdk.test.ts` (new)
+
+### Step 4 — Flip default to SDK
+
+- Default `CLAUDE_ENGINE_BACKEND` to `sdk`
+- Keep legacy executor + files in the tree, guarded by the flag
+- Run at least one release cycle in production before Step 5
+- Update `CLAUDE.md` engine section to document the flag
+
+**Files**: `engines/executors/index.ts` (default), `CLAUDE.md` (docs)
+
+### Step 5 — Collapse normalizer to typed input, delete legacy
+
+- Rewrite `executors/claude-sdk/normalizer.ts` to consume `SDKMessage` directly (no string → JSON round-trip)
+- Delete:
+  - `executors/claude/` in its entirety (~2100 L)
+  - `engines/types.ts#SpawnedProcess.protocolHandler` field and its Subprocess coupling (if Option B is adopted)
+  - `--permission-prompt-tool=stdio`, `--input-format`, `--output-format=stream-json` CLI plumbing in `CommandBuilder` usages specific to claude
+- Remove the `CLAUDE_ENGINE_BACKEND` flag — only SDK remains
+
+**Net diff estimate**: −1600 to −1800 L after all cleanup.
+
+## Risks
+
+1. **ProcessManager coupling** (§Step 2) — resolved by introducing a narrow `ProcessHandle` interface (`{ pid?, exited, kill }`). Audit of `process-manager.ts` confirmed only 5 call sites touch the subprocess; `Bun.Subprocess` structurally satisfies the new interface so legacy executors need no changes. Claude-sdk executor provides a ~30 L handle wrapper around `Query.interrupt()` + generator-completion promise.
+2. **Binary path contract** — SDK requires a real binary; existing fallback to `npx -y @anthropic-ai/claude-code` disappears for SDK backend. Mitigation: keep `resolveBinaryOnly()` helper, surface a clearer error when binary is missing (prompt user to `bun install -g @anthropic-ai/claude-code` or use the project's bundled binary).
+3. **SDK ↔ CLI version drift** — SDK protocol is tied to the local `claude` binary. If a user's `/work/bin/claude` is older/newer than SDK's expected protocol version, handshake can fail silently. Mitigation: read `claude --version` at startup and compare to `@anthropic-ai/claude-agent-sdk` `package.json.version`; warn on mismatch; document the compatibility matrix.
+4. **ExitPlanMode permission patch** — Current code returns `updatedPermissions: [{ type: 'setMode', mode: 'bypassPermissions' }]` from `can_use_tool`. Must verify SDK's `canUseTool` return type supports the same shape on the target version.
+5. **Debug logging** — `--debug --debug-file` is currently enabled when `LOG_LEVEL=debug|trace`. Must confirm `extraArgs` passthrough works for these flags in the SDK's command assembly.
+6. **Bun runtime** — SDK has `executable: 'bun' | 'deno' | 'node'`. Confirm that `executable: 'bun'` spawns `claude` correctly under Bun (the SDK itself is JS so the runtime choice affects how SDK handles its own child process, not the `claude` binary).
+7. **Log-level parity** — `LOG_EXECUTOR_IO=1` currently dumps every stdin/stdout line via `protocol.ts`. The SDK hides protocol frames. We lose that debug surface unless we add an equivalent `includePartialMessages` + stderr callback pipeline.
+8. **Session fork semantics** — `options.forkSession` exists on SDK and may interact differently with our `resetToMessageId` / `resumeSessionAt` flow. Verify with a test that reset-to-message behaves identically.
+9. **Rollback** — Step 4 flip is a single env-var flip; Step 5 (deletion) is irreversible without git revert. Do not merge Step 5 until two weeks of SDK-default production stability.
+10. **npm supply chain** — Adding a direct Anthropic SDK dependency affects `compile` bundle size. Measure before/after.
+
+## Verification Plan
+
+Per step:
+
+- **Step 1**: POC harness script logs SDK messages for a real issue; manual inspection of message flow; compare against legacy executor output for the same prompt (diff should only be formatting).
+- **Step 2/3**: `bun test:api` green; new `claude-sdk.test.ts` covers spawn/followup/cancel/resume-at-message. Manual smoke on dev server: create issue → run → cancel → followup.
+- **Step 4**: Deploy with `CLAUDE_ENGINE_BACKEND=sdk` as default in dev; run the kanban UI for a full session; verify SSE log entries arrive identically to legacy.
+- **Step 5**: Full `bun run test`, `bun run lint`, `bun run typecheck`. Measure `compile` binary size before/after.
+
+## Out of Scope
+
+- Codex (`executors/codex/`) and ACP (`executors/acp/`) executors. They use different protocols and will not be touched.
+- Frontend changes. The normalized log entry shape is preserved.
+- MCP server configuration surface changes (SDK's `mcpServers` option is richer than what we expose, but aligning is a follow-up task).
+
+## Alternatives Considered
+
+1. **Do nothing** — maintain ~2100 L of hand-rolled protocol. Cost: every CLI upgrade risks control-protocol drift; past incidents (`hook_callback` field-shape changes) required reverse-engineering. Rejected.
+2. **Partial migration** — use SDK only for new capabilities (`supportedCommands`, `supportedModels`) while keeping hand-rolled spawn. Keeps two code paths permanently; rejected as a long-term state but acceptable as an intermediate (Step 1 essentially achieves this).
+3. **Switch to the Anthropic HTTP SDK (`@anthropic-ai/sdk`)** — bypasses the `claude` binary entirely. Would lose Claude Code–specific features (slash commands, hooks, plugin discovery, session resume semantics, ExitPlanMode). Rejected — we explicitly want Claude Code behavior, not raw messages API.

--- a/docs/plan/PLAN-004.md
+++ b/docs/plan/PLAN-004.md
@@ -1,0 +1,331 @@
+# PLAN-004 Enable AskUserQuestion in claude-code-sdk executor (web UI answer flow)
+
+- **status**: draft — awaiting approval
+- **createdAt**: 2026-04-18
+- **approvedAt**:
+- **relatedTask**: ENG-002
+
+## Progress
+
+- Not started. Feasibility analysis complete (see Context).
+
+## Context
+
+The legacy `claude-code` executor and the new `claude-code-sdk` executor both
+block the SDK's built-in `AskUserQuestion` tool via `disallowedTools`. Current
+sites on the SDK path:
+
+- `apps/api/src/engines/executors/claude-sdk/executor.ts:305` — discovery query
+- `apps/api/src/engines/executors/claude-sdk/executor.ts:376` — `startQuery`
+
+The legacy executor also disables it in its `CommandBuilder` flag list (out of
+scope for this plan; scope is SDK backend only).
+
+### Why it was disabled
+
+When the integration was first built there was no bidirectional surface for the
+web UI to receive a tool call, pause the run, collect the user's choice, and
+return a tool result. Blocking the tool prevented the model from stalling on an
+unanswered question.
+
+### Why it is feasible now
+
+The SDK exposes two primitives that together let us implement the round trip
+without protocol hacks:
+
+1. `AskUserQuestion` is a *normal tool* from the model's perspective. The SDK
+   emits it as an assistant `tool_use` with the question payload in the tool
+   input. We already observe every `SDKMessage` in `startBridge`
+   (`executor.ts:147`) and normalize it through `ClaudeSdkNormalizer`.
+2. The prompt stream is user-controlled. `protocolHandler.sendUserMessage`
+   already pushes `SDKUserMessage` into the `PushableStream`. A user message
+   whose `content` is an array of `tool_result` ContentBlocks is how the SDK
+   conveys "here is the answer to that tool call" — the same shape the SDK's
+   internal permission tool uses.
+
+So the mechanism is: **allow the tool, capture `tool_use_id` from the stream,
+surface the question to the UI, then inject a `tool_result` user message when
+the user answers.**
+
+### Tool input shape (from SDK 0.2.114)
+
+`AskUserQuestion` tool input is:
+
+```typescript
+{
+  questions: Array<{
+    question: string            // prompt text
+    header: string              // short title (≤12 chars per SDK)
+    multiSelect: boolean        // allow multiple answers
+    options: Array<{
+      label: string             // option title (≤28 chars)
+      description: string       // sub-label
+    }>
+  }>
+}
+```
+
+Result shape expected by the model (wrap in `tool_result.content`):
+
+```typescript
+{
+  answers: Array<{ header: string, selected: string[] }>
+}
+```
+
+Plan-level contract: one AskUserQuestion tool call = one "ask-user-question"
+log entry emitted with `{tool_use_id, questions}` metadata, parked until the
+UI posts the answers, then a `tool_result` injected back and a paired result
+entry recorded for the chat timeline.
+
+### Downstream touch points
+
+| Layer | File | Change |
+|---|---|---|
+| SDK executor | `executors/claude-sdk/executor.ts` | Remove `AskUserQuestion` from `disallowedTools`; detect the tool_use in stream; register pending question with the issue engine |
+| Normalizer | `executors/claude-sdk/normalizer.ts` | Special-case `AskUserQuestion` tool_use → emit dedicated entry type so the UI can render a question bubble instead of generic tool card |
+| Shared types | `packages/shared/src/index.ts` | Add `'ask-user-question'` to `LogEntryType`; add `AskUserQuestionMeta` shape |
+| Persistence | `engines/issue/streams/persistence.ts` (or log classifier) | Route the new entry type identically to other tool entries; store questions blob in metadata |
+| Pending-answer registry | new `engines/issue/ask-user-question.ts` | Map `issueId -> {tool_use_id, questions, createdAt}`; cleared when the answer posts or the run cancels |
+| API route | `routes/issues/ask-user-question.ts` (new) | `POST /api/projects/:projectId/issues/:id/answer-question` — validates answer shape, looks up executor's `protocolHandler.sendUserMessage`, pushes `tool_result`, records "user answer" log entry |
+| Frontend hook | `hooks/use-kanban.ts` | `useAnswerQuestion` mutation |
+| Frontend UI | `components/issue-detail/chat/AskUserQuestionBubble.tsx` (new) | Renders question + option buttons; disabled after answer or when engine is not `claude-code-sdk`; wires into `ChatBody` message rendering |
+| i18n | `i18n/{en,zh}.json` | Strings: "Waiting for your answer…", "Send answer", "Cancelled", etc. |
+
+### Not in scope
+
+- Legacy `claude-code` executor (still disables the tool; can be lifted after
+  PLAN-003 Step 4 flips SDK default).
+- Interactive approval for other tools (those remain auto-approved by the
+  `canUseTool` callback).
+- Rich answer types beyond option buttons (freeform text, file picker, etc.).
+
+## Proposal
+
+### Step 1 — Unblock the tool + capture tool_use_id in the stream
+
+- Remove `'AskUserQuestion'` from `disallowedTools` at `executor.ts:305` and
+  `executor.ts:376`.
+- In `startBridge` (`executor.ts:105`), while iterating `SDKMessage`s, detect
+  assistant messages with a `tool_use` block whose `name === 'AskUserQuestion'`.
+  Extract `tool_use_id` and `input.questions`.
+- Register the pending question via a new `AskUserQuestionRegistry`
+  (`engines/issue/ask-user-question.ts`). Registry is a singleton `Map<issueId,
+  PendingQuestion>` with `set`, `get`, `take`, `clearForIssue`. Only one
+  outstanding question per issue at a time (simple; revisit if model starts
+  chaining calls).
+- The executor does **not** block the for-await loop. The SDK itself awaits
+  the tool_result via its own `AsyncIterable` prompt contract — we just need
+  to push it when ready.
+
+**Files**: `executors/claude-sdk/executor.ts`, new
+`engines/issue/ask-user-question.ts`.
+
+**Exit criteria**: sending a prompt that triggers AskUserQuestion (e.g.
+a prompt containing "ask me which color") produces exactly one
+registry entry with `{issueId, tool_use_id, questions}`, visible via a
+temporary `logger.info` dump.
+
+### Step 2 — Surface the question as a log entry + SSE event
+
+- Add `'ask-user-question'` to `LogEntryType` in `packages/shared/src/index.ts`
+  and an `AskUserQuestionMeta` helper type.
+- In `ClaudeSdkNormalizer.parseMessage`, when an assistant tool_use is
+  `AskUserQuestion`, emit a dedicated entry with `entryType:
+  'ask-user-question'`, `toolDetail.toolCallId = tool_use_id`, and
+  `metadata.questions = input.questions` (serialize as JSON string per
+  existing `NormalizedLogEntry` convention if needed).
+- The entry is persisted to `issueLogs` by the existing persistence path (no
+  schema change). Chat rebuild on frontend picks it up like any other entry.
+- `SSE` log event already forwards arbitrary `NormalizedLogEntry`. Nothing to
+  add server-side — the new entry type rides the existing `log` event.
+
+**Files**: `packages/shared/src/index.ts`,
+`executors/claude-sdk/normalizer.ts`, any log-classification helpers
+(`engines/log-entry.ts` if it asserts on the union).
+
+**Exit criteria**: one SSE `log` event carrying the new entry type arrives at
+the browser when the model calls AskUserQuestion. Existing chat renderer
+shows an unstyled placeholder (acceptable until Step 4).
+
+### Step 3 — Answer injection endpoint
+
+- New route `POST /api/projects/:projectId/issues/:id/answer-question` with
+  Zod validator:
+
+  ```typescript
+  z.object({
+    toolUseId: z.string(),
+    answers: z.array(z.object({
+      header: z.string(),
+      selected: z.array(z.string()),
+    })),
+  })
+  ```
+
+- Handler:
+  1. Verify issue ownership + currently running session on
+     `claude-code-sdk` engine.
+  2. Look up the pending question via `AskUserQuestionRegistry.take(issueId)`.
+     If missing or `toolUseId` mismatch → 409.
+  3. Call `IssueEngine.answerQuestion(issueId, toolUseId, answers)`. Internally
+     this reaches the running process's `protocolHandler.sendUserMessage` with
+     a structured content array:
+
+     ```typescript
+     {
+       type: 'user',
+       parent_tool_use_id: null,
+       message: {
+         role: 'user',
+         content: [{
+           type: 'tool_result',
+           tool_use_id: toolUseId,
+           content: JSON.stringify({ answers }),
+         }],
+       },
+     }
+     ```
+
+     NOTE: current `sendUserMessage(content: string)` signature only passes
+     plain text. We extend `protocolHandler.sendUserMessage` to accept
+     `string | ContentBlock[]` and the SDK executor's
+     `makeUserMessage` to handle both shapes. Other executors keep the
+     string-only path (they don't use AskUserQuestion).
+  4. Persist a synthetic `user-message` log entry
+     (`content: "Answered: <summary>"`, metadata carries full answer) so the
+     chat timeline shows the choice next to the question bubble.
+
+- Cancellation: when `IssueEngine.cancelIssue` fires while a question is
+  pending, clear the registry entry and emit a synthetic log entry marking it
+  cancelled. The SDK's underlying run is already interrupted; we do not need
+  to inject a tool_result in that path — the subprocess settles.
+
+**Files**: `routes/issues/ask-user-question.ts` (new),
+`routes/issues/index.ts` (mount), `engines/issue/engine.ts` (new
+`answerQuestion` method), `engines/types.ts` (`protocolHandler.sendUserMessage`
+signature), `executors/claude-sdk/executor.ts` (updated `makeUserMessage`).
+
+**Exit criteria**: manual curl-equivalent with a valid `toolUseId` + answers
+triggers the model to continue its turn with the answer injected. `bun test:api`
+adds integration test that mocks the registry + protocolHandler.
+
+### Step 4 — Frontend question bubble + answer flow
+
+- Add `AskUserQuestionBubble.tsx` under
+  `apps/frontend/src/components/issue-detail/chat/`. Renders:
+  - Title (first question's `header`), body (question text)
+  - Option buttons with description sub-label
+  - If `multiSelect === true`, checkboxes + a "Send" button; else single-click
+    sends immediately
+  - Greyed-out state after answer posted (derive from "user answer" entry for
+    the same `toolUseId` adjacent in timeline)
+- Extend `ChatBody` rebuild to recognize `entryType === 'ask-user-question'`
+  and render the bubble instead of the generic tool group.
+- Add `useAnswerQuestion(issueId)` mutation in `hooks/use-kanban.ts` + API
+  client fn in `lib/kanban-api.ts`.
+- i18n keys in both `en.json` and `zh.json`.
+
+**Files**: `components/issue-detail/chat/AskUserQuestionBubble.tsx` (new),
+`components/issue-detail/chat/ChatBody.tsx`, `hooks/use-kanban.ts`,
+`lib/kanban-api.ts`, `i18n/{en,zh}.json`.
+
+**Exit criteria**: clicking an option in the UI posts to the new endpoint,
+shows the "Answered: X" bubble below, and the model's next assistant message
+appears within a few seconds.
+
+### Step 5 — Test coverage + documentation
+
+- `apps/api/test/claude-sdk.test.ts`: add cases for
+  (a) normalizer emits `ask-user-question` entry, (b) registry
+  set/take/clearForIssue invariants, (c) `answerQuestion` dispatches to
+  `protocolHandler.sendUserMessage` with correct ContentBlock shape,
+  (d) mismatched tool_use_id rejected.
+- `apps/frontend/src/__tests__/`: unit test for bubble component (render +
+  click dispatches mutation).
+- Update `CLAUDE.md` engine section: document the new route and that
+  AskUserQuestion is supported only on `claude-code-sdk` backend.
+
+**Files**: `apps/api/test/claude-sdk.test.ts`,
+`apps/frontend/src/__tests__/components/AskUserQuestionBubble.test.tsx`
+(new), `CLAUDE.md`.
+
+**Exit criteria**: `bun run test`, `bun run lint`, `bun run typecheck` all
+green. Manual smoke on dev server with a prompt that reliably triggers
+AskUserQuestion.
+
+## Risks
+
+1. **Concurrent questions per issue** — SDK may theoretically emit multiple
+   AskUserQuestion calls in one turn. Mitigation: registry rejects a second
+   `set` while one is outstanding and logs a warning; model typically issues
+   one at a time per SDK docs. If real traffic shows chaining, upgrade the
+   registry to a per-`tool_use_id` queue.
+2. **Answer race after cancel** — user clicks an option just as `cancelIssue`
+   fires. Endpoint checks session state first; if session no longer running,
+   returns 409 and UI shows a "cancelled" state.
+3. **`tool_use_id` leakage / spoofing** — endpoint verifies that
+   `toolUseId` matches the registry entry for that issue. Endpoint is also
+   auth-gated by the existing project-scoped auth middleware.
+4. **Protocol-handler signature change** — widening `sendUserMessage` from
+   `string` to `string | ContentBlock[]` touches every executor. Codex / ACP
+   handlers can keep the string path; type union is safe because they only
+   receive calls from the issue engine's existing follow-up flow which always
+   passes strings.
+5. **Legacy `claude-code` executor still blocks the tool** — unchanged by
+   this plan. If a user on the legacy backend asks the model in a way that
+   would trigger AskUserQuestion, the model simply doesn't see the tool.
+   Document the limitation in CLAUDE.md.
+6. **Restart / resume behaviour** — if the server restarts while a question
+   is pending, the registry is lost and the subprocess is dead. Reconciler
+   already moves stale `running` sessions to `failed`; the UI's question
+   bubble then shows a "cancelled" state because the underlying log entry's
+   issue is no longer running. Acceptable for v1; persisting pending
+   questions across restart is out of scope.
+7. **Model abuse** — nothing stops the model from asking dozens of questions.
+   We already rate-limit elsewhere; add a per-issue counter that auto-cancels
+   the run after N unanswered prompts (N=5 default, behind an app setting).
+8. **i18n drift** — missed translation keys fail lint. Run `bun run lint`
+   before merging.
+
+## Verification Plan
+
+- **Step 1**: manual prompt known to trigger AskUserQuestion; confirm exactly
+  one registry entry appears via debug log; no `bun test` regressions.
+- **Step 2**: confirm SSE log event reaches the browser with the new entry
+  type; check DB row in `issueLogs` table matches the emitted shape.
+- **Step 3**: integration test in `apps/api/test/` with mocked
+  `protocolHandler`. Verify payload shape is:
+  `{ type: 'tool_result', tool_use_id, content: '{"answers":[...]}' }`.
+  Invalid / mismatched IDs return 409.
+- **Step 4**: manual browser smoke. Multi-select case with 2 selected options
+  round-trips through the model. Cancel mid-question resets bubble state.
+- **Step 5**: `bun run test` / `bun run lint` / `bun run typecheck` green.
+  `bun test --filter ask-user-question` passes all new cases.
+
+## Out of Scope
+
+- Freeform answer inputs (text box, file picker).
+- Cross-restart persistence of pending questions.
+- Enabling AskUserQuestion on the legacy `claude-code` executor.
+- Permission prompting for other tools (kept auto-approved).
+
+## Alternatives Considered
+
+1. **Do nothing** — keep the tool disabled. Cost: model cannot disambiguate
+   underspecified tasks; degrades long interactive sessions where it would
+   otherwise ask. Rejected now that the SDK gives us the primitives.
+2. **Use `canUseTool` as the question channel** — intercept AskUserQuestion
+   in `canUseTool`, return a hanging promise that resolves after the user
+   answers, and feed the user's choice as `updatedInput`. Rejected:
+   `canUseTool` signals permission (allow/deny/updatedInput to mutate the
+   tool call), not tool_result. The SDK would execute the tool after the
+   callback resolves, producing its own internal result — we'd be
+   double-answering, and `updatedInput` can't return the chosen option in a
+   shape the model will parse.
+3. **Build a generic "pause and ask" mechanism for any tool** — too broad.
+   AskUserQuestion has a well-defined contract; other tools don't. Revisit
+   only if concrete demand appears.
+4. **Replace the SDK's AskUserQuestion with a custom MCP tool** — possible,
+   but duplicates what Claude Code already ships with. Adds maintenance
+   surface for no user-visible benefit.

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -31,3 +31,4 @@ Each plan is a single line linking to its detail file. All detailed information 
 
 - [-] [**PLAN-001 Project whiteboard mindmap technical design**](PLAN-001.md) `2026-04-14`
 - [-] [**PLAN-002 Whiteboard UI overhaul — edges, collapse badges, markdown**](PLAN-002.md) `2026-04-15`
+- [-] [**PLAN-003 Migrate claude executor to @anthropic-ai/claude-agent-sdk**](PLAN-003.md) `2026-04-17`

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -32,3 +32,4 @@ Each plan is a single line linking to its detail file. All detailed information 
 - [-] [**PLAN-001 Project whiteboard mindmap technical design**](PLAN-001.md) `2026-04-14`
 - [-] [**PLAN-002 Whiteboard UI overhaul — edges, collapse badges, markdown**](PLAN-002.md) `2026-04-15`
 - [-] [**PLAN-003 Migrate claude executor to @anthropic-ai/claude-agent-sdk**](PLAN-003.md) `2026-04-17`
+- [ ] [**PLAN-004 Enable AskUserQuestion in claude-code-sdk executor (web UI answer flow)**](PLAN-004.md) `2026-04-18`

--- a/docs/task/ENG-001.md
+++ b/docs/task/ENG-001.md
@@ -1,0 +1,65 @@
+# ENG-001 Migrate claude executor from manual stream-json to @anthropic-ai/claude-agent-sdk
+
+- **status**: in_progress
+- **priority**: P2
+- **owner**: claude
+- **createdAt**: 2026-04-17
+
+## Description
+
+The `claude-code` executor in `apps/api/src/engines/executors/claude/` spawns
+the `claude` CLI with `-p --output-format=stream-json --input-format=stream-json`
+and hand-rolls ~2100 lines covering:
+
+- `protocol.ts` (415 L) — bidirectional control protocol: `control_request` /
+  `control_response`, `can_use_tool`, `hook_callback`, `initialize`,
+  `set_permission_mode`, `interrupt`, ExitPlanMode mode-switch handling
+- `normalizer*.ts` (1155 L) — stream-json line → `NormalizedLogEntry`
+- `executor.ts` (538 L) — binary discovery, spawn, SDK init handshake,
+  slash-command / agent / plugin discovery via `--max-turns 1 -- /`
+
+Anthropic now ships `@anthropic-ai/claude-agent-sdk` (npm, v0.2.113, versioned
+in lockstep with Claude Code `2.1.112`) that exposes the exact same control
+protocol behind a typed async generator API: `query()`, `Query.interrupt()`,
+`Query.setPermissionMode()`, `Query.setModel()`, `Query.supportedCommands()`,
+streaming `AsyncIterable<SDKUserMessage>` prompt, `canUseTool` callback, typed
+`hooks`, `resume` / `resumeSessionAt`, `pathToClaudeCodeExecutable`, etc.
+
+Migrating lets us delete the entire hand-rolled protocol layer, shrink the
+normalizer (input becomes typed `SDKMessage` not raw strings), and track CLI
+protocol changes via SDK upgrades instead of reverse-engineering.
+
+## ActiveForm
+
+Migrating Claude executor to the official Claude Agent SDK
+
+## Phases
+
+See PLAN-003 for the full staged proposal. High-level phases:
+
+- [x] 1.1 Add SDK dependency, parallel `executors/claude-sdk/` executor
+- [x] 1.2 Narrow `ProcessManager` to `ProcessHandle` interface (Step 2)
+- [ ] 1.3 Rewrite normalizer input side: `SDKMessage` → `NormalizedLogEntry` (Step 5)
+- [x] 1.4 Wire SDK executor behind `CLAUDE_ENGINE_BACKEND` env flag (side-by-side, default legacy)
+- [ ] 1.5 Flip default to SDK, keep legacy behind flag for one release cycle (Step 4)
+- [ ] 1.6 Delete `protocol.ts`, stream-json parsing paths, npx fallback glue (Step 5)
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+- Scope is limited to `claude-code` engine type. `codex` (json-rpc) and `acp`
+  (agent-client-protocol) executors are unaffected.
+- Binary discovery (`/work/bin/claude`, `$HOME/.local/bin`, `/usr/local/bin`)
+  must be preserved and piped into SDK via `pathToClaudeCodeExecutable`; SDK
+  requires a real binary (no `npx -y` fallback path).
+- SDK version tracks CLI version — upgrade discipline must bump both together
+  to avoid control-protocol handshake drift.
+- `ProcessManager<TMeta>` currently types its subprocess field as Bun's
+  `Subprocess`, but only touches three members (`kill`, `exited`, `pid`).
+  Step 2 of PLAN-003 narrows this to a `ProcessHandle` interface; Bun's
+  subprocess matches structurally, and the SDK executor supplies a
+  ~30 L wrapper around `Query.interrupt()` + a generator-completion promise.

--- a/docs/task/ENG-002.md
+++ b/docs/task/ENG-002.md
@@ -1,0 +1,62 @@
+# ENG-002 Enable AskUserQuestion in claude-code-sdk executor
+
+- **status**: pending
+- **priority**: P2
+- **owner**:
+- **createdAt**: 2026-04-18
+
+## Description
+
+The `AskUserQuestion` tool is currently blocked via `disallowedTools` in the
+`claude-code-sdk` executor (`executors/claude-sdk/executor.ts:305` and
+`:376`). Claude uses this tool to disambiguate underspecified requests by
+asking the user a structured multiple-choice question mid-turn. Blocking it
+means the model silently muddles through or abandons the line of reasoning.
+
+This task lifts the block for the SDK backend and builds the round-trip:
+
+1. Capture the `tool_use_id` and question payload from the SDK stream.
+2. Persist a new `ask-user-question` log entry (serialized with `questions`
+   metadata) and surface it over the existing SSE `log` channel.
+3. Add an authenticated endpoint
+   (`POST /api/projects/:projectId/issues/:id/answer-question`) that injects
+   a `tool_result` user message into the running query via the existing
+   pushable prompt stream.
+4. Render a dedicated question bubble in the chat UI with option buttons and
+   a multi-select mode.
+
+Scope is limited to the SDK backend (`claude-code-sdk`). Legacy `claude-code`
+executor remains unchanged; users on that backend never see the tool.
+
+## ActiveForm
+
+Enabling AskUserQuestion with web-UI answer collection on the SDK backend
+
+## Phases
+
+See PLAN-004 for the full staged proposal. High-level phases:
+
+- [ ] 2.1 Unblock tool + capture `tool_use_id` in the stream, wire registry
+- [ ] 2.2 Emit `ask-user-question` log entry + extend shared `LogEntryType`
+- [ ] 2.3 Answer injection endpoint + `protocolHandler.sendUserMessage`
+      ContentBlock support
+- [ ] 2.4 Frontend question bubble + `useAnswerQuestion` mutation
+- [ ] 2.5 Test coverage + CLAUDE.md docs
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+- Only one outstanding question per issue at a time (simple registry). Upgrade
+  to a per-`tool_use_id` queue only if real traffic shows chaining.
+- Server restart while a question is pending loses the registry — reconciler
+  marks the session failed and the UI shows "cancelled". Cross-restart
+  persistence is out of scope.
+- Extending `protocolHandler.sendUserMessage` from `string` to
+  `string | ContentBlock[]` touches `engines/types.ts` and all executors.
+  Codex / ACP paths continue to pass strings only.
+- Enabling the same flow on the legacy `claude-code` executor can be revisited
+  after PLAN-003 Step 4 flips the default backend to SDK.

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -36,3 +36,4 @@ Each task is a single line linking to its detail file. All detailed information 
 - [-] [**WB-002 Improve whiteboard node UI, edges, and markdown rendering**](WB-002.md) `P1`
 - [x] [**WB-003 Refactor whiteboard AI: hidden sessions + MCP tools**](WB-003.md) `P1`
 - [x] [**WB-004 Whiteboard manual editing UX fixes**](WB-004.md) `P1`
+- [-] [**ENG-001 Migrate claude executor to @anthropic-ai/claude-agent-sdk**](ENG-001.md) `P2`

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -37,3 +37,4 @@ Each task is a single line linking to its detail file. All detailed information 
 - [x] [**WB-003 Refactor whiteboard AI: hidden sessions + MCP tools**](WB-003.md) `P1`
 - [x] [**WB-004 Whiteboard manual editing UX fixes**](WB-004.md) `P1`
 - [-] [**ENG-001 Migrate claude executor to @anthropic-ai/claude-agent-sdk**](ENG-001.md) `P2`
+- [ ] [**ENG-002 Enable AskUserQuestion in claude-code-sdk executor**](ENG-002.md) `P2`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,7 +17,7 @@ export interface Project {
   updatedAt: string
 }
 
-export type EngineType = 'claude-code' | 'codex' | 'acp' | `acp:${string}`
+export type EngineType = 'claude-code' | 'claude-code-sdk' | 'codex' | 'acp' | `acp:${string}`
 
 export interface PluginInfo { name: string, path: string }
 


### PR DESCRIPTION
## Summary

Migrates the `claude-code` engine executor from the hand-rolled stream-json protocol (~2100 L across `protocol.ts` / `normalizer*.ts` / `executor.ts`) to Anthropic's official `@anthropic-ai/claude-agent-sdk` (v0.2.113). This PR implements **steps 1-3** of PLAN-003 — a parallel SDK executor behind a `CLAUDE_ENGINE_BACKEND` env flag (defaults to `legacy`), so nothing changes for existing deployments.

## What's included

- **New parallel executor** `apps/api/src/engines/executors/claude-sdk/`
  - `executor.ts` — `ClaudeCodeSdkExecutor` using the SDK's `query()` async generator, `canUseTool` callback (handles `ExitPlanMode` → `bypassPermissions` via `setMode`), permission-mode mapping, `resume` / `resumeSessionAt` for follow-ups, and `supportedCommands` / `supportedAgents` discovery
  - `handle.ts` — `SdkProcessHandle` adapter: first `kill()` → `Query.interrupt()`, second → `Query.close()`, third is a no-op; exposes a settled `exited` promise
  - `normalizer.ts` — thin wrapper that JSON-stringifies `SDKMessage` and delegates to the existing `ClaudeLogNormalizer` (typed rewrite deferred to step 5)
  - `pushable-stream.ts` — async-iterable queue bridging user messages into the SDK's `AsyncIterable<SDKUserMessage>` prompt
- **ProcessManager abstraction** — `engines/process-handle.ts` narrows PM's dependency from Bun's `Subprocess` to a minimal `{ pid?, exited, kill }` interface; Bun subprocesses satisfy this structurally so Codex / ACP / legacy-Claude executors need no changes. Terminal PTY subprocess moved onto `meta.pty`.
- **Shared helpers** — `engines/executors/claude-shared/binary.ts` factors binary discovery + auth-status probing out of the legacy executor so both paths share one implementation without cross-importing.
- **Backend selection** — `getClaudeBackend()` + `createClaudeExecutor()` honor `CLAUDE_ENGINE_BACKEND={sdk,legacy}` (default `legacy`), log the selected backend at startup.
- **Startup probe** — `instanceof` check broadened to accept either `ClaudeCodeExecutor` or `ClaudeCodeSdkExecutor`.
- **Tests** — `apps/api/test/claude-sdk.test.ts` covers `PushableStream`, `SdkProcessHandle` kill semantics, normalizer round-trip, and backend-selection env parsing (14 cases).

## What's NOT in this PR (per PLAN-003)

- **Step 4** — flipping the default to `sdk`. Requires production soak first.
- **Step 5** — deleting legacy `executors/claude/` (~2100 L) and rewriting the normalizer to consume typed `SDKMessage` directly. Needs Step 4 to run a full release cycle first.

Tracking task: `docs/task/ENG-001.md`. Full rollout plan: `docs/plan/PLAN-003.md`.

## Test plan

- [x] `bunx tsc --noEmit -p apps/api/tsconfig.json` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 495 pass / 1 skip / 0 fail
- [ ] Manual smoke with `CLAUDE_ENGINE_BACKEND=sdk bun run dev:api`: create issue → run → cancel → follow-up → verify SSE logs match legacy path
- [ ] Manual smoke with flag unset (legacy default): verify no regressions
- [ ] Verify slash-command / agent discovery works via `Query.supportedCommands()` / `supportedAgents()`
- [ ] Verify ExitPlanMode → bypassPermissions mode switch via `canUseTool` `updatedPermissions`

## Risk / rollback

- Default stays `legacy`; zero behavior change for existing users unless they opt in via env.
- Rollback = flip flag or revert this commit; no DB migrations, no breaking API changes.