### PR TITLE
feat(api): add project-scoped issue terminate endpoint

### DIFF
--- a/apps/api/src/openapi/routes.ts
+++ b/apps/api/src/openapi/routes.ts
@@ -395,6 +395,20 @@ export const cancelIssue = createRoute({
   },
 })
 
+export const terminateIssue = createRoute({
+  method: 'post',
+  path: '/{issueId}/terminate',
+  tags: ['Issue Commands'],
+  summary: 'Force-terminate the engine process for an issue',
+  operationId: 'terminateIssue',
+  request: { params: projectIssueParams },
+  responses: {
+    200: successResponse(z.object({ issueId: z.string(), status: z.string() }), 'Terminated'),
+    400: errorResponse('Terminate failed'),
+    404: errorResponse('Issue not found'),
+  },
+})
+
 export const clearIssueSession = createRoute({
   method: 'post',
   path: '/{issueId}/clear-session',

--- a/apps/api/src/routes/issues/command.ts
+++ b/apps/api/src/routes/issues/command.ts
@@ -276,6 +276,36 @@ command.openapi(R.cancelIssue, async (c) => {
   }
 })
 
+// POST /api/projects/:projectId/issues/:issueId/terminate — Force terminate
+command.openapi(R.terminateIssue, async (c) => {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404 as const)
+  }
+
+  const issueId = c.req.param('issueId')!
+  const issue = await getProjectOwnedIssue(project.id, issueId)
+  if (!issue) {
+    return c.json({ success: false, error: 'Issue not found' }, 404 as const)
+  }
+
+  try {
+    await issueEngine.terminateProcess(issueId)
+    return c.json({ success: true, data: { issueId, status: 'terminated' } }, 200 as const)
+  } catch (error) {
+    logger.warn(
+      {
+        projectId: project.id,
+        issueId,
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      },
+      'issue_terminate_failed',
+    )
+    return c.json({ success: false, error: 'Operation failed' }, 400 as const)
+  }
+})
+
 // GET /api/projects/:projectId/issues/:issueId/slash-commands — Get available slash commands
 command.openapi(R.getSlashCommands, async (c) => {
   const projectId = c.req.param('projectId')!

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -334,10 +334,17 @@ general.put(
   zValidator(
     'json',
     z.object({
-      vars: z.record(z.string(), z.string()).refine(
-        obj => Object.keys(obj).length <= 50,
-        { message: 'Maximum 50 environment variables allowed' },
-      ),
+      vars: z.record(z.string(), z.string())
+        .refine(
+          obj => Object.keys(obj).length <= 50,
+          { message: 'Maximum 50 environment variables allowed' },
+        )
+        .refine(
+          obj => Object.entries(obj).every(
+            ([k, v]) => !/[\r\n]/.test(k) && !/[\r\n]/.test(v),
+          ),
+          { message: 'Environment variable keys and values must not contain line breaks' },
+        ),
     }),
     (result, c) => {
       if (!result.success) {

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -421,6 +421,24 @@ export function useCancelIssue(projectId: string) {
   })
 }
 
+export function useTerminateIssue(projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (issueId: string) => kanbanApi.terminateIssue(projectId, issueId),
+    onSuccess: (_data, issueId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issue(projectId, issueId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issues(projectId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.allProcesses(),
+      })
+    },
+  })
+}
+
 export function useSlashCommands(projectId: string, issueId: string, enabled = false) {
   return useQuery({
     queryKey: queryKeys.slashCommands(projectId, issueId),

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -328,6 +328,12 @@ export const kanbanApi = {
       {},
     ),
 
+  terminateIssue: (projectId: string, issueId: string) =>
+    post<{ issueId: string, status: string }>(
+      `/api/projects/${projectId}/issues/${issueId}/terminate`,
+      {},
+    ),
+
   restartIssue: (projectId: string, issueId: string) =>
     post<ExecuteIssueResponse>(`/api/projects/${projectId}/issues/${issueId}/restart`, {}),
 


### PR DESCRIPTION
## Summary

Two small, separable changes from the same session:

1. **Project-scoped issue terminate endpoint** — adds `POST /api/projects/:projectId/issues/:issueId/terminate`, mirroring the existing `cancel` endpoint. It force-kills the engine process for an issue (any process state), sets `sessionStatus: cancelled`, and moves the issue to `review`. Handler verifies project + issue ownership and delegates to the existing `issueEngine.terminateProcess()`. Frontend gets an API client (`terminateIssue`) and a React Query hook (`useTerminateIssue`).

   The pre-existing global endpoint `POST /api/processes/:issueId/terminate` (used by the cross-project process manager) is kept; both call the same engine method.

2. **Reject line breaks in global env vars** — the `PUT /api/settings/global-env-vars` Zod schema now rejects any key/value containing `\r` or `\n`. Env vars are stored as `KEY=VALUE` per line; a value with a newline would be silently mangled on the text-area round-trip.

## Changes

- `apps/api/src/openapi/routes.ts` — new `terminateIssue` route definition
- `apps/api/src/routes/issues/command.ts` — terminate handler
- `apps/api/src/routes/settings/general.ts` — env var newline validation
- `apps/frontend/src/lib/kanban-api.ts` — `terminateIssue` client
- `apps/frontend/src/hooks/use-kanban.ts` — `useTerminateIssue` hook

## Test plan

- [x] ESLint on all changed files
- [x] `tsc --noEmit` for api and frontend
- [x] `api-process-state-regression.test.ts` passes
- [ ] Manually exercise terminate from the issue detail view