### PR TITLE
feat(issues): pin sessions to top of the issue list

### DIFF
--- a/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   FolderOpen,
   MoreHorizontal,
+  Pin,
   Plus,
   Search,
   Settings,
@@ -295,6 +296,7 @@ const IssueRow = memo(({
         #
         {issue.issueNumber}
       </span>
+      {issue.isPinned && <Pin className="size-3 shrink-0 text-primary" />}
       <span
         title={issue.title}
         className={`text-[13px] truncate ${
@@ -304,7 +306,7 @@ const IssueRow = memo(({
         {issue.title}
       </span>
       <div className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity shrink-0" onClick={e => e.stopPropagation()} onPointerDown={e => e.stopPropagation()}>
-        <IssueContextMenu issue={issue} projectId={projectId}>
+        <IssueContextMenu issue={issue} projectId={projectId} showPin>
           <button
             type="button"
             className="inline-flex items-center justify-center rounded-md p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"

--- a/docs/task/UI-001.md
+++ b/docs/task/UI-001.md
@@ -1,0 +1,38 @@
+# UI-001 Enable session pin in the issue list panel
+
+- **status**: completed
+- **priority**: P2
+- **owner**: roy
+- **createdAt**: 2026-05-16 00:00
+
+## Description
+
+The pin feature is already implemented end-to-end (DB column `issues.isPinned`,
+backend query `desc(isPinned)` ordering, `useUpdateIssue` mutation, shared types,
+i18n keys, and the `IssueContextMenu` pin/unpin item gated by `showPin`). It is
+wired into the Kanban card but **not** into the session list (`IssueListPanel`):
+
+- `IssueListPanel` already sorts pinned issues to the top (line 68), but
+- it renders `IssueContextMenu` without `showPin`, so the pin/unpin action is
+  hidden in the session list, and
+- pinned rows show no visual indicator (Kanban card shows a `Pin` icon).
+
+Acceptance criteria:
+
+- Right-click / kebab menu on a session row exposes Pin to top / Unpin.
+- Pinning a session moves it to the top of its status group in the list.
+- Pinned rows display a visual pin indicator.
+
+## ActiveForm
+
+Enabling session pin in the issue list panel.
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+Frontend-only change, single file (`IssueListPanel.tsx`). Backend/sorting/i18n
+already complete.


### PR DESCRIPTION
## Summary

Wire the existing pin/unpin capability into the issue list panel.

- Enable the pin/unpin action in the `IssueListPanel` row context menu (`showPin`).
- Show a pin indicator on pinned rows, consistent with the Kanban card.

Backend ordering (`desc(isPinned)`), the `useUpdateIssue` mutation, and i18n keys were already in place; this only connects them to the session list.

## Test plan

- [x] `bun run lint` (changed files clean)
- [x] `tsc --noEmit` (frontend)
- [ ] Manual: kebab menu on a session row shows Pin to top / Unpin; pinning moves the row to the top of its status group with a pin icon