### PR TITLE
fix(webhooks): drop legacy event from default selection, surface save errors

### DIFF
--- a/apps/frontend/src/components/settings/WebhookSection.tsx
+++ b/apps/frontend/src/components/settings/WebhookSection.tsx
@@ -140,6 +140,7 @@ function WebhookForm({ webhook, onClose }: { webhook?: Webhook, onClose: () => v
     webhook?.events ?? [...WEBHOOK_EVENT_TYPES],
   )
   const [isActive, setIsActive] = useState(webhook?.isActive ?? true)
+  const [error, setError] = useState<string | null>(null)
 
   const isEditing = !!webhook
   const isPending = createWebhook.isPending || updateWebhook.isPending
@@ -151,6 +152,7 @@ function WebhookForm({ webhook, onClose }: { webhook?: Webhook, onClose: () => v
 
   const handleSubmit = () => {
     if (!url || (!secret && isTelegram) || events.length === 0) return
+    setError(null)
 
     if (isEditing) {
       updateWebhook.mutate(
@@ -161,12 +163,18 @@ function WebhookForm({ webhook, onClose }: { webhook?: Webhook, onClose: () => v
           events,
           isActive,
         },
-        { onSuccess: onClose },
+        {
+          onSuccess: onClose,
+          onError: err => setError(err.message),
+        },
       )
     } else {
       createWebhook.mutate(
         { channel, url, secret: secret || undefined, events, isActive },
-        { onSuccess: onClose },
+        {
+          onSuccess: onClose,
+          onError: err => setError(err.message),
+        },
       )
     }
   }
@@ -301,6 +309,12 @@ function WebhookForm({ webhook, onClose }: { webhook?: Webhook, onClose: () => v
           ))}
         </div>
       </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -475,10 +475,7 @@ export const WEBHOOK_EVENT_GROUPS: { category: string, events: WebhookEventType[
   },
 ]
 
-export const WEBHOOK_EVENT_TYPES: WebhookEventType[] = [
-  ...WEBHOOK_EVENT_GROUPS.flatMap(g => g.events),
-  'issue.status_changed', // legacy compat
-]
+export const WEBHOOK_EVENT_TYPES: WebhookEventType[] = WEBHOOK_EVENT_GROUPS.flatMap(g => g.events)
 
 export type NotificationChannel = 'webhook' | 'telegram'
 


### PR DESCRIPTION
## Symptom
Creating a new webhook always failed with:
\`\`\`
Invalid option: expected one of \"issue.created\"|\"issue.updated\"|\"issue.deleted\"|\"issue.status.todo\"|...
\`\`\`
…and the form silently stayed open with no visible error.

## Root cause
- \`WEBHOOK_EVENT_TYPES\` (in \`@bkd/shared\`) included the legacy \`issue.status_changed\` value, and the new-webhook form used it as the "select all" default.
- The backend's \`CreateWebhookSchema\` only accepts the granular event names — \`issue.status_changed\` is not in the enum, so the POST always 422'd.
- \`WebhookForm\` only handled \`onSuccess\`, so the error was swallowed.

## Fix
- Remove the legacy value from \`WEBHOOK_EVENT_TYPES\`. The dispatcher's runtime subscription filter still recognises \`issue.status_changed\` for existing DB rows.
- Add \`onError\` handlers to the create/update mutations and render the message inline.

## Test plan
- [ ] Open settings → notifications → "Add" → fill URL → save: webhook persists, no error shown
- [ ] Submit invalid URL (e.g. private network): inline red banner shows the backend error
- [ ] Existing webhook rows that contain \`issue.status_changed\` continue to receive granular status webhooks