### PR TITLE
fix(webhooks): skip session.failed dispatch on user cancellation

### DIFF
--- a/apps/api/src/webhooks/dispatcher.ts
+++ b/apps/api/src/webhooks/dispatcher.ts
@@ -485,6 +485,11 @@ export function initWebhookDispatcher() {
   appEvents.on(
     'done',
     (data) => {
+      // Skip cancellations — user-initiated cancels are not failures and
+      // should not trigger session.failed notifications. Only completed/failed
+      // engine outcomes warrant a webhook.
+      if (data.finalStatus !== 'completed' && data.finalStatus !== 'failed') return
+
       void (async () => {
         try {
           const eventType: WebhookEventType =


### PR DESCRIPTION
## Summary
- The `done` event handler mapped any `finalStatus !== 'completed'` to `session.failed`, so user-initiated cancellations triggered false-positive failure notifications.
- Now only dispatch when `finalStatus` is `completed` or `failed`. `cancelled` outcomes no longer fire a webhook.

## Evidence
Latest two `session.failed` rows in `webhook_deliveries` had payloads with `"finalStatus":"cancelled"` — confirms the false-positive path.

## Test plan
- [ ] Cancel a running session — no `session.failed` webhook is delivered
- [ ] Engine fails naturally — `session.failed` still delivered as before
- [ ] Engine completes normally — `session.completed` delivered as before