### PR TITLE
feat(db): add fix-db command and share repair across entrypoints

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -1,17 +1,15 @@
 import { Database } from 'bun:sqlite'
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { dirname, resolve } from 'node:path'
+import { existsSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 import { sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/bun-sqlite'
 import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
 import { logger } from '@/logger'
-import { APP_DIR, ROOT_DIR } from '@/root'
 import { embeddedMigrations } from './embedded-migrations'
+import { resolveDbPath, resolveMigrationsDir } from './migrations-source'
 import * as schema from './schema'
 
-const rawDbPath = process.env.DB_PATH || 'data/db/bkd.db'
-const dbPath = rawDbPath.startsWith('/') ? rawDbPath : resolve(ROOT_DIR, rawDbPath)
+const dbPath = resolveDbPath()
 
 const dir = dirname(dbPath)
 if (!existsSync(dir)) {
@@ -28,13 +26,6 @@ sqlite.run('PRAGMA mmap_size = 268435456')
 
 export const db = drizzle({ client: sqlite, schema })
 export { dbPath, sqlite }
-
-// In package mode, migrations live inside APP_DIR/migrations/.
-// In dev mode, they live in apps/api/drizzle/.
-const migrationsFolder = APP_DIR ?
-    resolve(APP_DIR, 'migrations') :
-    resolve(ROOT_DIR, 'apps/api/drizzle')
-const journalPath = resolve(migrationsFolder, 'meta/_journal.json')
 
 function runMigrations(folder: string) {
   try {
@@ -53,21 +44,10 @@ function runMigrations(folder: string) {
   }
 }
 
-if (existsSync(journalPath)) {
-  // Filesystem migrations available (dev / package mode / non-compiled mode)
-  runMigrations(migrationsFolder)
-} else if (embeddedMigrations.size > 0) {
-  // Compiled binary — write embedded migrations to a temp directory
-  // and let drizzle's standard migrator process them.
-  const tmpMigrations = resolve(tmpdir(), 'bkd-migrations')
-  mkdirSync(resolve(tmpMigrations, 'meta'), { recursive: true })
-  for (const [name, content] of embeddedMigrations) {
-    writeFileSync(resolve(tmpMigrations, name), content)
-  }
-  runMigrations(tmpMigrations)
+const migrations = resolveMigrationsDir()
+runMigrations(migrations.dir)
+if (migrations.embedded) {
   logger.info({ count: embeddedMigrations.size }, 'embedded_migrations_applied')
-} else {
-  throw new Error('No migrations available (missing drizzle/ folder and no embedded migrations)')
 }
 
 // --- Post-migration schema verification ---

--- a/apps/api/src/db/migrations-source.ts
+++ b/apps/api/src/db/migrations-source.ts
@@ -1,0 +1,59 @@
+/**
+ * Side-effect-free resolution of the database path and the directory that
+ * holds the Drizzle migration files (`*.sql` + `meta/_journal.json`).
+ *
+ * Importing this module must NOT open the database or run migrations — it is
+ * shared by the normal startup path (`db/index.ts`) and the `fix-db` repair
+ * path (`db/repair.ts`), the latter of which must run before the startup
+ * migrate+verify side-effect.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { APP_DIR, ROOT_DIR } from '@/root'
+import { embeddedMigrations } from './embedded-migrations'
+
+/** Absolute path to the SQLite database file. */
+export function resolveDbPath(): string {
+  const raw = process.env.DB_PATH || 'data/db/bkd.db'
+  return raw.startsWith('/') ? raw : resolve(ROOT_DIR, raw)
+}
+
+export interface MigrationsSource {
+  /** Directory containing migration `*.sql` files and `meta/_journal.json`. */
+  dir: string
+  /** True when migrations were materialized from the embedded binary map. */
+  embedded: boolean
+}
+
+/**
+ * Resolve the migrations directory.
+ *
+ * - Package mode: `APP_DIR/migrations`.
+ * - Dev / non-compiled: `apps/api/drizzle`.
+ * - Compiled binary (no filesystem migrations): the embedded migration map is
+ *   written to a temp directory and that path is returned.
+ */
+export function resolveMigrationsDir(): MigrationsSource {
+  const fsFolder = APP_DIR
+    ? resolve(APP_DIR, 'migrations')
+    : resolve(ROOT_DIR, 'apps/api/drizzle')
+
+  if (existsSync(resolve(fsFolder, 'meta/_journal.json'))) {
+    return { dir: fsFolder, embedded: false }
+  }
+
+  if (embeddedMigrations.size > 0) {
+    const tmp = resolve(tmpdir(), 'bkd-migrations')
+    for (const [name, content] of embeddedMigrations) {
+      const target = resolve(tmp, name)
+      mkdirSync(dirname(target), { recursive: true })
+      writeFileSync(target, content)
+    }
+    return { dir: tmp, embedded: true }
+  }
+
+  throw new Error(
+    'No migrations available (missing drizzle/ folder and no embedded migrations)',
+  )
+}

--- a/apps/api/src/db/repair.ts
+++ b/apps/api/src/db/repair.ts
@@ -1,0 +1,120 @@
+/**
+ * Idempotent database repair.
+ *
+ * Re-applies pending Drizzle migrations using only `bun:sqlite` +
+ * `node:crypto` (no `drizzle-orm`), so it works in dev, full compiled
+ * binaries, and package mode. Unlike the normal startup migrator
+ * (`db/index.ts` `runMigrations`), repair is tolerant per-statement of
+ * "table/index already exists" and "duplicate column name", and records each
+ * migration's hash in `__drizzle_migrations` so subsequent normal startups
+ * are consistent.
+ *
+ * This recovers databases whose `__drizzle_migrations` is hash-inconsistent
+ * with the (re-aligned) migration history, where the normal migrator silently
+ * aborts the chain on the first "already exists" and leaves later migrations
+ * (e.g. column additions) unapplied.
+ */
+import { Database } from 'bun:sqlite'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { resolveDbPath, resolveMigrationsDir } from './migrations-source'
+
+/** Errors safe to skip per-statement: the schema change is already present. */
+const TOLERATED = /already exists|duplicate column name/i
+
+export interface RepairResult {
+  /** Migrations whose hash was newly recorded this run. */
+  applied: number
+  /** Migrations already recorded (hash match) and skipped. */
+  skipped: number
+}
+
+interface Journal {
+  entries: Array<{ idx: number, when: number, tag: string }>
+}
+
+export function repairDatabase(
+  opts: { dbPath?: string, migrationsDir?: string } = {},
+): RepairResult {
+  const dbPath = opts.dbPath ?? resolveDbPath()
+  if (!existsSync(dbPath)) {
+    // No database yet — normal startup will create and migrate it.
+    return { applied: 0, skipped: 0 }
+  }
+
+  const migrationsDir = opts.migrationsDir ?? resolveMigrationsDir().dir
+  const journalFile = resolve(migrationsDir, 'meta/_journal.json')
+  if (!existsSync(journalFile)) {
+    throw new Error(`Migrations journal not found: ${journalFile}`)
+  }
+  const journal = JSON.parse(readFileSync(journalFile, 'utf8')) as Journal
+
+  const sqlite = new Database(dbPath)
+  try {
+    sqlite.run('PRAGMA journal_mode = WAL')
+    sqlite.run(`CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at numeric
+    )`)
+
+    const appliedHashes = new Set(
+      (sqlite.query('SELECT hash FROM __drizzle_migrations').all() as Array<{ hash: string }>)
+        .map(r => r.hash),
+    )
+
+    let applied = 0
+    let skipped = 0
+
+    // foreign_keys must be toggled outside any transaction.
+    sqlite.run('PRAGMA foreign_keys = OFF')
+
+    for (const entry of [...journal.entries].sort((a, b) => a.idx - b.idx)) {
+      const sqlFile = resolve(migrationsDir, `${entry.tag}.sql`)
+      if (!existsSync(sqlFile)) {
+        throw new Error(`Migration file not found: ${sqlFile}`)
+      }
+      const sql = readFileSync(sqlFile, 'utf8')
+      const hash = createHash('sha256').update(sql).digest('hex')
+      if (appliedHashes.has(hash)) {
+        skipped++
+        continue
+      }
+
+      const statements = sql
+        .split('--> statement-breakpoint')
+        .map(s => s.trim())
+        .filter(Boolean)
+
+      sqlite.run('BEGIN')
+      try {
+        for (const stmt of statements) {
+          try {
+            sqlite.run(stmt)
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err)
+            if (TOLERATED.test(msg)) continue
+            throw err
+          }
+        }
+        sqlite.run(
+          'INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)',
+          [hash, entry.when],
+        )
+        sqlite.run('COMMIT')
+        applied++
+      } catch (err) {
+        sqlite.run('ROLLBACK')
+        throw new Error(
+          `Repair failed at ${entry.tag}: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    }
+
+    sqlite.run('PRAGMA foreign_keys = ON')
+    return { applied, skipped }
+  } finally {
+    sqlite.close()
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,214 +1,30 @@
-import { existsSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { serveStatic, websocket } from 'hono/bun'
-import app from './app'
-import { embeddedStatic } from './embedded-static'
-import { issueEngine } from './engines/issue'
-import { migrateSlashCommandsKey, refreshSlashCommandsCache } from './engines/issue/queries'
-import {
-  registerSettledReconciliation,
-  startPeriodicReconciliation,
-  startupReconciliation,
-  stopPeriodicReconciliation,
-} from './engines/reconciler'
-import { refreshGlobalEnvCache } from './engines/safe-env'
-import { startChangesSummaryWatcher, stopChangesSummaryWatcher } from './events/changes-summary'
-import { startCron } from './cron'
-import { logger } from './logger'
-import { acquirePidLock, releasePidLock } from './pid-lock'
-import { APP_DIR, ROOT_DIR } from './root'
-import { printStartupBanner } from './startup-banner'
-import { staticAssets } from './static-assets'
-import { initUpgradeSystem, registerShutdownForUpgrade, stopPeriodicCheck } from './upgrade/service'
-import { initWebhookDispatcher, startDeliveryCleanup } from './webhooks/dispatcher'
+/**
+ * Process entry point.
+ *
+ * `bkd fix-db` / `bkd --fix-db` repairs the database and exits WITHOUT loading
+ * the server, so it works even when normal startup `verifySchema()` would
+ * `process.exit(1)`. Any other invocation boots the server.
+ *
+ * The server bootstrap lives in `./server-main` and is loaded via dynamic
+ * import so its db migrate+verify startup side-effect never runs on the
+ * fix-db path.
+ */
+const argv = process.argv.slice(2)
 
-// ---------- Global error handlers ----------
-// Catch unhandled promise rejections so they are always logged.
-// This prevents silent failures in fire-and-forget async operations
-// (monitorCompletion, turn settlement, GC sweep, etc.).
-process.on('unhandledRejection', (reason, promise) => {
-  logger.error({ reason, promise: String(promise) }, 'unhandled_rejection')
-})
-
-// Catch truly uncaught exceptions. Log and exit — the process state is
-// unreliable after an uncaught exception.
-process.on('uncaughtException', (err, origin) => {
-  logger.fatal({ err, origin }, 'uncaught_exception')
-  // Give pino time to flush the log entry before exiting
-  setTimeout(() => process.exit(1), 200)
-})
-
-// ---------- PID lock ----------
-// Prevent multiple BKD instances from running simultaneously against the
-// same data directory. Must run before any DB writes or Bun.serve().
-acquirePidLock()
-
-// Safety net: release the PID lock on any exit path (uncaughtException,
-// process.exit, SIGKILL is not catchable but stale-lock detection handles it).
-// `process.on('exit')` only allows synchronous work — releasePidLock is sync.
-process.on('exit', () => {
-  releasePidLock()
-})
-
-// Migrate legacy global slash commands key to per-engine format, then load cache
-void migrateSlashCommandsKey()
-  .then(() => refreshSlashCommandsCache())
-  .catch((err) => {
-    logger.error({ err }, 'slash_commands_cache_load_failed')
-  })
-
-// Pre-warm global env vars cache from DB
-void refreshGlobalEnvCache().catch((err) => {
-  logger.error({ err }, 'global_env_cache_load_failed')
-})
-
-// Load max concurrent executions setting from DB
-void issueEngine.initMaxConcurrent().catch((err) => {
-  logger.error({ err }, 'init_max_concurrent_failed')
-})
-
-// Run startup reconciliation: mark stale sessions as failed and move
-// orphaned working issues to review.
-void startupReconciliation().catch((err) => {
-  logger.error({ err }, 'startup_reconciliation_failed')
-})
-
-// Register event-driven reconciliation (fires after each process settles)
-const stopSettledReconciliation = registerSettledReconciliation()
-
-// Start periodic reconciliation (fallback safety net)
-startPeriodicReconciliation()
-
-// Start watching for file changes to push summaries via SSE
-startChangesSummaryWatcher()
-
-// Initialize webhook dispatcher (subscribes to event bus)
-initWebhookDispatcher()
-
-// Start periodic webhook delivery cleanup (keeps last 100 per webhook)
-const stopDeliveryCleanup = startDeliveryCleanup()
-
-const listenHost = process.env.HOST ?? '0.0.0.0'
-const listenPort = Number(process.env.PORT ?? 3000)
-
-// --- Static file serving ---
-// In compiled mode, static-assets.ts is replaced at build time with
-// generated imports that embed all frontend/dist files.
-// In dev mode, the file exports an empty Map and we fall back to disk.
-if (staticAssets.size > 0) {
-  app.use('*', embeddedStatic(staticAssets))
-  logger.info({ assets: staticAssets.size }, 'embedded_static_loaded')
-} else {
-  // In package mode, static files live in APP_DIR/public/.
-  // In dev mode, they live in apps/frontend/dist/.
-  const staticRoot = APP_DIR ? resolve(APP_DIR, 'public') : resolve(ROOT_DIR, 'apps/frontend/dist')
-  if (existsSync(staticRoot)) {
-    app.use(
-      '/assets/*',
-      serveStatic({
-        root: staticRoot,
-        onFound: (_path, c) => {
-          c.header('Cache-Control', 'public, max-age=31536000, immutable')
-        },
-      }),
+if (argv.includes('fix-db') || argv.includes('--fix-db')) {
+  // eslint-disable-next-line antfu/no-top-level-await
+  const { repairDatabase } = await import('./db/repair')
+  try {
+    const result = repairDatabase()
+    console.log(
+      `[fix-db] database repair complete — applied ${result.applied}, skipped ${result.skipped}`,
     )
-
-    app.use(
-      '*',
-      serveStatic({
-        root: staticRoot,
-        onFound: (_path, c) => {
-          c.header('Cache-Control', 'public, max-age=3600, must-revalidate')
-        },
-      }),
-    )
-
-    app.get(
-      '*',
-      serveStatic({
-        root: staticRoot,
-        path: 'index.html',
-        onFound: (_path, c) => {
-          c.header('Cache-Control', 'no-cache')
-        },
-      }),
-    )
-  }
-}
-
-const http = Bun.serve({
-  port: listenPort,
-  hostname: listenHost,
-  idleTimeout: 60,
-  fetch: app.fetch,
-  websocket,
-})
-
-printStartupBanner(listenHost, listenPort)
-
-// Start cron scheduler (replaces individual setInterval jobs)
-const stopCron = startCron()
-
-// Register shutdown callback for upgrade restarts (stops server + cancels engines)
-registerShutdownForUpgrade(async () => {
-  stopChangesSummaryWatcher()
-  stopSettledReconciliation()
-  stopPeriodicReconciliation()
-  stopCron()
-  stopPeriodicCheck()
-  stopDeliveryCleanup()
-  await issueEngine.cancelAll()
-  http.stop()
-  releasePidLock()
-  logger.info('server_stopped_for_upgrade')
-})
-
-// Initialize upgrade system (check for updates on startup + periodic check)
-void initUpgradeSystem().catch((err) => {
-  logger.error({ err }, 'upgrade_system_init_failed')
-})
-
-let isShuttingDown = false
-
-async function shutdown(signal: string) {
-  if (isShuttingDown) {
-    // Second signal → force-exit immediately (e.g. double Ctrl+C)
-    logger.warn({ signal }, 'server_shutdown_forced')
+    process.exit(0)
+  } catch (err) {
+    console.error(`[fix-db] ${err instanceof Error ? err.message : String(err)}`)
     process.exit(1)
   }
-  isShuttingDown = true
-
-  const activeProcesses = issueEngine.getActiveProcesses()
-  logger.warn(
-    {
-      signal,
-      activeProcessCount: activeProcesses.length,
-      activeIssues: activeProcesses.map(p => p.issueId),
-      uptimeSeconds: Math.round(process.uptime()),
-    },
-    'server_shutdown',
-  )
-
-  // Stop SSE subscriptions and periodic jobs before cancelling processes
-  stopChangesSummaryWatcher()
-  stopSettledReconciliation()
-  stopPeriodicReconciliation()
-  stopCron()
-  stopPeriodicCheck()
-  stopDeliveryCleanup()
-
-  // Cancel all active engine processes before shutting down
-  await issueEngine.cancelAll()
-
-  http.stop()
-  releasePidLock()
-  logger.info('server_stopped')
-  process.exit(0)
+} else {
+  // eslint-disable-next-line antfu/no-top-level-await
+  await import('./server-main')
 }
-
-process.on('SIGINT', () => {
-  void shutdown('SIGINT')
-})
-process.on('SIGTERM', () => {
-  void shutdown('SIGTERM')
-})

--- a/apps/api/src/server-main.ts
+++ b/apps/api/src/server-main.ts
@@ -1,0 +1,214 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { serveStatic, websocket } from 'hono/bun'
+import app from './app'
+import { embeddedStatic } from './embedded-static'
+import { issueEngine } from './engines/issue'
+import { migrateSlashCommandsKey, refreshSlashCommandsCache } from './engines/issue/queries'
+import {
+  registerSettledReconciliation,
+  startPeriodicReconciliation,
+  startupReconciliation,
+  stopPeriodicReconciliation,
+} from './engines/reconciler'
+import { refreshGlobalEnvCache } from './engines/safe-env'
+import { startChangesSummaryWatcher, stopChangesSummaryWatcher } from './events/changes-summary'
+import { startCron } from './cron'
+import { logger } from './logger'
+import { acquirePidLock, releasePidLock } from './pid-lock'
+import { APP_DIR, ROOT_DIR } from './root'
+import { printStartupBanner } from './startup-banner'
+import { staticAssets } from './static-assets'
+import { initUpgradeSystem, registerShutdownForUpgrade, stopPeriodicCheck } from './upgrade/service'
+import { initWebhookDispatcher, startDeliveryCleanup } from './webhooks/dispatcher'
+
+// ---------- Global error handlers ----------
+// Catch unhandled promise rejections so they are always logged.
+// This prevents silent failures in fire-and-forget async operations
+// (monitorCompletion, turn settlement, GC sweep, etc.).
+process.on('unhandledRejection', (reason, promise) => {
+  logger.error({ reason, promise: String(promise) }, 'unhandled_rejection')
+})
+
+// Catch truly uncaught exceptions. Log and exit — the process state is
+// unreliable after an uncaught exception.
+process.on('uncaughtException', (err, origin) => {
+  logger.fatal({ err, origin }, 'uncaught_exception')
+  // Give pino time to flush the log entry before exiting
+  setTimeout(() => process.exit(1), 200)
+})
+
+// ---------- PID lock ----------
+// Prevent multiple BKD instances from running simultaneously against the
+// same data directory. Must run before any DB writes or Bun.serve().
+acquirePidLock()
+
+// Safety net: release the PID lock on any exit path (uncaughtException,
+// process.exit, SIGKILL is not catchable but stale-lock detection handles it).
+// `process.on('exit')` only allows synchronous work — releasePidLock is sync.
+process.on('exit', () => {
+  releasePidLock()
+})
+
+// Migrate legacy global slash commands key to per-engine format, then load cache
+void migrateSlashCommandsKey()
+  .then(() => refreshSlashCommandsCache())
+  .catch((err) => {
+    logger.error({ err }, 'slash_commands_cache_load_failed')
+  })
+
+// Pre-warm global env vars cache from DB
+void refreshGlobalEnvCache().catch((err) => {
+  logger.error({ err }, 'global_env_cache_load_failed')
+})
+
+// Load max concurrent executions setting from DB
+void issueEngine.initMaxConcurrent().catch((err) => {
+  logger.error({ err }, 'init_max_concurrent_failed')
+})
+
+// Run startup reconciliation: mark stale sessions as failed and move
+// orphaned working issues to review.
+void startupReconciliation().catch((err) => {
+  logger.error({ err }, 'startup_reconciliation_failed')
+})
+
+// Register event-driven reconciliation (fires after each process settles)
+const stopSettledReconciliation = registerSettledReconciliation()
+
+// Start periodic reconciliation (fallback safety net)
+startPeriodicReconciliation()
+
+// Start watching for file changes to push summaries via SSE
+startChangesSummaryWatcher()
+
+// Initialize webhook dispatcher (subscribes to event bus)
+initWebhookDispatcher()
+
+// Start periodic webhook delivery cleanup (keeps last 100 per webhook)
+const stopDeliveryCleanup = startDeliveryCleanup()
+
+const listenHost = process.env.HOST ?? '0.0.0.0'
+const listenPort = Number(process.env.PORT ?? 3000)
+
+// --- Static file serving ---
+// In compiled mode, static-assets.ts is replaced at build time with
+// generated imports that embed all frontend/dist files.
+// In dev mode, the file exports an empty Map and we fall back to disk.
+if (staticAssets.size > 0) {
+  app.use('*', embeddedStatic(staticAssets))
+  logger.info({ assets: staticAssets.size }, 'embedded_static_loaded')
+} else {
+  // In package mode, static files live in APP_DIR/public/.
+  // In dev mode, they live in apps/frontend/dist/.
+  const staticRoot = APP_DIR ? resolve(APP_DIR, 'public') : resolve(ROOT_DIR, 'apps/frontend/dist')
+  if (existsSync(staticRoot)) {
+    app.use(
+      '/assets/*',
+      serveStatic({
+        root: staticRoot,
+        onFound: (_path, c) => {
+          c.header('Cache-Control', 'public, max-age=31536000, immutable')
+        },
+      }),
+    )
+
+    app.use(
+      '*',
+      serveStatic({
+        root: staticRoot,
+        onFound: (_path, c) => {
+          c.header('Cache-Control', 'public, max-age=3600, must-revalidate')
+        },
+      }),
+    )
+
+    app.get(
+      '*',
+      serveStatic({
+        root: staticRoot,
+        path: 'index.html',
+        onFound: (_path, c) => {
+          c.header('Cache-Control', 'no-cache')
+        },
+      }),
+    )
+  }
+}
+
+const http = Bun.serve({
+  port: listenPort,
+  hostname: listenHost,
+  idleTimeout: 60,
+  fetch: app.fetch,
+  websocket,
+})
+
+printStartupBanner(listenHost, listenPort)
+
+// Start cron scheduler (replaces individual setInterval jobs)
+const stopCron = startCron()
+
+// Register shutdown callback for upgrade restarts (stops server + cancels engines)
+registerShutdownForUpgrade(async () => {
+  stopChangesSummaryWatcher()
+  stopSettledReconciliation()
+  stopPeriodicReconciliation()
+  stopCron()
+  stopPeriodicCheck()
+  stopDeliveryCleanup()
+  await issueEngine.cancelAll()
+  http.stop()
+  releasePidLock()
+  logger.info('server_stopped_for_upgrade')
+})
+
+// Initialize upgrade system (check for updates on startup + periodic check)
+void initUpgradeSystem().catch((err) => {
+  logger.error({ err }, 'upgrade_system_init_failed')
+})
+
+let isShuttingDown = false
+
+async function shutdown(signal: string) {
+  if (isShuttingDown) {
+    // Second signal → force-exit immediately (e.g. double Ctrl+C)
+    logger.warn({ signal }, 'server_shutdown_forced')
+    process.exit(1)
+  }
+  isShuttingDown = true
+
+  const activeProcesses = issueEngine.getActiveProcesses()
+  logger.warn(
+    {
+      signal,
+      activeProcessCount: activeProcesses.length,
+      activeIssues: activeProcesses.map(p => p.issueId),
+      uptimeSeconds: Math.round(process.uptime()),
+    },
+    'server_shutdown',
+  )
+
+  // Stop SSE subscriptions and periodic jobs before cancelling processes
+  stopChangesSummaryWatcher()
+  stopSettledReconciliation()
+  stopPeriodicReconciliation()
+  stopCron()
+  stopPeriodicCheck()
+  stopDeliveryCleanup()
+
+  // Cancel all active engine processes before shutting down
+  await issueEngine.cancelAll()
+
+  http.stop()
+  releasePidLock()
+  logger.info('server_stopped')
+  process.exit(0)
+}
+
+process.on('SIGINT', () => {
+  void shutdown('SIGINT')
+})
+process.on('SIGTERM', () => {
+  void shutdown('SIGTERM')
+})

--- a/apps/api/test/db-repair.test.ts
+++ b/apps/api/test/db-repair.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the idempotent database repair (`bkd fix-db`).
+ *
+ * Uses a self-contained migrations fixture so the test does not depend on the
+ * real schema/migration history.
+ */
+import { Database } from 'bun:sqlite'
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { repairDatabase } from '@/db/repair'
+
+const workDirs: string[] = []
+
+function makeFixture() {
+  const root = mkdtempSync(resolve(tmpdir(), 'bkd-repair-'))
+  workDirs.push(root)
+  const migrationsDir = resolve(root, 'migrations')
+  mkdirSync(resolve(migrationsDir, 'meta'), { recursive: true })
+
+  writeFileSync(
+    resolve(migrationsDir, '0001_init.sql'),
+    'CREATE TABLE t (id text PRIMARY KEY);',
+  )
+  writeFileSync(
+    resolve(migrationsDir, '0002_add_col.sql'),
+    'ALTER TABLE t ADD COLUMN c text;',
+  )
+  writeFileSync(
+    resolve(migrationsDir, 'meta/_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'sqlite',
+      entries: [
+        { idx: 1, version: '6', when: 1000, tag: '0001_init', breakpoints: true },
+        { idx: 2, version: '6', when: 2000, tag: '0002_add_col', breakpoints: true },
+      ],
+    }),
+  )
+
+  const dbPath = resolve(root, 'test.db')
+  return { dbPath, migrationsDir }
+}
+
+function columns(dbPath: string, table: string): string[] {
+  const db = new Database(dbPath)
+  try {
+    return (db.query(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>)
+      .map(r => r.name)
+  } finally {
+    db.close()
+  }
+}
+
+function migrationCount(dbPath: string): number {
+  const db = new Database(dbPath)
+  try {
+    const row = db.query('SELECT count(*) as n FROM __drizzle_migrations').get() as { n: number }
+    return row.n
+  } finally {
+    db.close()
+  }
+}
+
+let fixture: { dbPath: string, migrationsDir: string }
+
+beforeEach(() => {
+  fixture = makeFixture()
+})
+
+afterAll(() => {
+  for (const dir of workDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+})
+
+describe('repairDatabase', () => {
+  test('returns no-op when the database file does not exist', () => {
+    const result = repairDatabase({
+      dbPath: resolve(fixture.migrationsDir, 'does-not-exist.db'),
+      migrationsDir: fixture.migrationsDir,
+    })
+    expect(result).toEqual({ applied: 0, skipped: 0 })
+  })
+
+  test('applies all pending migrations on an empty database', () => {
+    // Create an empty DB file.
+    new Database(fixture.dbPath).close()
+
+    const result = repairDatabase(fixture)
+    expect(result).toEqual({ applied: 2, skipped: 0 })
+    expect(columns(fixture.dbPath, 't').sort()).toEqual(['c', 'id'])
+    expect(migrationCount(fixture.dbPath)).toBe(2)
+  })
+
+  test('is idempotent — a second run skips everything', () => {
+    new Database(fixture.dbPath).close()
+    repairDatabase(fixture)
+
+    const second = repairDatabase(fixture)
+    expect(second).toEqual({ applied: 0, skipped: 2 })
+    expect(migrationCount(fixture.dbPath)).toBe(2)
+  })
+
+  test('tolerates pre-existing schema with no migration records', () => {
+    // Simulate a DB whose objects exist but __drizzle_migrations is
+    // inconsistent (the real-world cause of the unapplied-0020 bug):
+    // table `t` already exists, the late column does NOT, and nothing is
+    // recorded as applied.
+    const db = new Database(fixture.dbPath)
+    db.run('CREATE TABLE t (id text PRIMARY KEY)')
+    db.close()
+
+    const result = repairDatabase(fixture)
+    // 0001's CREATE TABLE is tolerated (already exists) but still recorded;
+    // 0002 adds the missing column.
+    expect(result).toEqual({ applied: 2, skipped: 0 })
+    expect(columns(fixture.dbPath, 't').sort()).toEqual(['c', 'id'])
+    expect(migrationCount(fixture.dbPath)).toBe(2)
+
+    // And a follow-up run is a clean no-op.
+    expect(repairDatabase(fixture)).toEqual({ applied: 0, skipped: 2 })
+  })
+
+  test('aborts loudly on a genuinely broken migration', () => {
+    new Database(fixture.dbPath).close()
+    writeFileSync(
+      resolve(fixture.migrationsDir, '0002_add_col.sql'),
+      'THIS IS NOT VALID SQL;',
+    )
+    expect(() => repairDatabase(fixture)).toThrow(/Repair failed at 0002_add_col/)
+    // 0001 still committed before the failure.
+    expect(migrationCount(fixture.dbPath)).toBe(1)
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,10 @@ BKD is a Kanban application for managing autonomous AI coding agents. Issues on 
 
 SQLite via `bun:sqlite` + Drizzle ORM. WAL mode, foreign keys, 64 MB cache, 256 MB mmap, `busy_timeout=15000`. Migrations auto-apply on startup.
 
+**Migration source resolution** (`db/migrations-source.ts`, side-effect free, shared by startup and repair): package mode → `APP_DIR/migrations`; dev → `apps/api/drizzle`; compiled binary → embedded map materialized to a temp dir.
+
+**Database repair (`bkd fix-db` / `bkd --fix-db`):** the main entry (`index.ts`) checks argv first and, on the fix-db path, dynamically imports `db/repair.ts` only — the server bootstrap (`server-main.ts`) and its migrate+`verifySchema()` side-effect never load, so repair works even when normal startup would `process.exit(1)`. `db/repair.ts` re-applies pending migrations idempotently (hash-tracked via `__drizzle_migrations`), tolerant per-statement of "already exists" / "duplicate column name", recovering DBs whose migration history is hash-inconsistent (the cause of unapplied late migrations such as the `default_engine`/`default_model` columns). Stop the server before running it.
+
 **ID conventions:** `shortId()` (8-char nanoid) for projects/issues; `id()` (ULID) for logs/attachments/tool calls.
 
 **Tables:**

--- a/docs/plan/PLAN-011.md
+++ b/docs/plan/PLAN-011.md
@@ -1,0 +1,138 @@
+# PLAN-011 `fix-db` CLI command on the main bkd entry
+
+- **status**: completed
+- **createdAt**: 2026-05-16
+
+## Context (Investigation)
+
+Entrypoints:
+
+- Full compiled binary + dev + package `server.js`: `apps/api/src/index.ts`.
+  No CLI parsing. `import app from './app'` transitively imports
+  `apps/api/src/db/index.ts`, whose top-level code runs `runMigrations()` +
+  `verifySchema()` (the latter `process.exit(1)` on schema mismatch).
+- Launcher binary: `scripts/launcher.ts`, has `--fix-db` →
+  `repairDatabase(dbPath, migrationsDir)` then dynamically imports server.js.
+
+Migration source resolution (mirrors `db/index.ts:32-71`):
+
+- dev: `apps/api/drizzle`
+- package mode: `APP_DIR/migrations`
+- full compiled binary: `embeddedMigrations` map → written to a tmp dir
+
+Root-cause relevance: `db/index.ts:39-54 runMigrations` catches
+"table/index already exists" and **silences without applying the rest of the
+chain**; launcher `repairDatabase` ROLLBACKs on any error. Neither recovers a
+DB whose `__drizzle_migrations` is hash-inconsistent with the (re-aligned)
+migration history, leaving 0020 unapplied.
+
+## Proposal
+
+1. New module `apps/api/src/db/repair.ts` exporting
+   `repairDatabase(opts: { dbPath: string, migrationsDir: string }): { applied: number }`.
+   - Pure `bun:sqlite` + `node:crypto` (no drizzle-orm), so the launcher can
+     also reuse it later if desired.
+   - Iterate `meta/_journal.json` entries in order. For each not present in
+     `__drizzle_migrations` (match by sql hash, not timestamp), split on
+     `--> statement-breakpoint` and run each statement; if a statement throws
+     and the message matches `/(table|index) .+ already exists/i` (or
+     `duplicate column name`), skip that statement and continue; any other
+     error aborts with a clear message.
+   - After a migration's statements succeed/skip, insert its hash into
+     `__drizzle_migrations` so subsequent normal startup is consistent.
+   - `PRAGMA foreign_keys = OFF` during repair, restored after.
+2. `apps/api/src/index.ts`: at the very top, before any
+   `import ... from './app'`, parse argv for the `fix-db` subcommand
+   (`bkd fix-db`) and `--fix-db` flag. If present:
+   - resolve dbPath + migrations source the same way `db/index.ts` does
+     (factor a small `resolveMigrationsDir()` helper, reused by both),
+   - call `repairDatabase(...)`, log result, `process.exit(0/1)`.
+   - This branch must not import `./app` or `./db` (avoid the migrate+verify
+     side-effect) — only import `db/repair.ts` + a path resolver.
+3. Refactor `apps/api/src/db/index.ts` minimally: extract migrations-dir /
+   embedded-tmp resolution into an exported helper so both the normal startup
+   path and the `fix-db` branch use one implementation (no duplicated logic).
+4. Docs: add a short "Repairing the database" note (README or
+   `docs/architecture.md` DB section) and `bkd fix-db` usage.
+
+Out of scope: changing `db/index.ts runMigrations` silencing behavior or
+`verifySchema` (separate concern; `fix-db` is the operator escape hatch). The
+launcher's existing `--fix-db` is left as-is in this task (can be pointed at
+the shared module in a follow-up).
+
+## Risks
+
+- `index.ts` top-of-file ordering: must intercept argv before the `./app`
+  import chain executes the db side-effect. Mitigated by putting the branch
+  first and dynamic-importing only `db/repair.ts`.
+- Embedded-binary mode: migrations only exist as `embeddedMigrations`; the
+  resolver must write them to tmp (reuse `db/index.ts` logic) — covered by
+  step 3.
+- Statement-level "already exists" tolerance could mask a genuinely broken
+  migration. Mitigated: only swallow the specific
+  already-exists/duplicate-column messages; everything else aborts loudly.
+
+## Scope
+
+- New: `apps/api/src/db/repair.ts`
+- Edit: `apps/api/src/index.ts` (early argv branch), `apps/api/src/db/index.ts`
+  (extract migrations-dir resolver, export it)
+- Docs: `docs/architecture.md` (or README) DB repair note
+- Test: `apps/api/test/` — repair applies a pending migration on a DB missing
+  it; repair tolerates a pre-existing table; idempotent re-run is a no-op.
+
+## Alternatives
+
+- A) Mirror launcher's `repairDatabase` into index.ts as a flag only
+  (ROLLBACK-on-error). Smaller, but does NOT fix the real "already exists"
+  case — the command would fail on exactly the DBs that need it. Rejected.
+- B) Make `db/index.ts runMigrations` itself "already exists"-tolerant so no
+  manual command is needed. Larger blast radius (every startup), riskier;
+  user explicitly asked for an explicit CLI command. Deferred.
+- C) (chosen) Shared idempotent `repair.ts` + explicit `fix-db` command on the
+  main entry.
+
+## Verification
+
+- `bun run test:api` (new repair tests green)
+- Manual: create DB, drop a late migration's column, run
+  `bun apps/api/src/index.ts fix-db` → column restored, server starts clean
+- `bun run lint` + `tsc --noEmit` for api
+
+## Implementation Notes (2026-05-16)
+
+Deviation from proposal step 2: the "static side-effect import first" mitigation
+does NOT hold in Bun — with a top-level `await import()` in a first-imported
+module, Bun still evaluates sibling static imports (`./app` → `./db`), so
+`verifySchema()` / engine probe / pid-lock ran during `fix-db` (observed
+`schema_verification_passed`, `probe_started`, plus a pino exit crash).
+
+Final design: `index.ts` is now a thin dispatcher with **no static app/db
+imports**. The server bootstrap moved verbatim to `apps/api/src/server-main.ts`.
+`index.ts` checks argv and either `await import('./db/repair')` (fix-db path) or
+`await import('./server-main')` (normal path). Dynamic import guarantees the
+server side-effect never loads on the fix-db path.
+
+Delivered files:
+- New: `apps/api/src/db/migrations-source.ts`, `apps/api/src/db/repair.ts`,
+  `apps/api/src/server-main.ts`, `apps/api/test/db-repair.test.ts`
+- Rewritten: `apps/api/src/index.ts` (dispatcher)
+- Refactored: `apps/api/src/db/index.ts` (uses shared resolver, duplication removed)
+- Docs: `docs/architecture.md` Database section
+
+Verification (all green):
+- `apps/api` lint + `tsc --noEmit` clean
+- Full api suite: 498 pass, 1 skip, 0 fail (34 files)
+- E2E: `bun src/index.ts fix-db` on empty DB → applied 21 real migrations,
+  exit 0, NO server side-effects (server-main not loaded); `--fix-db` variant
+  identical; normal `bun src/index.ts` boots fully (no regression)
+
+Out of scope (unchanged): `db/index.ts runMigrations` silencing, `verifySchema`,
+launcher's own `--fix-db`.
+
+## Follow-up CLI-002 (2026-05-16)
+
+Launcher `--fix-db` now reuses the shared implementation: deleted
+`scripts/launcher.ts` `repairDatabase()` (~80 lines) and the step-5 block;
+`--fix-db` is delegated to the bundled server.js dispatcher (same process,
+same `process.argv`). One repair implementation across all modes.

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -39,3 +39,4 @@ Each plan is a single line linking to its detail file. All detailed information 
 - [x] [**PLAN-008 Preserve Codex tool actions for grouping**](PLAN-008.md) `2026-05-11`
 - [x] [**PLAN-009 Allow unresolved webhook hostnames on save**](PLAN-009.md) `2026-05-11`
 - [x] [**PLAN-010 Per-project default engine and model**](PLAN-010.md) `2026-05-15`
+- [x] [**PLAN-011 fix-db CLI command on the main bkd entry**](PLAN-011.md) `2026-05-16`

--- a/docs/task/CLI-001.md
+++ b/docs/task/CLI-001.md
@@ -1,0 +1,51 @@
+# CLI-001 Add a `fix-db` CLI command to the main bkd entry
+
+- **status**: completed
+- **priority**: P1
+- **owner**: roy
+- **createdAt**: 2026-05-16 00:00
+
+## Description
+
+Provide a CLI command, invokable via the main `bkd` executable, that repairs
+the database (re-applies pending Drizzle migrations idempotently) without
+starting the server.
+
+Context from prior investigation:
+
+- `--fix-db` already exists but **only in the launcher** (`scripts/launcher.ts`,
+  package/launcher mode). Its `repairDatabase()` ROLLBACKs on any error, so it
+  does NOT recover from the "table already exists" / `__drizzle_migrations`
+  hash-mismatch case (the realistic cause of unapplied migration 0020 →
+  `no such column: default_engine` → 500 on project save).
+- The full compiled binary and dev/`bun run start` use `apps/api/src/index.ts`
+  as entry. It has **no CLI** and imports `./app` → `db/index.ts`, which runs
+  migrations + `verifySchema()` (can `process.exit(1)`) at import time. There
+  is no way to repair the DB in these modes; `bun run db:migrate` (drizzle-kit)
+  only works in dev with node_modules.
+
+Acceptance criteria:
+
+- `bkd fix-db` (or `bkd --fix-db`) on the main entry repairs the DB and exits,
+  in dev (`bun apps/api/src/index.ts`), full compiled binary, and package
+  `server.js` modes.
+- Repair is idempotent and tolerates already-applied statements
+  ("table/index already exists") per-statement, then records the migration in
+  `__drizzle_migrations` so subsequent normal startup is consistent.
+- The repair branch runs BEFORE the normal `db/index.ts` migrate+verify
+  side-effect so it works even when `verifySchema()` would otherwise exit.
+- Shared repair logic is not duplicated a third time.
+
+## ActiveForm
+
+Adding a fix-db CLI command to the main bkd entry.
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+See PLAN-011 for design. Related to the project default engine/model 500
+investigation (migration 0020 not applied).

--- a/docs/task/CLI-002.md
+++ b/docs/task/CLI-002.md
@@ -1,0 +1,42 @@
+# CLI-002 Make launcher --fix-db reuse the shared repair implementation
+
+- **status**: completed
+- **priority**: P2
+- **owner**: roy
+- **createdAt**: 2026-05-16 00:00
+
+## Description
+
+Follow-up to CLI-001. The launcher (`scripts/launcher.ts`) had its own
+`repairDatabase()` (~80 lines, ROLLBACK-on-error, timestamp-based) duplicating
+migration logic and NOT recovering hash-inconsistent DBs.
+
+Delegate the launcher's `--fix-db` to the bundled server entry (`server.js` =
+compiled `apps/api/src/index.ts` dispatcher), which owns the single shared
+`apps/api/src/db/repair.ts`. The dispatcher detects `--fix-db`/`fix-db` from
+`process.argv`, and the launcher already runs server.js via
+`await import(serverPath)` in the same process, so passing through is enough.
+
+Acceptance criteria:
+
+- Launcher's duplicated `repairDatabase()` removed.
+- `bkd --fix-db` via the launcher runs the shared idempotent repair and exits
+  without starting the server.
+- Single repair implementation across full binary, dev, and launcher modes.
+
+## ActiveForm
+
+Making launcher --fix-db reuse the shared repair implementation.
+
+## Dependencies
+
+- **blocked by**: CLI-001
+- **blocks**: (none)
+
+## Notes
+
+`scripts/launcher.ts`: deleted `repairDatabase()` + section comment; step 5
+now just `await import(serverPath)` (skips the "Starting version" log on the
+fix-db path); cleye `fixDb` flag retained for `--help`. Verified: eslint clean,
+`bun build scripts/launcher.ts` succeeds. The dispatcher path itself was e2e
+verified under CLI-001 (`--fix-db` applies migrations, exits, no server boot).

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -48,3 +48,6 @@ Each task is a single line linking to its detail file. All detailed information 
 - [x] [**ENG-007 Remove claude-code-sdk engine**](ENG-007.md) `P2`
 - [x] [**ENG-008 Add per-project default engine and model**](ENG-008.md) `P2`
 - [x] [**ENG-009 Guard drizzle migration/snapshot consistency**](ENG-009.md) `P3`
+- [x] [**UI-001 Enable session pin in the issue list panel**](UI-001.md) `P2`
+- [x] [**CLI-001 Add a `fix-db` CLI command to the main bkd entry**](CLI-001.md) `P1`
+- [x] [**CLI-002 Make launcher --fix-db reuse the shared repair implementation**](CLI-002.md) `P2`

--- a/scripts/launcher.ts
+++ b/scripts/launcher.ts
@@ -390,90 +390,6 @@ async function downloadAndExtract(
   }
 }
 
-// --- DB repair (--fix-db) ---
-// Reimplements Drizzle's migration logic using only bun:sqlite + node:crypto
-// so it works in standalone compiled binaries without drizzle-orm.
-
-function repairDatabase(dbPath: string, migrationsDir: string) {
-  console.log('[launcher] Running database repair (re-applying migrations)...')
-
-  if (!existsSync(dbPath)) {
-    console.log('[launcher] No database file found, nothing to repair.')
-    return
-  }
-
-  const journalFile = resolve(migrationsDir, 'meta/_journal.json')
-  if (!existsSync(journalFile)) {
-    console.error(`[launcher] Migrations not found at: ${migrationsDir}`)
-    process.exit(1)
-  }
-
-  const { Database } = require('bun:sqlite') as typeof import('bun:sqlite')
-  const crypto = require('node:crypto') as typeof import('node:crypto')
-
-  const journal = JSON.parse(readFileSync(journalFile, 'utf8')) as {
-    entries: Array<{ tag: string, when: number }>
-  }
-
-  const sqlite = new Database(dbPath)
-  sqlite.run('PRAGMA journal_mode = WAL')
-
-  // Create migrations table if needed (matches Drizzle's schema)
-  sqlite.run(`
-    CREATE TABLE IF NOT EXISTS __drizzle_migrations (
-      id SERIAL PRIMARY KEY,
-      hash text NOT NULL,
-      created_at numeric
-    )
-  `)
-
-  // Get last applied migration timestamp
-  const lastRow = sqlite.query(
-    'SELECT created_at FROM __drizzle_migrations ORDER BY created_at DESC LIMIT 1',
-  ).get() as { created_at: number } | null
-  const lastTimestamp = lastRow?.created_at ?? 0
-
-  sqlite.run('PRAGMA foreign_keys = OFF')
-  sqlite.run('BEGIN')
-
-  let applied = 0
-  try {
-    for (const entry of journal.entries) {
-      if (entry.when <= lastTimestamp) continue
-
-      const sqlFile = resolve(migrationsDir, `${entry.tag}.sql`)
-      if (!existsSync(sqlFile)) {
-        throw new Error(`Migration file not found: ${sqlFile}`)
-      }
-
-      const sql = readFileSync(sqlFile, 'utf8')
-      const hash = crypto.createHash('sha256').update(sql).digest('hex')
-
-      // Split on Drizzle's statement breakpoint marker
-      const statements = sql.split('--> statement-breakpoint').map(s => s.trim()).filter(Boolean)
-      for (const stmt of statements) {
-        sqlite.run(stmt)
-      }
-
-      sqlite.run(
-        'INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)',
-        [hash, entry.when],
-      )
-      applied++
-      console.log(`[repair] Applied: ${entry.tag}`)
-    }
-    sqlite.run('COMMIT')
-  } catch (err) {
-    sqlite.run('ROLLBACK')
-    sqlite.run('PRAGMA foreign_keys = ON')
-    console.error('[launcher] Database repair failed:', err instanceof Error ? err.message : err)
-    process.exit(1)
-  }
-
-  sqlite.run('PRAGMA foreign_keys = ON')
-  console.log(`[launcher] Database repair complete. ${applied} migration(s) applied.`)
-}
-
 // --- CLI parsing ---
 
 const versionStr = getVersionString()
@@ -646,15 +562,13 @@ async function main() {
     process.exit(1)
   }
 
-  // 5. Run DB repair if requested
-  if (flags.fixDb) {
-    const migrationsDir = resolve(appDir, 'migrations')
-    await repairDatabase(process.env.DB_PATH!, migrationsDir)
+  // 5. Start server — or, with `--fix-db`, repair the database and exit.
+  //    Both paths are handled by the bundled server entry (server.js), which
+  //    owns the single shared repair implementation (db/repair.ts) and
+  //    detects `--fix-db` from process.argv.
+  if (!flags.fixDb) {
+    console.log(`[launcher] Starting version ${version}`)
   }
-
-  console.log(`[launcher] Starting version ${version}`)
-
-  // 6. Start server
   await import(serverPath)
 }
 


### PR DESCRIPTION
## Summary

Add `bkd fix-db` / `bkd --fix-db` to repair a database whose migration history is hash-inconsistent (the cause of unapplied late migrations such as `projects.default_engine` / `default_model`, surfacing as `no such column: default_engine` after upgrade).

- `index.ts` is now a thin dispatcher with **no static app/db imports**. The server bootstrap moved to `server-main.ts` and is loaded via dynamic import, so the fix-db path never triggers the startup migrate + `verifySchema()` side-effect and works even when `verifySchema()` would `process.exit(1)`.
- `db/repair.ts`: idempotent re-apply of pending migrations, hash-tracked via `__drizzle_migrations`, tolerant per-statement of `already exists` / `duplicate column name`.
- `db/migrations-source.ts`: centralized db-path / migrations-dir resolution, shared by startup and repair (removes duplication in `db/index.ts`).
- Launcher delegates `--fix-db` to the bundled server entry instead of its own duplicated repair — one repair implementation across full-binary, dev, and launcher modes.

Out of scope: `runMigrations` silencing behavior and `verifySchema` are unchanged; `fix-db` is the operator escape hatch.

## Test plan

- [x] `bun run lint` (changed files clean) + `tsc --noEmit` (api)
- [x] Full api suite: 498 pass, 1 skip, 0 fail
- [x] New `db-repair.test.ts`: applies pending migration, tolerates pre-existing schema, idempotent re-run, aborts loudly on broken migration
- [x] E2E: `bun src/index.ts fix-db` applies 21 real migrations and exits with no server side-effects; `--fix-db` identical; normal boot unaffected