### PR TITLE
feat(issues): file attachments on create + click-to-preview in chat

### DIFF
--- a/apps/api/src/openapi/routes.ts
+++ b/apps/api/src/openapi/routes.ts
@@ -231,11 +231,15 @@ export const listIssues = createRoute({
   },
 })
 
+// Note: createIssue accepts both JSON and multipart/form-data (file uploads).
+// It uses a plain .post() handler with manual content-type parsing — same
+// pattern as followUpIssue. This definition exists for documentation; the
+// handler validates manually.
 export const createIssue = createRoute({
   method: 'post',
   path: '/',
   tags: ['Issues'],
-  summary: 'Create issue',
+  summary: 'Create issue (JSON or multipart/form-data with file attachments)',
   operationId: 'createIssue',
   request: {
     params: projectParam,

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -247,7 +247,8 @@ export const IssueChangedFileSchema = z.object({
 }).openapi('IssueChangedFile')
 
 export const IssueChangesResponseSchema = z.object({
-  root: z.string(),
+  // Absent when the project has no directory configured.
+  root: z.string().optional(),
   gitRepo: z.boolean(),
   files: z.array(IssueChangedFileSchema),
   additions: z.number().int(),

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -1,16 +1,17 @@
 import { mkdir, stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import * as z from 'zod'
 import { cacheDel, cacheGetOrSet } from '@/cache'
 import { STATUS_IDS } from '@/config'
 import { db } from '@/db'
 import { getAppSetting } from '@/db/helpers'
 import {
+  buildFileContextFromRows,
   relocatePendingForProcessing,
   restorePendingVisibility,
 } from '@/db/pending-messages'
-import { issues as issuesTable } from '@/db/schema'
+import { attachments as attachmentsTable, issues as issuesTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
 import type { EngineType } from '@/engines/types'
 import { emitIssueLogRemoved, emitIssueUpdated } from '@/events/issue-events'
@@ -291,27 +292,86 @@ export function triggerIssueExecution(
 
       // Relocate any pending messages: hide old pending row, include content in prompt
       relocated = await relocatePendingForProcessing(issueId)
+
+      // Attachments uploaded at create-time (or before the first execute) carry
+      // logId = null. Fold them into the engine prompt and message metadata so
+      // they appear as chips on the first user-message and are reachable by the
+      // engine via the standard file context.
+      const unlinkedAttachments = await db
+        .select()
+        .from(attachmentsTable)
+        .where(
+          and(
+            eq(attachmentsTable.issueId, issueId),
+            isNull(attachmentsTable.logId),
+            eq(attachmentsTable.isDeleted, 0),
+          ),
+        )
+      const attachmentFileContext = buildFileContextFromRows(unlinkedAttachments)
+      const attachmentsMetaList = unlinkedAttachments.map(a => ({
+        id: a.id,
+        name: a.originalName,
+        mimeType: a.mimeType,
+        size: a.size,
+      }))
+
       const basePrompt = systemPrompt ?
         `${systemPrompt}\n\n${issue.prompt ?? ''}` :
           (issue.prompt ?? '')
+      const baseWithFiles = basePrompt + attachmentFileContext
       const effectivePrompt = relocated ?
-          [basePrompt, relocated.prompt].filter(Boolean).join('\n\n') :
-        basePrompt
+          [baseWithFiles, relocated.prompt].filter(Boolean).join('\n\n') :
+        baseWithFiles
 
-      await issueEngine.executeIssue(issueId, {
+      // Merge metadata: relocated metadata wins for scalar keys, attachments
+      // arrays from both sources are concatenated.
+      const mergedAttachments = [
+        ...attachmentsMetaList,
+        ...((relocated?.metadata.attachments as unknown[] | undefined) ?? []),
+      ]
+      const baseMeta: Record<string, unknown> = { ...(relocated?.metadata ?? {}) }
+      if (mergedAttachments.length > 0) baseMeta.attachments = mergedAttachments
+      const hasMeta = Object.keys(baseMeta).length > 0
+
+      // displayPrompt rules:
+      // - relocated already supplies one when pending messages exist
+      // - otherwise, if we appended file context, surface only issue.prompt to
+      //   the chat (avoid leaking the "[Attached file: …]" lines)
+      const effectiveDisplayPrompt = relocated ?
+        relocated.displayPrompt :
+        unlinkedAttachments.length > 0 ?
+            (issue.prompt ?? '') :
+          undefined
+
+      const execResult = await issueEngine.executeIssue(issueId, {
         engineType: (issue.engineType ?? 'claude-code') as EngineType,
         prompt: effectivePrompt,
         workingDir: effectiveWorkingDir,
         model: issue.model ?? undefined,
         permissionMode: issue.permissionMode as 'plan' | 'auto' | undefined,
         envVars: envVars ?? undefined,
-        ...(relocated ? { displayPrompt: relocated.displayPrompt, metadata: relocated.metadata } : {}),
+        ...(effectiveDisplayPrompt !== undefined ? { displayPrompt: effectiveDisplayPrompt } : {}),
+        ...(hasMeta ? { metadata: baseMeta } : {}),
       })
+      // Link the create-time attachments to the freshly persisted user-message
+      if (unlinkedAttachments.length > 0 && execResult.messageId) {
+        await db
+          .update(attachmentsTable)
+          .set({ logId: execResult.messageId })
+          .where(inArray(attachmentsTable.id, unlinkedAttachments.map(a => a.id)))
+      }
       // Notify frontend to remove old pending entry after successful execution
       if (relocated) {
         emitIssueLogRemoved(issueId, relocated.oldIds)
       }
-      logger.debug({ issueId, hadPending: !!relocated }, 'auto_execute_started')
+      logger.debug(
+        {
+          issueId,
+          hadPending: !!relocated,
+          createTimeAttachments: unlinkedAttachments.length,
+        },
+        'auto_execute_started',
+      )
     } catch (err) {
       logger.error({ issueId, err }, 'auto_execute_failed')
       if (relocated) restorePendingVisibility(relocated.oldIds)

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -152,7 +152,13 @@ changes.openapi(R.getIssueChanges, async (c) => {
 
   const projectRoot = await resolveProjectDir(project.id)
   if (!projectRoot) {
-    return c.json({ success: false, error: 'Project directory is not configured' }, 400 as const)
+    // Project has no working directory configured (or it no longer exists).
+    // Treat as "no changes to report" rather than an error so callers (chat
+    // input file-count badge, etc.) can render cleanly without a 400.
+    return c.json({
+      success: true,
+      data: { gitRepo: false, files: [], additions: 0, deletions: 0 },
+    }, 200 as const)
   }
   const root = await resolveIssueDir(project.id, issueId, issue.useWorktree, projectRoot)
   const gitRepo = await isGitRepo(root)
@@ -210,7 +216,12 @@ changes.get('/:id/changes/file', async (c) => {
 
   const projectRoot = await resolveProjectDir(project.id)
   if (!projectRoot) {
-    return c.json({ success: false, error: 'Project directory is not configured' }, 400)
+    // No working dir → nothing to diff. Return empty patch payload instead
+    // of 400 so the diff panel renders cleanly.
+    return c.json({
+      success: true,
+      data: { path, patch: '', truncated: false },
+    })
   }
   const root = await resolveIssueDir(project.id, issueId, issue.useWorktree, projectRoot)
 

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -1,14 +1,17 @@
 import { and, desc, eq, max } from 'drizzle-orm'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
+import * as z from 'zod'
 import { cacheDel } from '@/cache'
+import { STATUS_IDS } from '@/config'
 import { db } from '@/db'
 import { findProject, getDefaultEngine, getEngineDefaultModel, getServerUrl } from '@/db/helpers'
-import { issues as issuesTable } from '@/db/schema'
+import { attachments as attachmentsTable, issues as issuesTable } from '@/db/schema'
 import { engineRegistry } from '@/engines/executors'
 import type { EngineType } from '@/engines/types'
 import { logger } from '@/logger'
 import { createOpenAPIRouter } from '@/openapi/hono'
-import * as R from '@/openapi/routes'
+import type { SavedFile } from '@/uploads'
+import { saveUploadedFile, validateFiles } from '@/uploads'
 import { buildIssueUrl, dispatch as webhookDispatch } from '@/webhooks/dispatcher'
 import {
   parseProjectEnvVars,
@@ -19,15 +22,94 @@ import {
 
 const create = createOpenAPIRouter()
 
+// ── Body parsing ─────────────────────────────────────
+
+const createBodySchema = z.object({
+  title: z.string().min(1).max(500),
+  tags: z.array(z.string().max(50)).max(10).optional(),
+  statusId: z.enum(STATUS_IDS),
+  useWorktree: z.boolean().optional(),
+  keepAlive: z.boolean().optional(),
+  engineType: z.enum(['claude-code', 'codex']).optional(),
+  model: z.string().regex(/^[\w./:\-[\]]{1,160}$/).optional(),
+  permissionMode: z.enum(['auto', 'supervised', 'plan']).optional(),
+})
+
+type CreateBody = z.infer<typeof createBodySchema>
+
+async function parseCreateBody(c: {
+  req: {
+    header: (name: string) => string | undefined
+    json: () => Promise<unknown>
+    formData: () => Promise<FormData>
+  }
+}): Promise<
+  | { ok: true, body: CreateBody, files: File[] }
+  | { ok: false, error: string }
+> {
+  const contentType = c.req.header('content-type') ?? ''
+  if (contentType.includes('multipart/form-data')) {
+    const fd = await c.req.formData()
+    const raw: Record<string, unknown> = {}
+    for (const [key, value] of fd.entries()) {
+      if (key === 'files' || value instanceof File) continue
+      if (typeof value !== 'string') continue
+      if (key === 'tags') {
+        try {
+          raw.tags = JSON.parse(value)
+        } catch {
+          raw.tags = value.split(',').map(s => s.trim()).filter(Boolean)
+        }
+      } else if (key === 'useWorktree' || key === 'keepAlive') {
+        raw[key] = value === 'true' || value === '1'
+      } else {
+        raw[key] = value
+      }
+    }
+    const parsed = createBodySchema.safeParse(raw)
+    if (!parsed.success) {
+      return { ok: false, error: parsed.error.issues.map(i => i.message).join(', ') }
+    }
+    const files: File[] = []
+    for (const entry of fd.getAll('files')) {
+      if (entry instanceof File) files.push(entry)
+    }
+    return { ok: true, body: parsed.data, files }
+  }
+
+  // JSON path
+  const raw = await c.req.json()
+  const parsed = createBodySchema.safeParse(raw)
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues.map(i => i.message).join(', ') }
+  }
+  return { ok: true, body: parsed.data, files: [] }
+}
+
+// ── Handler ──────────────────────────────────────────
+
 // POST /api/projects/:projectId/issues — Create issue
-create.openapi(R.createIssue, async (c) => {
+// Accepts JSON or multipart/form-data. With multipart, `files` parts are saved
+// as attachments and folded into the engine prompt on first execute.
+create.post('/', async (c) => {
   const projectId = c.req.param('projectId')!
   const project = await findProject(projectId)
   if (!project) {
     return c.json({ success: false, error: 'Project not found' }, 404 as const)
   }
 
-  const body = c.req.valid('json')
+  const parsed = await parseCreateBody(c)
+  if (!parsed.ok) {
+    return c.json({ success: false, error: parsed.error }, 400 as const)
+  }
+  const { body, files } = parsed
+
+  if (files.length > 0) {
+    const validation = validateFiles(files)
+    if (!validation.ok) {
+      return c.json({ success: false, error: validation.error }, 400 as const)
+    }
+  }
 
   // Resolve engine/model defaults when not explicitly provided
   let resolvedEngine = body.engineType ?? null
@@ -114,6 +196,25 @@ create.openapi(R.createIssue, async (c) => {
         .returning()
     })
 
+    // Persist uploaded files and attach them to the new issue. logId stays null;
+    // triggerIssueExecution links each row to the user-message it generates.
+    let savedFiles: SavedFile[] = []
+    if (files.length > 0) {
+      savedFiles = await Promise.all(files.map(saveUploadedFile))
+      await db.insert(attachmentsTable).values(
+        savedFiles.map(f => ({
+          id: f.id,
+          issueId: newIssue!.id,
+          logId: null,
+          originalName: f.originalName,
+          storedName: f.storedName,
+          mimeType: f.mimeType,
+          size: f.size,
+          storagePath: f.storagePath,
+        })),
+      )
+    }
+
     // After successful creation, invalidate relevant caches
     await cacheDel(`projectIssueIds:${project.id}`)
 
@@ -151,7 +252,10 @@ create.openapi(R.createIssue, async (c) => {
       )
     }
 
-    return c.json({ success: true, data: serializeIssue(newIssue!) }, (shouldExecute ? 202 : 201) as 201 | 202)
+    return c.json(
+      { success: true, data: serializeIssue(newIssue!) },
+      (shouldExecute ? 202 : 201) as 201 | 202,
+    )
   } catch (error) {
     logger.warn(
       {

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -52,7 +52,7 @@ async function parseCreateBody(c: {
     const fd = await c.req.formData()
     const raw: Record<string, unknown> = {}
     for (const [key, value] of fd.entries()) {
-      if (key === 'files' || value instanceof File) continue
+      // Skip File entries (key === 'files'); only string scalars feed the body
       if (typeof value !== 'string') continue
       if (key === 'tags') {
         try {

--- a/apps/api/test/api-issues.test.ts
+++ b/apps/api/test/api-issues.test.ts
@@ -133,6 +133,92 @@ describe('POST /api/projects/:projectId/issues', () => {
     })
     expect(result.status).toBe(404)
   })
+
+  test('accepts multipart/form-data with files', async () => {
+    const { default: app } = await import('@/app')
+    const { db } = await import('@/db')
+    const { attachments } = await import('@/db/schema')
+    const { eq } = await import('drizzle-orm')
+
+    const fd = new FormData()
+    fd.append('title', 'Multipart Issue')
+    fd.append('statusId', 'todo')
+    fd.append('tags', JSON.stringify(['a', 'b']))
+    fd.append('useWorktree', 'false')
+    fd.append('files', new File(['hello world'], 'note.txt', { type: 'text/plain' }))
+    fd.append('files', new File(['data'], 'data.bin', { type: 'application/octet-stream' }))
+
+    const res = await app.request(`http://localhost/api/projects/${projectId}/issues`, {
+      method: 'POST',
+      body: fd,
+    })
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as { success: boolean, data: Issue }
+    expect(json.success).toBe(true)
+    expect(json.data.title).toBe('Multipart Issue')
+    expect(json.data.tags).toEqual(['a', 'b'])
+
+    const rows = await db.select().from(attachments).where(eq(attachments.issueId, json.data.id))
+    expect(rows.length).toBe(2)
+    expect(rows.every(r => r.logId === null)).toBe(true)
+    expect(rows.map(r => r.originalName).sort()).toEqual(['data.bin', 'note.txt'])
+  })
+
+  test('rejects multipart with oversized file', async () => {
+    const { default: app } = await import('@/app')
+    const fd = new FormData()
+    fd.append('title', 'Too Big')
+    fd.append('statusId', 'todo')
+    // 11 MB > 10 MB limit
+    fd.append('files', new File([new Uint8Array(11 * 1024 * 1024)], 'big.bin'))
+
+    const res = await app.request(`http://localhost/api/projects/${projectId}/issues`, {
+      method: 'POST',
+      body: fd,
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /api/projects/:projectId/issues/:issueId/changes', () => {
+  test('returns empty success when project has no directory', async () => {
+    const issue = expectSuccess(
+      await post<Issue>(`/api/projects/${projectId}/issues`, {
+        title: 'Changes No Dir',
+        statusId: 'todo',
+      }),
+    )
+    const result = await get<{
+      gitRepo: boolean
+      root?: string
+      files: unknown[]
+      additions: number
+      deletions: number
+    }>(`/api/projects/${projectId}/issues/${issue.id}/changes`)
+    expect(result.status).toBe(200)
+    const data = expectSuccess(result)
+    expect(data.gitRepo).toBe(false)
+    expect(data.files).toEqual([])
+    expect(data.additions).toBe(0)
+    expect(data.deletions).toBe(0)
+    expect(data.root).toBeUndefined()
+  })
+
+  test('changes/file returns empty patch when project has no directory', async () => {
+    const issue = expectSuccess(
+      await post<Issue>(`/api/projects/${projectId}/issues`, {
+        title: 'Changes File No Dir',
+        statusId: 'todo',
+      }),
+    )
+    const result = await get<{ path: string, patch: string, truncated: boolean }>(
+      `/api/projects/${projectId}/issues/${issue.id}/changes/file?path=README.md`,
+    )
+    expect(result.status).toBe(200)
+    const data = expectSuccess(result)
+    expect(data.patch).toBe('')
+    expect(data.truncated).toBe(false)
+  })
 })
 
 describe('GET /api/projects/:projectId/issues', () => {

--- a/apps/frontend/src/components/AttachmentChips.tsx
+++ b/apps/frontend/src/components/AttachmentChips.tsx
@@ -1,0 +1,52 @@
+import { FileText, Image as ImageIcon, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { formatFileSize } from '@/lib/format'
+
+/**
+ * Shared chip-list renderer for attached files. Clicking a chip triggers
+ * `onPreview(file)`; the × button removes by index.
+ */
+export function AttachmentChips({
+  files,
+  onPreview,
+  onRemove,
+}: {
+  files: File[]
+  onPreview: (file: File) => void
+  onRemove: (index: number) => void
+}) {
+  const { t } = useTranslation()
+  if (files.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-1.5 px-2 pb-1.5">
+      {files.map((file, idx) => (
+        <div
+          key={`${file.name}-${file.size}-${idx}`}
+          className="group/file flex items-center gap-1.5 rounded-lg bg-muted/50 border border-border/40 px-2 py-1 text-xs cursor-pointer hover:bg-muted/70 transition-colors"
+          onClick={() => onPreview(file)}
+        >
+          {file.type.startsWith('image/') ?
+              (
+                <ImageIcon className="h-3 w-3 shrink-0 text-blue-500" />
+              ) :
+              (
+                <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
+              )}
+          <span className="truncate max-w-[140px]">{file.name}</span>
+          <span className="text-muted-foreground/60">{formatFileSize(file.size)}</span>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove(idx)
+            }}
+            className="ml-0.5 rounded p-0.5 text-muted-foreground/60 hover:text-destructive hover:bg-destructive/10 transition-colors"
+            title={t('chat.removeFile')}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/FilePreviewModal.tsx
+++ b/apps/frontend/src/components/FilePreviewModal.tsx
@@ -1,0 +1,85 @@
+import { FileText, Image as ImageIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { formatFileSize } from '@/lib/format'
+
+/**
+ * Either an in-memory File (upload-area chip) or a server-side attachment
+ * already persisted and reachable by URL (chat-message chip).
+ */
+export type PreviewItem =
+  | { kind: 'file', file: File }
+  | { kind: 'remote', name: string, mimeType: string, size: number, url: string }
+
+function describe(item: PreviewItem) {
+  if (item.kind === 'file') {
+    return { name: item.file.name, mimeType: item.file.type, size: item.file.size }
+  }
+  return { name: item.name, mimeType: item.mimeType, size: item.size }
+}
+
+export function FilePreviewModal({ item, onClose }: { item: PreviewItem, onClose: () => void }) {
+  const { t } = useTranslation()
+  const { name, mimeType, size } = describe(item)
+  const isImage = mimeType.startsWith('image/')
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isImage) {
+      setImageUrl(null)
+      return
+    }
+    if (item.kind === 'remote') {
+      setImageUrl(item.url)
+      return
+    }
+    const url = URL.createObjectURL(item.file)
+    setImageUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [item, isImage])
+
+  return (
+    <Dialog open onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-[600px] max-h-[80vh] overflow-hidden p-0">
+        <DialogHeader className="flex flex-row items-center gap-2 px-4 py-3 border-b border-border/30 space-y-0">
+          {isImage ?
+              (
+                <ImageIcon className="h-4 w-4 shrink-0 text-blue-500" />
+              ) :
+              (
+                <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+          <DialogTitle className="text-sm font-medium truncate">{name}</DialogTitle>
+        </DialogHeader>
+
+        <div className="p-4 overflow-auto max-h-[calc(80vh-56px)]">
+          {imageUrl ?
+              (
+                <img
+                  src={imageUrl}
+                  alt={name}
+                  className="max-w-full max-h-[60vh] rounded-lg object-contain mx-auto"
+                />
+              ) :
+              (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-center w-16 h-16 rounded-xl bg-muted/60 mx-auto">
+                    <FileText className="h-8 w-8 text-muted-foreground/60" />
+                  </div>
+                  <div className="text-center space-y-1">
+                    <p className="text-sm font-medium truncate">{name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {mimeType || t('chat.unknownType')}
+                      {' '}
+                      &middot;
+                      {formatFileSize(size)}
+                    </p>
+                  </div>
+                </div>
+              )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -2,6 +2,8 @@ import { ArrowDownToLine, ArrowUpToLine, ChevronDown, ChevronRight, Clock, FileT
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import type { PreviewItem } from '@/components/FilePreviewModal'
+import { FilePreviewModal } from '@/components/FilePreviewModal'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -163,6 +165,7 @@ export function ChatBody({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [isCancelling, setIsCancelling] = useState(false)
   const [pendingEditContent, setPendingEditContent] = useState<string | null>(null)
+  const [previewAttachment, setPreviewAttachment] = useState<PreviewItem | null>(null)
 
   const handleDelete = useCallback(() => {
     setDeleteDialogOpen(true)
@@ -378,18 +381,39 @@ export function ChatBody({
                   {attachments.length > 0
                     ? (
                         <div className={`flex flex-wrap gap-1.5${displayContent ? ' mt-2' : ''}`}>
-                          {attachments.map(att => (
-                            <span
-                              key={att.id}
-                              className="inline-flex items-center gap-1 rounded bg-muted/60 border border-border/40 px-1.5 py-0.5 text-[11px] text-muted-foreground"
-                            >
-                              {att.mimeType.startsWith('image/')
-                                ? <Image className="h-3 w-3 shrink-0 text-blue-500" />
-                                : <FileText className="h-3 w-3 shrink-0" />}
-                              <span className="truncate max-w-[120px]">{att.name}</span>
-                              <span className="text-muted-foreground/50">{formatFileSize(att.size)}</span>
-                            </span>
-                          ))}
+                          {attachments.map((att) => {
+                            const chipClass = 'inline-flex items-center gap-1 rounded bg-muted/60 border border-border/40 px-1.5 py-0.5 text-[11px] text-muted-foreground'
+                            const inner = (
+                              <>
+                                {att.mimeType.startsWith('image/')
+                                  ? <Image className="h-3 w-3 shrink-0 text-blue-500" />
+                                  : <FileText className="h-3 w-3 shrink-0" />}
+                                <span className="truncate max-w-[120px]">{att.name}</span>
+                                <span className="text-muted-foreground/50">{formatFileSize(att.size)}</span>
+                              </>
+                            )
+                            // Optimistic entries with empty id are not yet reachable
+                            if (!att.id) {
+                              return <span key={att.id} className={chipClass}>{inner}</span>
+                            }
+                            const url = `/api/projects/${projectId}/issues/${issueId}/attachments/${att.id}`
+                            return (
+                              <button
+                                key={att.id}
+                                type="button"
+                                onClick={() => setPreviewAttachment({
+                                  kind: 'remote',
+                                  name: att.name,
+                                  mimeType: att.mimeType,
+                                  size: att.size,
+                                  url,
+                                })}
+                                className={`${chipClass} cursor-pointer hover:bg-muted/80 transition-colors`}
+                              >
+                                {inner}
+                              </button>
+                            )
+                          })}
                         </div>
                       )
                     : null}
@@ -467,6 +491,12 @@ export function ChatBody({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {previewAttachment ?
+          (
+            <FilePreviewModal item={previewAttachment} onClose={() => setPreviewAttachment(null)} />
+          ) :
+        null}
     </>
   )
 }

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -1,17 +1,16 @@
 import {
   Eraser,
-  FileText,
   FolderOpen,
-  Image as ImageIcon,
   Loader2,
   Paperclip,
   RefreshCw,
   SlashSquare,
-  X,
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { AttachmentChips } from '@/components/AttachmentChips'
 import { EngineIcon } from '@/components/EngineIcons'
+import { FilePreviewModal } from '@/components/FilePreviewModal'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -30,7 +29,6 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -40,13 +38,11 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
 import { useChangesSummary } from '@/hooks/use-changes-summary'
+import { useFileAttachments } from '@/hooks/use-file-attachments'
 import { useClearIssueSession, useEngineAvailability, useEngineSettings, useFollowUpIssue } from '@/hooks/use-kanban'
-import { formatFileSize, formatModelName } from '@/lib/format'
+import { formatModelName } from '@/lib/format'
 import { useFileBrowserStore } from '@/stores/file-browser-store'
 import type { BusyAction, EngineModel, SessionStatus } from '@/types/kanban'
-
-const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
-const MAX_FILES = 10
 
 const MODE_OPTIONS = ['auto', 'ask'] as const
 type ModeOption = (typeof MODE_OPTIONS)[number]
@@ -158,11 +154,23 @@ export function ChatInput({
   }, [pendingEditContent, onPendingEditConsumed])
 
   const [sendError, setSendError] = useState<string | null>(null)
-  const [attachedFiles, setAttachedFiles] = useState<File[]>([])
-  const [isDragOver, setIsDragOver] = useState(false)
-  const [previewFile, setPreviewFile] = useState<File | null>(null)
+  const attach = useFileAttachments()
+  const {
+    attachedFiles,
+    attachError,
+    isDragOver,
+    previewFile,
+    setPreviewFile,
+    fileInputRef,
+    handlePaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleFileSelect,
+    openPicker,
+    reset: resetAttachments,
+  } = attach
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const isSendingRef = useRef(false)
   const [textareaH, setTextareaH] = useState(36)
   const dragRef = useRef({ active: false, startY: 0, startH: 0 })
@@ -260,48 +268,6 @@ export function ChatInput({
   const canSend =
     (normalizedPrompt.length > 0 || attachedFiles.length > 0) && !!issueId && !!projectId
 
-  const addFiles = useCallback(
-    (incoming: File[]) => {
-      setAttachedFiles((prev) => {
-        const combined = [...prev]
-        for (const file of incoming) {
-          if (file.size > MAX_FILE_SIZE) {
-            setSendError(
-              t('chat.fileTooBig', {
-                name: file.name,
-                limit: MAX_FILE_SIZE / 1024 / 1024,
-              }),
-            )
-            setTimeout(setSendError, 5000, null)
-            continue
-          }
-          if (combined.length >= MAX_FILES) {
-            setSendError(t('chat.tooManyFiles', { max: MAX_FILES }))
-            setTimeout(setSendError, 5000, null)
-            break
-          }
-          // Deduplicate by name+size
-          if (!combined.some(f => f.name === file.name && f.size === file.size)) {
-            combined.push(file)
-          }
-        }
-        return combined
-      })
-    },
-    [t],
-  )
-
-  const removeFile = useCallback((index: number) => {
-    setAttachedFiles((prev) => {
-      const removed = prev[index]
-      // Clear preview if the removed file is currently being previewed
-      setPreviewFile(current =>
-        current && current.name === removed.name && current.size === removed.size ? null : current,
-      )
-      return prev.filter((_, i) => i !== index)
-    })
-  }, [])
-
   const handleClearSession = async () => {
     if (!issueId) return
     try {
@@ -327,7 +293,7 @@ export function ChatInput({
         /* ignore */
       }
     }
-    setAttachedFiles([])
+    resetAttachments()
     setSendError(null)
     try {
       const isTodo = statusId === 'todo'
@@ -386,7 +352,7 @@ export function ChatInput({
       // issueId, which is always the same value as draftKey's source.
       if (issueIdRef.current === issueId) {
         setInput(prompt)
-        setAttachedFiles(filesToSend)
+        attach.setAttachedFiles(filesToSend)
       }
       setTimeout(setSendError, 5000, null)
     } finally {
@@ -441,54 +407,6 @@ export function ChatInput({
   const handleInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value)
   }, [])
-
-  const handlePaste = useCallback(
-    (e: React.ClipboardEvent) => {
-      const items = e.clipboardData.items
-      const files: File[] = []
-      for (const item of items) {
-        if (item.kind === 'file') {
-          const file = item.getAsFile()
-          if (file) files.push(file)
-        }
-      }
-      if (files.length > 0) {
-        e.preventDefault()
-        addFiles(files)
-      }
-    },
-    [addFiles],
-  )
-
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragOver(true)
-  }, [])
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragOver(false)
-  }, [])
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault()
-      setIsDragOver(false)
-      const files = [...e.dataTransfer.files]
-      if (files.length > 0) addFiles(files)
-    },
-    [addFiles],
-  )
-
-  const handleFileSelect = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const files = [...e.target.files ?? []]
-      if (files.length > 0) addFiles(files)
-      // Reset input so same file can be re-selected
-      e.target.value = ''
-    },
-    [addFiles],
-  )
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
@@ -604,11 +522,11 @@ export function ChatInput({
           </div>
         </div>
 
-        {/* Error banner */}
-        {sendError ?
+        {/* Error banner — combines send + attach errors */}
+        {(sendError ?? attachError) ?
             (
               <div className="mx-2 mt-2 rounded-lg bg-destructive/10 border border-destructive/20 px-2 py-2 text-xs text-destructive">
-                {sendError}
+                {sendError ?? attachError}
               </div>
             ) :
           null}
@@ -663,40 +581,7 @@ export function ChatInput({
         </div>
 
         {/* File preview bar — below textarea */}
-        {attachedFiles.length > 0 ?
-            (
-              <div className="flex flex-wrap gap-1.5 px-2 pb-1.5">
-                {attachedFiles.map((file, idx) => (
-                  <div
-                    key={`${file.name}-${file.size}`}
-                    className="group/file flex items-center gap-1.5 rounded-lg bg-muted/50 border border-border/40 px-2 py-1 text-xs cursor-pointer hover:bg-muted/70 transition-colors"
-                    onClick={() => setPreviewFile(file)}
-                  >
-                    {file.type.startsWith('image/') ?
-                        (
-                          <ImageIcon className="h-3 w-3 shrink-0 text-blue-500" />
-                        ) :
-                        (
-                          <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
-                        )}
-                    <span className="truncate max-w-[120px]">{file.name}</span>
-                    <span className="text-muted-foreground/60">{formatFileSize(file.size)}</span>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        removeFile(idx)
-                      }}
-                      className="ml-0.5 rounded p-0.5 text-muted-foreground/60 hover:text-destructive hover:bg-destructive/10 transition-colors"
-                      title={t('chat.removeFile')}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            ) :
-          null}
+        <AttachmentChips files={attachedFiles} onPreview={setPreviewFile} onRemove={attach.removeFile} />
 
         {/* Hidden file input */}
         <input
@@ -715,7 +600,7 @@ export function ChatInput({
               variant="ghost"
               size="icon"
               title={t('chat.attach')}
-              onClick={() => fileInputRef.current?.click()}
+              onClick={openPicker}
             >
               <Paperclip className="size-4" />
             </Button>
@@ -790,71 +675,10 @@ export function ChatInput({
       {/* File preview modal — shadcn Dialog */}
       {previewFile ?
           (
-            <FilePreviewModal file={previewFile} onClose={() => setPreviewFile(null)} />
+            <FilePreviewModal item={{ kind: 'file', file: previewFile }} onClose={() => setPreviewFile(null)} />
           ) :
         null}
     </div>
-  )
-}
-
-// ─── FilePreviewModal ────────────────────────────────────────────────────────
-// Replaced custom modal with shadcn Dialog
-
-function FilePreviewModal({ file, onClose }: { file: File, onClose: () => void }) {
-  const { t } = useTranslation()
-  const [imageUrl, setImageUrl] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (file.type.startsWith('image/')) {
-      const url = URL.createObjectURL(file)
-      setImageUrl(url)
-      return () => URL.revokeObjectURL(url)
-    }
-    setImageUrl(null)
-  }, [file])
-
-  return (
-    <Dialog open onOpenChange={open => !open && onClose()}>
-      <DialogContent className="max-w-[600px] max-h-[80vh] overflow-hidden p-0">
-        <DialogHeader className="flex flex-row items-center gap-2 px-4 py-3 border-b border-border/30 space-y-0">
-          {file.type.startsWith('image/') ?
-              (
-                <ImageIcon className="h-4 w-4 shrink-0 text-blue-500" />
-              ) :
-              (
-                <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-              )}
-          <DialogTitle className="text-sm font-medium truncate">{file.name}</DialogTitle>
-        </DialogHeader>
-
-        <div className="p-4 overflow-auto max-h-[calc(80vh-56px)]">
-          {imageUrl ?
-              (
-                <img
-                  src={imageUrl}
-                  alt={file.name}
-                  className="max-w-full max-h-[60vh] rounded-lg object-contain mx-auto"
-                />
-              ) :
-              (
-                <div className="space-y-3">
-                  <div className="flex items-center justify-center w-16 h-16 rounded-xl bg-muted/60 mx-auto">
-                    <FileText className="h-8 w-8 text-muted-foreground/60" />
-                  </div>
-                  <div className="text-center space-y-1">
-                    <p className="text-sm font-medium truncate">{file.name}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {file.type || t('chat.unknownType')}
-                      {' '}
-                      &middot;
-                      {formatFileSize(file.size)}
-                    </p>
-                  </div>
-                </div>
-              )}
-        </div>
-      </DialogContent>
-    </Dialog>
   )
 }
 

--- a/apps/frontend/src/components/issue-detail/LogEntry.tsx
+++ b/apps/frontend/src/components/issue-detail/LogEntry.tsx
@@ -24,6 +24,9 @@ import {
 } from 'lucide-react'
 import { lazy, Suspense, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import type { PreviewItem } from '@/components/FilePreviewModal'
+import { FilePreviewModal } from '@/components/FilePreviewModal'
 import {
   Dialog,
   DialogContent,
@@ -266,6 +269,120 @@ function TaskPlanEntry({ entry }: { entry: NormalizedLogEntry }) {
   )
 }
 
+function UserMessageEntry({ entry }: { entry: NormalizedLogEntry }) {
+  const { t } = useTranslation()
+  const { projectId, issueId } = useParams<{ projectId: string, issueId: string }>()
+  const [preview, setPreview] = useState<PreviewItem | null>(null)
+
+  const isPending = entry.metadata?.type === 'pending'
+  const isDone = entry.metadata?.type === 'done'
+  const messageAttachments = (entry.metadata?.attachments ?? []) as AttachmentMeta[]
+  // Strip "--- Attached files ---" block from display (already shown as chips)
+  const displayContent = entry.content.replace(/\n*--- Attached files ---\n(?:\[Attached file:.*\]\n?)*/g, '').trim()
+  // Skip empty user messages (no text, no attachments, not pending/done)
+  if (!displayContent && messageAttachments.length === 0 && !isPending && !isDone)
+    return null
+
+  const barColor = isPending ?
+    'border-amber-400 bg-amber-500/[0.06]' :
+    isDone ?
+      'border-emerald-400 bg-emerald-500/[0.06]' :
+      'border-foreground/70'
+
+  // Optimistic attachments (created locally before the server assigns an id)
+  // carry id === '' and aren't yet reachable; render them as static chips.
+  const buildPreview = (att: AttachmentMeta): PreviewItem | null => {
+    if (!projectId || !issueId || !att.id) return null
+    return {
+      kind: 'remote',
+      name: att.name,
+      mimeType: att.mimeType,
+      size: att.size,
+      url: `/api/projects/${projectId}/issues/${issueId}/attachments/${att.id}`,
+    }
+  }
+
+  return (
+    <div className="group py-2 animate-message-enter">
+      <div className={`bg-muted/70 px-3 py-2.5 border border-l-[3px] ${barColor}`}>
+        {displayContent ?
+            (
+              <div className="text-[15px] whitespace-pre-wrap break-words text-foreground leading-[1.75]">
+                {displayContent}
+              </div>
+            ) :
+          null}
+        {messageAttachments.length > 0 ?
+            (
+              <div className={`flex flex-wrap gap-1.5${entry.content.trim() ? ' mt-2' : ''}`}>
+                {messageAttachments.map((att) => {
+                  const previewItem = buildPreview(att)
+                  const chipClass = 'inline-flex items-center gap-1 rounded bg-muted/60 border border-border/40 px-1.5 py-0.5 text-[11px] text-muted-foreground'
+                  const inner = (
+                    <>
+                      {att.mimeType.startsWith('image/') ?
+                          (
+                            <Image className="h-3 w-3 shrink-0 text-blue-500" />
+                          ) :
+                          (
+                            <FileText className="h-3 w-3 shrink-0" />
+                          )}
+                      <span className="truncate max-w-[120px]">{att.name}</span>
+                      <span className="text-muted-foreground/50">{formatFileSize(att.size)}</span>
+                    </>
+                  )
+                  if (!previewItem) {
+                    return (
+                      <span key={att.id} className={chipClass}>
+                        {inner}
+                      </span>
+                    )
+                  }
+                  return (
+                    <button
+                      key={att.id}
+                      type="button"
+                      onClick={() => setPreview(previewItem)}
+                      className={`${chipClass} cursor-pointer hover:bg-muted/80 transition-colors`}
+                    >
+                      {inner}
+                    </button>
+                  )
+                })}
+              </div>
+            ) :
+          null}
+        {isPending || isDone ?
+            (
+              <div className="flex items-center gap-2 mt-1">
+                {isPending ?
+                    (
+                      <span className="inline-flex items-center gap-1 text-[10px] text-amber-500/70">
+                        <Clock className="h-2.5 w-2.5" />
+                        {t('chat.pendingMessage')}
+                      </span>
+                    ) :
+                  null}
+                {isDone ?
+                    (
+                      <span className="inline-flex items-center gap-1 text-[10px] text-emerald-500/70">
+                        {t('chat.doneMessage')}
+                      </span>
+                    ) :
+                  null}
+              </div>
+            ) :
+          null}
+      </div>
+      {preview ?
+          (
+            <FilePreviewModal item={preview} onClose={() => setPreview(null)} />
+          ) :
+        null}
+    </div>
+  )
+}
+
 export function LogEntry({
   entry,
   durationMs,
@@ -278,77 +395,8 @@ export function LogEntry({
   const { t } = useTranslation()
 
   switch (entry.entryType) {
-    case 'user-message': {
-      const isPending = entry.metadata?.type === 'pending'
-      const isDone = entry.metadata?.type === 'done'
-      const messageAttachments = (entry.metadata?.attachments ?? []) as AttachmentMeta[]
-      // Strip "--- Attached files ---" block from display (already shown as chips)
-      const displayContent = entry.content.replace(/\n*--- Attached files ---\n(?:\[Attached file:.*\]\n?)*/g, '').trim()
-      // Skip empty user messages (no text, no attachments, not pending/done)
-      if (!displayContent && messageAttachments.length === 0 && !isPending && !isDone)
-        return null
-      const barColor = isPending ?
-        'border-amber-400 bg-amber-500/[0.06]' :
-        isDone ?
-          'border-emerald-400 bg-emerald-500/[0.06]' :
-          'border-foreground/70'
-      return (
-        <div className="group py-2 animate-message-enter">
-          <div className={`bg-muted/70 px-3 py-2.5 border border-l-[3px] ${barColor}`}>
-            {displayContent ?
-                (
-                  <div className="text-[15px] whitespace-pre-wrap break-words text-foreground leading-[1.75]">
-                    {displayContent}
-                  </div>
-                ) :
-              null}
-            {messageAttachments.length > 0 ?
-                (
-                  <div className={`flex flex-wrap gap-1.5${entry.content.trim() ? ' mt-2' : ''}`}>
-                    {messageAttachments.map(att => (
-                      <span
-                        key={att.id}
-                        className="inline-flex items-center gap-1 rounded bg-muted/60 border border-border/40 px-1.5 py-0.5 text-[11px] text-muted-foreground"
-                      >
-                        {att.mimeType.startsWith('image/') ?
-                            (
-                              <Image className="h-3 w-3 shrink-0 text-blue-500" />
-                            ) :
-                            (
-                              <FileText className="h-3 w-3 shrink-0" />
-                            )}
-                        <span className="truncate max-w-[120px]">{att.name}</span>
-                        <span className="text-muted-foreground/50">{formatFileSize(att.size)}</span>
-                      </span>
-                    ))}
-                  </div>
-                ) :
-              null}
-            {isPending || isDone ?
-                (
-                  <div className="flex items-center gap-2 mt-1">
-                    {isPending ?
-                        (
-                          <span className="inline-flex items-center gap-1 text-[10px] text-amber-500/70">
-                            <Clock className="h-2.5 w-2.5" />
-                            {t('chat.pendingMessage')}
-                          </span>
-                        ) :
-                      null}
-                    {isDone ?
-                        (
-                          <span className="inline-flex items-center gap-1 text-[10px] text-emerald-500/70">
-                            {t('chat.doneMessage')}
-                          </span>
-                        ) :
-                      null}
-                  </div>
-                ) :
-              null}
-          </div>
-        </div>
-      )
-    }
+    case 'user-message':
+      return <UserMessageEntry entry={entry} />
 
     case 'assistant-message':
       if (!entry.content.trim()) return null

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -1,8 +1,10 @@
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Paperclip } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
+import { AttachmentChips } from '@/components/AttachmentChips'
 import { EngineIcon } from '@/components/EngineIcons'
+import { FilePreviewModal } from '@/components/FilePreviewModal'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import {
@@ -13,6 +15,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { useFileAttachments } from '@/hooks/use-file-attachments'
 import {
   useCreateIssue,
   useEngineAvailability,
@@ -75,6 +78,22 @@ export function CreateIssueForm({
   const [modelId, setModelId] = useState('')
   const [permission, setPermission] = useState<PermissionId>('auto')
   const [useWorktree, setUseWorktree] = useState(false)
+  const {
+    attachedFiles,
+    attachError,
+    isDragOver,
+    previewFile,
+    setPreviewFile,
+    fileInputRef,
+    removeFile,
+    openPicker,
+    reset: resetAttachments,
+    handlePaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleFileSelect,
+  } = useFileAttachments()
 
   // Keep worktree disabled for non-git projects, but do not auto-enable it.
   useEffect(() => {
@@ -142,6 +161,7 @@ export function CreateIssueForm({
         engineType: engineType || undefined,
         model: modelId || undefined,
         permissionMode: permissionMap[permission],
+        files: attachedFiles.length > 0 ? attachedFiles : undefined,
       },
       {
         onSuccess: () => {
@@ -151,6 +171,7 @@ export function CreateIssueForm({
           setModelId('')
           setPermission('auto')
           setUseWorktree(false)
+          resetAttachments()
           onCreated?.()
         },
       },
@@ -163,8 +184,10 @@ export function CreateIssueForm({
     useWorktree,
     engineType,
     modelId,
+    attachedFiles,
     createIssue,
     onCreated,
+    resetAttachments,
   ])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -184,18 +207,75 @@ export function CreateIssueForm({
   return (
     <div onKeyDown={handleKeyDown}>
       {/* ─── Input area ─────────────────────────── */}
-      <div className="rounded-lg border bg-muted/30 focus-within:ring-1 focus-within:ring-ring transition-shadow">
+      <div
+        className={`rounded-lg border bg-muted/30 focus-within:ring-1 focus-within:ring-ring transition-shadow ${
+          isDragOver ? 'border-primary/50 ring-2 ring-primary/20' : ''
+        }`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
         <Textarea
           ref={textareaRef}
           value={input}
           onChange={handleTextarea}
+          onPaste={handlePaste}
           placeholder={t('issue.describeWork')}
           rows={4}
           className="w-full bg-transparent text-sm resize-none border-none shadow-none outline-none placeholder:text-muted-foreground/50 px-3 pt-3 pb-2 min-h-25 focus-visible:ring-0 rounded-b-none!"
           disabled={createIssue.isPending}
         />
+
+        {isDragOver ?
+            (
+              <div className="px-3 py-1.5 text-[11px] text-primary font-medium">
+                {t('chat.attachDragHint')}
+              </div>
+            ) :
+          null}
+
+        {attachError ?
+            (
+              <div className="mx-3 mb-1.5 rounded bg-destructive/10 border border-destructive/20 px-2 py-1.5 text-[11px] text-destructive">
+                {attachError}
+              </div>
+            ) :
+          null}
+
+        <AttachmentChips
+          files={attachedFiles}
+          onPreview={setPreviewFile}
+          onRemove={removeFile}
+        />
+
+        {previewFile ?
+            (
+              <FilePreviewModal item={{ kind: 'file', file: previewFile }} onClose={() => setPreviewFile(null)} />
+            ) :
+          null}
+
+        {/* Hidden file input */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleFileSelect}
+        />
+
         <div className="flex items-center justify-between px-3 py-2">
-          <span className="text-[11px] text-muted-foreground/50">{t('issue.cmdEnterSubmit')}</span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={openPicker}
+              title={t('chat.attach')}
+              className="inline-flex items-center justify-center rounded p-1 text-muted-foreground/60 hover:text-foreground hover:bg-muted/60 transition-colors"
+              disabled={createIssue.isPending}
+            >
+              <Paperclip className="h-3.5 w-3.5" />
+            </button>
+            <span className="text-[11px] text-muted-foreground/50">{t('issue.cmdEnterSubmit')}</span>
+          </div>
           <span className="text-[11px] text-muted-foreground/50 tabular-nums">
             {input.length}
             {' '}

--- a/apps/frontend/src/hooks/use-file-attachments.ts
+++ b/apps/frontend/src/hooks/use-file-attachments.ts
@@ -1,0 +1,140 @@
+import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
+const DEFAULT_MAX_FILES = 10
+
+/**
+ * Shared file-attachment state + handlers used by ChatInput (follow-up) and
+ * CreateIssueDialog. Keeps the picker/drag/paste/preview behaviour aligned.
+ *
+ * Limits mirror server-side `uploads.ts` constants. Errors auto-clear after 5s.
+ */
+export function useFileAttachments(opts: { maxFileSize?: number, maxFiles?: number } = {}) {
+  const { t } = useTranslation()
+  const maxFileSize = opts.maxFileSize ?? DEFAULT_MAX_FILE_SIZE
+  const maxFiles = opts.maxFiles ?? DEFAULT_MAX_FILES
+
+  const [attachedFiles, setAttachedFiles] = useState<File[]>([])
+  const [attachError, setAttachError] = useState<string | null>(null)
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [previewFile, setPreviewFile] = useState<File | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const addFiles = useCallback(
+    (incoming: File[]) => {
+      setAttachedFiles((prev) => {
+        const combined = [...prev]
+        for (const file of incoming) {
+          if (file.size > maxFileSize) {
+            setAttachError(
+              t('chat.fileTooBig', { name: file.name, limit: maxFileSize / 1024 / 1024 }),
+            )
+            setTimeout(setAttachError, 5000, null)
+            continue
+          }
+          if (combined.length >= maxFiles) {
+            setAttachError(t('chat.tooManyFiles', { max: maxFiles }))
+            setTimeout(setAttachError, 5000, null)
+            break
+          }
+          if (!combined.some(f => f.name === file.name && f.size === file.size)) {
+            combined.push(file)
+          }
+        }
+        return combined
+      })
+    },
+    [t, maxFileSize, maxFiles],
+  )
+
+  const removeFile = useCallback((index: number) => {
+    setAttachedFiles((prev) => {
+      const removed = prev[index]
+      setPreviewFile(current =>
+        current && removed && current.name === removed.name && current.size === removed.size
+          ? null
+          : current,
+      )
+      return prev.filter((_, i) => i !== index)
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    setAttachedFiles([])
+    setAttachError(null)
+    setPreviewFile(null)
+  }, [])
+
+  const openPicker = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const items = e.clipboardData.items
+      const files: File[] = []
+      for (const item of items) {
+        if (item.kind === 'file') {
+          const file = item.getAsFile()
+          if (file) files.push(file)
+        }
+      }
+      if (files.length > 0) {
+        e.preventDefault()
+        addFiles(files)
+      }
+    },
+    [addFiles],
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragOver(false)
+      const files = [...e.dataTransfer.files]
+      if (files.length > 0) addFiles(files)
+    },
+    [addFiles],
+  )
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = [...e.target.files ?? []]
+      if (files.length > 0) addFiles(files)
+      // Reset so the same file can be re-selected later
+      e.target.value = ''
+    },
+    [addFiles],
+  )
+
+  return {
+    attachedFiles,
+    setAttachedFiles,
+    attachError,
+    setAttachError,
+    isDragOver,
+    previewFile,
+    setPreviewFile,
+    fileInputRef,
+    addFiles,
+    removeFile,
+    reset,
+    openPicker,
+    handlePaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleFileSelect,
+  }
+}

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -244,6 +244,7 @@ export function useCreateIssue(projectId: string) {
       engineType?: string
       model?: string
       permissionMode?: string
+      files?: File[]
     }) => kanbanApi.createIssue(projectId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.issues(projectId) })

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -242,8 +242,24 @@ export const kanbanApi = {
       engineType?: string
       model?: string
       permissionMode?: string
+      files?: File[]
     },
-  ) => post<Issue>(`/api/projects/${projectId}/issues`, data),
+  ) => {
+    const { files, ...rest } = data
+    if (files && files.length > 0) {
+      const fd = new FormData()
+      fd.append('title', rest.title)
+      fd.append('statusId', rest.statusId)
+      if (rest.tags) fd.append('tags', JSON.stringify(rest.tags))
+      if (rest.useWorktree !== undefined) fd.append('useWorktree', String(rest.useWorktree))
+      if (rest.engineType) fd.append('engineType', rest.engineType)
+      if (rest.model) fd.append('model', rest.model)
+      if (rest.permissionMode) fd.append('permissionMode', rest.permissionMode)
+      for (const file of files) fd.append('files', file)
+      return postFormData<Issue>(`/api/projects/${projectId}/issues`, fd)
+    }
+    return post<Issue>(`/api/projects/${projectId}/issues`, rest)
+  },
   updateIssue: (projectId: string, id: string, data: Partial<Issue>) =>
     patch<Issue>(`/api/projects/${projectId}/issues/${id}`, data),
   bulkUpdateIssues: (

--- a/docs/task/UI-002.md
+++ b/docs/task/UI-002.md
@@ -1,0 +1,53 @@
+# UI-002 Support attachments and image paste in create-issue dialog
+
+- **status**: completed
+- **priority**: P1
+- **owner**: roy
+- **createdAt**: 2026-05-17 00:00
+
+## Description
+
+`CreateIssueDialog` has no attachment UI; users can attach files / paste images
+only in `ChatInput` (follow-up flow). Bring create-issue to parity:
+
+- Frontend: paperclip button, drag-drop highlight, `onPaste` image capture, file
+  preview chips with remove. Same 10 MB / 10-file limits and i18n keys as
+  `ChatInput` (`chat.fileTooBig`, `chat.tooManyFiles`, `chat.attach`,
+  `chat.attachDragHint`, `chat.removeFile`).
+- API client (`kanban-api.ts`): `createIssue` accepts `files?: File[]` and
+  switches to `FormData` when files are present.
+- Backend (`apps/api/src/routes/issues/create.ts`): convert to manual `.post('/')`
+  handler (same pattern as follow-up); dual JSON / multipart parsing. Save files
+  with `saveUploadedFile`, insert `attachments` rows with `logId = null`.
+- `triggerIssueExecution` (`_shared.ts`): query `attachments WHERE issueId=? AND
+  logId IS NULL`, fold their file context into the engine prompt and merge their
+  metadata. Set `displayPrompt = issue.prompt` so chips show in chat without
+  leaking the file-path lines. After `executeIssue` returns `messageId`, link
+  those attachment rows to it.
+- `openapi/routes.ts`: add a note like `followUpIssue` documenting the dual
+  content-type.
+
+Acceptance criteria:
+
+- Create issue dialog accepts files via picker, drag-drop, and Ctrl/Cmd+V.
+- Submitting a create-issue with files succeeds; created issue card appears.
+- For `working` status, first user-message in chat shows attachment chips and
+  the AI engine prompt includes file paths.
+- For `todo` status, files are stored; when the issue is later moved to working,
+  the engine receives the file context.
+- Existing JSON-only create flow continues to work.
+
+## ActiveForm
+
+Adding attachment and paste support to the create-issue dialog.
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+Reuses existing infrastructure: `uploads.ts` (`saveUploadedFile`,
+`validateFiles`), `attachments` table, `pending-messages.ts`
+(`buildFileContextFromRows`). No schema migration. No new dependencies.

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -54,3 +54,4 @@ Each task is a single line linking to its detail file. All detailed information 
 - [x] [**ENG-010 Fix non-monotonic migration journal (0020) + harden fix-db**](ENG-010.md) `P0`
 - [x] [**ENG-011 Generic schema safety-net (snapshot-driven self-heal)**](ENG-011.md) `P1`
 - [x] [**ENG-012 Create dialog ignores project-level default engine**](ENG-012.md) `P1`
+- [x] [**UI-002 Support attachments and image paste in create-issue dialog**](UI-002.md) `P1`


### PR DESCRIPTION
## Summary

- **Create-issue dialog**: parity with chat-input — paperclip, drag-drop, paste image, file chips with click-to-preview. Backed by a new shared `useFileAttachments` hook, `AttachmentChips`, and a generalized `FilePreviewModal` reused by both surfaces.
- **Backend create endpoint**: `POST /api/projects/:projectId/issues` now also accepts `multipart/form-data`. Saved attachments are folded into the engine prompt + user-message metadata by `triggerIssueExecution` and back-linked to the persisted `messageId`. Works for both `working`/`review` (auto-execute) and `todo` (consumed on later move-to-working).
- **Chat-message attachments**: chips in `LogEntry` user-message and the pending preview in `ChatBody` are now clickable buttons that open the shared preview modal against `/api/.../attachments/:attachmentId`. Optimistic entries (empty `id`) stay as static spans.
- **`/changes` endpoint UX fix**: returns success with empty data when the project has no `directory` configured (was `400 Project directory is not configured`); `IssueChangesResponseSchema.root` is now optional.

Closes UI-002.

## Test plan

- [ ] Create an issue in `todo` with a pasted image + a dropped file; chip preview opens; created card shows them
- [ ] Create an issue in `working` with attachments; first user-message in chat shows the chips, file paths reach the engine prompt
- [ ] Move a `todo` issue with attachments to `working`; engine receives the file context, chips render on the user-message
- [ ] Click an image chip in a delivered chat message — preview opens
- [ ] Click an image chip in the pending-message preview bar — preview opens
- [ ] Click an image chip in the upload area (chat input + create dialog) — preview still opens
- [ ] Submitting create-issue with no files still uses JSON (unchanged behaviour)
- [ ] Open an issue page where the project has no `directory` — no 400 in network panel, file-count badge shows 0
- [ ] Backend: `bun --filter @bkd/api test` (32 issue tests including 2 multipart + 2 changes)
- [ ] Frontend: `bun run build` + `bun --filter @bkd/frontend test`