### PR TITLE
fix(issues): address PR #130 review (atomicity, validation, spec, polish)

### DIFF
--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -353,12 +353,22 @@ export function triggerIssueExecution(
         ...(effectiveDisplayPrompt !== undefined ? { displayPrompt: effectiveDisplayPrompt } : {}),
         ...(hasMeta ? { metadata: baseMeta } : {}),
       })
-      // Link the create-time attachments to the freshly persisted user-message
-      if (unlinkedAttachments.length > 0 && execResult.messageId) {
-        await db
-          .update(attachmentsTable)
-          .set({ logId: execResult.messageId })
-          .where(inArray(attachmentsTable.id, unlinkedAttachments.map(a => a.id)))
+      // Link the create-time attachments to the freshly persisted user-message.
+      // If messageId is missing (persist pipeline failed silently), leave the
+      // rows unlinked and warn — they'll be re-tried on the next execute via
+      // the isNull(logId) query rather than being silently double-attached.
+      if (unlinkedAttachments.length > 0) {
+        if (execResult.messageId) {
+          await db
+            .update(attachmentsTable)
+            .set({ logId: execResult.messageId })
+            .where(inArray(attachmentsTable.id, unlinkedAttachments.map(a => a.id)))
+        } else {
+          logger.warn(
+            { issueId, count: unlinkedAttachments.length },
+            'auto_execute_no_message_id_attachments_left_unlinked',
+          )
+        }
       }
       // Notify frontend to remove old pending entry after successful execution
       if (relocated) {

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -1,3 +1,4 @@
+import { unlink } from 'node:fs/promises'
 import { and, desc, eq, max } from 'drizzle-orm'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
 import * as z from 'zod'
@@ -61,6 +62,10 @@ async function parseCreateBody(c: {
           raw.tags = value.split(',').map(s => s.trim()).filter(Boolean)
         }
       } else if (key === 'useWorktree' || key === 'keepAlive') {
+        // Strict: silently coercing typos like "tru" to false hides client bugs.
+        if (value !== 'true' && value !== 'false' && value !== '1' && value !== '0') {
+          return { ok: false, error: `${key} must be "true", "false", "1", or "0"` }
+        }
         raw[key] = value === 'true' || value === '1'
       } else {
         raw[key] = value
@@ -148,6 +153,24 @@ create.post('/', async (c) => {
     }
   }
 
+  // Save files to disk BEFORE opening the issue transaction so a disk failure
+  // surfaces as a clean 400 with no issue row created. The transaction inserts
+  // the issue and its attachment rows together; on rollback we unlink the
+  // disk files so the API response and persisted state stay in lockstep
+  // (no orphaned issue rows, no orphaned files driving client-side retries).
+  let savedFiles: SavedFile[] = []
+  if (files.length > 0) {
+    try {
+      savedFiles = await Promise.all(files.map(saveUploadedFile))
+    } catch (saveError) {
+      logger.warn(
+        { projectId: project.id, error: saveError },
+        'issue_create_attachment_save_failed',
+      )
+      return c.json({ success: false, error: 'Failed to save uploaded files' }, 400 as const)
+    }
+  }
+
   try {
     const issuePrompt = body.title
     const shouldExecute = body.statusId === 'working' || body.statusId === 'review'
@@ -177,7 +200,7 @@ create.post('/', async (c) => {
         .limit(1)
       const sortOrder = generateKeyBetween(lastItem?.sortOrder ?? null, null)
 
-      return tx
+      const inserted = await tx
         .insert(issuesTable)
         .values({
           projectId: project.id,
@@ -194,26 +217,27 @@ create.post('/', async (c) => {
           prompt: issuePrompt,
         })
         .returning()
-    })
 
-    // Persist uploaded files and attach them to the new issue. logId stays null;
-    // triggerIssueExecution links each row to the user-message it generates.
-    let savedFiles: SavedFile[] = []
-    if (files.length > 0) {
-      savedFiles = await Promise.all(files.map(saveUploadedFile))
-      await db.insert(attachmentsTable).values(
-        savedFiles.map(f => ({
-          id: f.id,
-          issueId: newIssue!.id,
-          logId: null,
-          originalName: f.originalName,
-          storedName: f.storedName,
-          mimeType: f.mimeType,
-          size: f.size,
-          storagePath: f.storagePath,
-        })),
-      )
-    }
+      // Attachment rows share the transaction with the issue insert so a
+      // failure here rolls back the issue too — kept in lockstep with the
+      // unlink-on-failure logic in the outer catch.
+      if (savedFiles.length > 0) {
+        await tx.insert(attachmentsTable).values(
+          savedFiles.map(f => ({
+            id: f.id,
+            issueId: inserted[0]!.id,
+            logId: null,
+            originalName: f.originalName,
+            storedName: f.storedName,
+            mimeType: f.mimeType,
+            size: f.size,
+            storagePath: f.storagePath,
+          })),
+        )
+      }
+
+      return inserted
+    })
 
     // After successful creation, invalidate relevant caches
     await cacheDel(`projectIssueIds:${project.id}`)
@@ -257,6 +281,20 @@ create.post('/', async (c) => {
       (shouldExecute ? 202 : 201) as 201 | 202,
     )
   } catch (error) {
+    // Transaction rolled back — unlink the disk files we saved up-front so we
+    // don't accumulate orphans alongside the rollback.
+    if (savedFiles.length > 0) {
+      await Promise.all(
+        savedFiles.map(f =>
+          unlink(f.absolutePath).catch(unlinkError =>
+            logger.warn(
+              { projectId: project.id, path: f.absolutePath, error: unlinkError },
+              'issue_create_attachment_cleanup_failed',
+            ),
+          ),
+        ),
+      )
+    }
     logger.warn(
       {
         projectId: project.id,

--- a/apps/api/src/routes/issues/index.ts
+++ b/apps/api/src/routes/issues/index.ts
@@ -1,4 +1,5 @@
 import { createOpenAPIRouter } from '@/openapi/hono'
+import * as R from '@/openapi/routes'
 import attachments from './attachments'
 import changes from './changes'
 import command from './command'
@@ -23,5 +24,12 @@ issues.route('/', message)
 issues.route('/', attachments)
 issues.route('/', logs)
 issues.route('/', changes)
+
+// createIssue and followUpIssue use plain .post() because their handlers parse
+// both JSON and multipart/form-data manually (auto-validation can't span dual
+// content types). Register their route definitions with the OpenAPI registry
+// so the generated spec still documents them.
+issues.openAPIRegistry.registerPath(R.createIssue)
+issues.openAPIRegistry.registerPath(R.followUpIssue)
 
 export default issues

--- a/apps/api/test/api-issues.test.ts
+++ b/apps/api/test/api-issues.test.ts
@@ -178,6 +178,22 @@ describe('POST /api/projects/:projectId/issues', () => {
     })
     expect(res.status).toBe(400)
   })
+
+  test('rejects multipart with invalid boolean string', async () => {
+    const { default: app } = await import('@/app')
+    const fd = new FormData()
+    fd.append('title', 'Bad Bool')
+    fd.append('statusId', 'todo')
+    fd.append('useWorktree', 'tru') // typo — must not silently coerce to false
+    const res = await app.request(`http://localhost/api/projects/${projectId}/issues`, {
+      method: 'POST',
+      body: fd,
+    })
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as { success: boolean, error?: string }
+    expect(json.success).toBe(false)
+    expect(json.error ?? '').toContain('useWorktree')
+  })
 })
 
 describe('GET /api/projects/:projectId/issues/:issueId/changes', () => {

--- a/apps/frontend/src/components/issue-detail/LogEntry.tsx
+++ b/apps/frontend/src/components/issue-detail/LogEntry.tsx
@@ -314,7 +314,7 @@ function UserMessageEntry({ entry }: { entry: NormalizedLogEntry }) {
           null}
         {messageAttachments.length > 0 ?
             (
-              <div className={`flex flex-wrap gap-1.5${entry.content.trim() ? ' mt-2' : ''}`}>
+              <div className={`flex flex-wrap gap-1.5${displayContent ? ' mt-2' : ''}`}>
                 {messageAttachments.map((att) => {
                   const previewItem = buildPreview(att)
                   const chipClass = 'inline-flex items-center gap-1 rounded bg-muted/60 border border-border/40 px-1.5 py-0.5 text-[11px] text-muted-foreground'

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -241,6 +241,7 @@ export function useCreateIssue(projectId: string) {
       tags?: string[]
       statusId: string
       useWorktree?: boolean
+      keepAlive?: boolean
       engineType?: string
       model?: string
       permissionMode?: string

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -239,6 +239,7 @@ export const kanbanApi = {
       tags?: string[]
       statusId: string
       useWorktree?: boolean
+      keepAlive?: boolean
       engineType?: string
       model?: string
       permissionMode?: string
@@ -252,6 +253,7 @@ export const kanbanApi = {
       fd.append('statusId', rest.statusId)
       if (rest.tags) fd.append('tags', JSON.stringify(rest.tags))
       if (rest.useWorktree !== undefined) fd.append('useWorktree', String(rest.useWorktree))
+      if (rest.keepAlive !== undefined) fd.append('keepAlive', String(rest.keepAlive))
       if (rest.engineType) fd.append('engineType', rest.engineType)
       if (rest.model) fd.append('model', rest.model)
       if (rest.permissionMode) fd.append('permissionMode', rest.permissionMode)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -290,7 +290,8 @@ export interface IssueChangedFile {
 }
 
 export interface IssueChangesResponse {
-  root: string
+  /** Absent when the project has no directory configured. */
+  root?: string
   gitRepo: boolean
   files: IssueChangedFile[]
   additions: number


### PR DESCRIPTION
Follow-up to #130 (which merged before these review fixes landed on the branch).

## Summary

- **Atomicity (Codex P1)** — `apps/api/src/routes/issues/create.ts`: files now saved up-front; issue insert and attachment rows happen inside one transaction; on rollback the disk files are unlinked. No more "issue row exists but client got 400 → retry → duplicate".
- **Strict multipart booleans (Codex P2)** — `useWorktree=tru` and similar typos now return 400 instead of silently coercing to `false`.
- **OpenAPI spec coverage (Codex P2)** — `createIssue` and the pre-existing `followUpIssue` keep their dual JSON/multipart handlers but are now registered via `issues.openAPIRegistry.registerPath(...)` so the generated spec stays in sync with reality.
- **Self-review follow-ups**:
  - `_shared.ts` warns when `executeIssue` returns no `messageId`, leaving create-time attachments unlinked so retry picks them up cleanly (no silent double-attach).
  - `LogEntry.tsx` chip-row top-margin uses `displayContent` instead of raw `entry.content` (chips on a pure-attachment message no longer get a phantom `mt-2`).
  - `packages/shared/src/index.ts` `IssueChangesResponse.root` is now optional, matching the API change shipped in #130.
  - `kanban-api.ts` + `use-kanban.ts` FormData branch now appends `keepAlive` (was silently dropped).

## Test plan

- [ ] `bun --filter @bkd/api test` — 35 issue tests pass, including new "rejects multipart with invalid boolean string"
- [ ] `bun --filter @bkd/frontend test` — 39 pass
- [ ] `bun run build` and `tsc --noEmit` on both projects — clean
- [ ] Manually: submit a create-issue with `useWorktree=tru` via curl → 400 with `useWorktree must be "true", "false", "1", or "0"`
- [ ] Manually: visit `/api/docs` → `POST /projects/{projectId}/issues` and `/issues/{issueId}/follow-up` appear in the spec