### PR TITLE
test(api): align idle timeout assertion with 30 minute value

### DIFF
--- a/apps/api/test/gc-stall-detection.test.ts
+++ b/apps/api/test/gc-stall-detection.test.ts
@@ -30,8 +30,8 @@ mock.module('@/engines/issue/diagnostic', () => ({
  * 5. Dead processes are terminated immediately
  */
 
-test('idle timeout is configured to 90 minutes', () => {
-  expect(IDLE_TIMEOUT_MS).toBe(90 * 60 * 1000)
+test('idle timeout is configured to 30 minutes', () => {
+  expect(IDLE_TIMEOUT_MS).toBe(30 * 60 * 1000)
 })
 
 // ---------- Mock helpers ----------


### PR DESCRIPTION
## Problem

The backend test suite was red on `main`. Commit `31701c3` (`perf(engines): reduce idle process timeout from 90 to 30 minutes`) lowered `IDLE_TIMEOUT_MS` to 30 minutes but left the assertion in `gc-stall-detection.test.ts` expecting 90 minutes:

```
(fail) idle timeout is configured to 90 minutes
```

## Fix

Update the test name and assertion to match the current 30-minute value.

## Verification

```
bun test --preload ./test/preload.ts test/gc-stall-detection.test.ts
# 15 pass, 0 fail
```
