### PR TITLE
ci(db): guard drizzle migration/snapshot consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             command: bun run lint
           - name: Typecheck
             command: bunx tsc --noEmit -p apps/api/tsconfig.json && bunx tsc --noEmit -p apps/frontend/tsconfig.json
+          - name: Migrations
+            command: bun run db:generate && test -z "$(git status --porcelain -- apps/api/drizzle)" || { echo 'Drizzle schema/migration/snapshot out of sync — run "bun run db:generate" and commit the generated migration + snapshot'; git status --porcelain -- apps/api/drizzle; exit 1; }
           - name: Test
             command: bun run test:api && cd apps/frontend && bunx vitest run --reporter=verbose
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ bun scripts/package.ts --version 0.0.6 --skip-frontend
 - **Database**: SQLite via `bun:sqlite` + Drizzle ORM (WAL mode, 64 MB cache, 256 MB mmap)
   - Schema in `db/schema.ts`. All tables share `commonFields` (`createdAt`, `updatedAt`, `isDeleted` soft delete)
   - Projects/issues use `shortId()` (nanoid 8-char), logs use `id()` (ULID)
-  - Migrations in `apps/api/drizzle/`, auto-applied on startup
+  - Migrations in `apps/api/drizzle/`, auto-applied on startup. Runtime applies them in `meta/_journal.json` order, tracked per-DB in `__drizzle_migrations` (snapshots are never read at runtime). Rules: never edit or reorder a shipped migration (drizzle keys applied state by file hash); only append new ones via `bun run db:generate`; always commit the schema change, generated `.sql`, `meta/<n>_snapshot.json`, and `_journal.json` together. CI (`Migrations` job) fails if `db:generate` yields uncommitted changes. Intermediate snapshots `0001,0005,0012,0014–0019` are missing — accepted (archival-only; the diff base re-aligned at `0020`, see ENG-009)
 - **Logging**: pino (`logger.ts`)
 - **Caching**: in-process LRU+TTL Map-based cache (`cache.ts`, max 500 entries)
 - **Static serving**: three modes — embedded (compiled binary), `APP_DIR/public/` (package mode), `apps/frontend/dist/` (dev)

--- a/docs/task/ENG-009.md
+++ b/docs/task/ENG-009.md
@@ -1,0 +1,65 @@
+# ENG-009 Guard drizzle migration/snapshot consistency
+
+- **status**: completed
+- **priority**: P3
+- **owner**: claude
+- **createdAt**: 2026-05-16
+
+## Description
+
+During ENG-008 the drizzle meta snapshots were found to have drifted:
+snapshots froze at `0013` while migrations `0014`–`0019` were added as
+raw SQL with no snapshot updates. Regenerating the `0020` snapshot (a
+side effect of ENG-008's migration) **re-aligned the diff base** — a
+fresh `bun run db:generate` now reports "No schema changes", so future
+migration generation is clean and the earlier spurious `CREATE TABLE
+cron_*` emission was a one-time artifact, not a recurring burden.
+
+Runtime migration ordering/idempotency was never at risk: the runtime
+applies migrations by `_journal.json` order tracked in the per-DB
+`__drizzle_migrations` table and never reads snapshots.
+
+Scope A (chosen): do **not** rebuild snapshot history (high risk,
+touches frozen migration metadata, zero functional benefit). Instead
+add a permanent automated guard plus documentation.
+
+## ActiveForm
+
+Adding a CI guard and docs for migration/snapshot consistency
+
+## Scope
+
+1. **CI guard** — new `check` matrix entry that runs `bun run
+   db:generate` and fails if it produces any uncommitted change under
+   `apps/api/drizzle/`. Catches any future schema/migration/snapshot
+   desync automatically (no reliance on manual discipline).
+2. **Docs** — record the migration rules in `CLAUDE.md`: runtime applies
+   by journal + `__drizzle_migrations`; never edit/reorder a shipped
+   migration; only append via `db:generate`; commit schema + migration +
+   snapshot together.
+3. **Accepted gap** — intermediate snapshots `0001,0005,0012,0014–0019`
+   are physically missing; drizzle-kit only uses the latest snapshot and
+   the runtime ignores snapshots, so this is archival-only and
+   explicitly accepted (recorded here), not backfilled.
+
+## Out of scope
+
+- Backfilling/rebuilding historical snapshots or rewriting `_journal.json`.
+
+## Verification
+
+1. Locally: `bun run db:generate` then `git diff --exit-code --
+   apps/api/drizzle` exits 0 (clean) on a consistent tree.
+2. CI: the new matrix entry passes on this branch.
+3. `bun run lint` unaffected (YAML + Markdown only).
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+- Decisive check: on the post-ENG-008 tree `db:generate` prints
+  "No schema changes, nothing to migrate" — drift is functionally
+  resolved; this task only prevents regressions.

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -47,3 +47,4 @@ Each task is a single line linking to its detail file. All detailed information 
 - [x] [**ENG-006 Allow unresolved webhook hostnames on save**](ENG-006.md) `P1`
 - [x] [**ENG-007 Remove claude-code-sdk engine**](ENG-007.md) `P2`
 - [x] [**ENG-008 Add per-project default engine and model**](ENG-008.md) `P2`
+- [x] [**ENG-009 Guard drizzle migration/snapshot consistency**](ENG-009.md) `P3`


### PR DESCRIPTION
## Summary

Adds an automated guard against drizzle schema/migration/snapshot desync, plus documentation of the migration model. Scope A from the ENG-009 investigation: **no snapshot-history rebuild** (high risk, touches frozen migration metadata, zero functional benefit) — the diff base already re-aligned at `0020` during ENG-008, so a fresh `db:generate` is already clean.

## Changes

- **CI**: new `Migrations` matrix job — runs `bun run db:generate` and fails if it leaves any uncommitted change under `apps/api/drizzle/`. Catches future schema/migration/snapshot desync automatically instead of relying on manual discipline.
- **Docs**: `CLAUDE.md` now records the runtime migration model (applied in `_journal.json` order, tracked per-DB in `__drizzle_migrations`, snapshots never read at runtime) and the append-only rules.
- **Accepted gap**: intermediate snapshots `0001,0005,0012,0014–0019` are missing; archival-only (drizzle-kit uses only the latest snapshot, runtime ignores snapshots). Explicitly accepted, not backfilled.

## Background

Runtime migration ordering/idempotency was never at risk: the runtime uses `_journal.json` + `__drizzle_migrations`, not snapshots. The earlier spurious `CREATE TABLE cron_*` in `0020` was a one-time artifact of a stale pre-`0013` diff base, resolved when ENG-008 regenerated the `0020` snapshot.

## Test plan

- [x] Local: `bun run db:generate` then `git status --porcelain apps/api/drizzle` → empty (guard passes on a consistent tree)
- [x] New `Migrations` CI job passes on this branch
- [x] Lint unaffected (YAML + Markdown only)