### PR TITLE
fix(frontend): navigate away after deleting the active issue from the list

### DIFF
--- a/apps/frontend/src/components/issue-detail/IssueContextMenu.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueContextMenu.tsx
@@ -104,6 +104,8 @@ interface IssueContextMenuProps {
   projectId: string
   showPin?: boolean
   children: ReactNode
+  /** Called after the issue is successfully deleted (e.g. to navigate away when it was active) */
+  onDeleted?: () => void
 }
 
 export function IssueContextMenu({
@@ -111,6 +113,7 @@ export function IssueContextMenu({
   projectId,
   showPin = false,
   children,
+  onDeleted,
 }: IssueContextMenuProps) {
   const { t } = useTranslation()
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -138,9 +141,11 @@ export function IssueContextMenu({
   }, [projectId, issue.id])
 
   const handleDelete = useCallback(() => {
-    deleteIssue.mutate(issue.id)
+    deleteIssue.mutate(issue.id, {
+      onSuccess: () => onDeleted?.(),
+    })
     setDeleteOpen(false)
-  }, [deleteIssue, issue.id])
+  }, [deleteIssue, issue.id, onDeleted])
 
   return (
     <>

--- a/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
@@ -165,6 +165,7 @@ export function IssueListPanel({
             onToggle={() => toggleCollapse(status.id)}
             activeIssueId={activeIssueId}
             onNavigate={issueId => navigate(`/projects/${projectId}/issues/${issueId}`)}
+            onActiveDeleted={() => navigate(`/projects/${projectId}/issues`)}
           />
         ))}
       </div>
@@ -191,6 +192,7 @@ function StatusGroup({
   onToggle,
   activeIssueId,
   onNavigate,
+  onActiveDeleted,
 }: {
   status: StatusDefinition
   issues: Issue[]
@@ -199,6 +201,7 @@ function StatusGroup({
   onToggle: () => void
   activeIssueId: string
   onNavigate: (issueId: string) => void
+  onActiveDeleted: () => void
 }) {
   const { t } = useTranslation()
 
@@ -238,6 +241,7 @@ function StatusGroup({
                 projectId={projectId}
                 isActive={isActive}
                 onNavigate={onNavigate}
+                onActiveDeleted={onActiveDeleted}
               />
             )
           })}
@@ -261,11 +265,13 @@ const IssueRow = memo(({
   projectId,
   isActive,
   onNavigate,
+  onActiveDeleted,
 }: {
   issue: Issue
   projectId: string
   isActive: boolean
   onNavigate: (issueId: string) => void
+  onActiveDeleted: () => void
 }) => {
   const handleClick = useCallback(() => {
     if (!isActive) {
@@ -306,7 +312,12 @@ const IssueRow = memo(({
         {issue.title}
       </span>
       <div className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity shrink-0" onClick={e => e.stopPropagation()} onPointerDown={e => e.stopPropagation()}>
-        <IssueContextMenu issue={issue} projectId={projectId} showPin>
+        <IssueContextMenu
+          issue={issue}
+          projectId={projectId}
+          showPin
+          onDeleted={isActive ? onActiveDeleted : undefined}
+        >
           <button
             type="button"
             className="inline-flex items-center justify-center rounded-md p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"


### PR DESCRIPTION
## Problem

Deleting the currently viewed issue from the issue list's context menu (kebab / right-click) left the detail pane resolving to not-found, rendering the "issue not found" state instead of navigating away.

The list context menu's delete path never navigated, unlike the in-chat delete button which already navigates via `onAfterDelete`.

## Fix

- `IssueContextMenu`: add an optional `onDeleted` callback fired on the delete mutation's `onSuccess`.
- `IssueListPanel`: thread the callback to each row; pass it only when the row is the active issue, navigating to `/projects/:projectId/issues` after deletion.

Deleting a non-active issue passes `onDeleted: undefined`, so behavior is unchanged. `KanbanCard` reuses the same component without `onDeleted`, so the board is unaffected.

## Verification

- `eslint` clean on both changed files
- `tsc -b` passes
