### PR TITLE
feat(api): add optional keyset pagination to issue list endpoint

### DIFF
--- a/apps/api/drizzle/0022_chilly_kat_farrell.sql
+++ b/apps/api/drizzle/0022_chilly_kat_farrell.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `issues_project_id_list_order_idx` ON `issues` (`project_id`,`is_deleted`,`is_pinned`,`status_updated_at`,`issue_number`);

--- a/apps/api/drizzle/meta/0022_snapshot.json
+++ b/apps/api/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1336 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2262af48-4d2e-4713-a886-b84541060c17",
+  "prevId": "5f192d5d-c368-4110-a542-2c54dfae84e6",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_issue_id_idx": {
+          "name": "attachments_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "attachments_log_id_idx": {
+          "name": "attachments_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attachments_issue_id_issues_id_fk": {
+          "name": "attachments_issue_id_issues_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_log_id_issues_logs_id_fk": {
+          "name": "attachments_log_id_issues_logs_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cron_job_logs": {
+      "name": "cron_job_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cron_job_logs_job_id_idx": {
+          "name": "cron_job_logs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "cron_job_logs_job_id_started_at_idx": {
+          "name": "cron_job_logs_job_id_started_at_idx",
+          "columns": [
+            "job_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "cron_job_logs_status_idx": {
+          "name": "cron_job_logs_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cron_job_logs_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_logs_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_logs",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cron_jobs": {
+      "name": "cron_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_config": {
+          "name": "task_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "cron_jobs_enabled_idx": {
+          "name": "cron_jobs_enabled_idx",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues_logs": {
+      "name": "issues_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_index": {
+          "name": "entry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_ref_id": {
+          "name": "tool_call_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_issue_id_idx": {
+          "name": "issues_logs_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_turn_entry_idx": {
+          "name": "issues_logs_issue_id_turn_entry_idx",
+          "columns": [
+            "issue_id",
+            "turn_index",
+            "entry_index"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_visible_type_idx": {
+          "name": "issues_logs_issue_id_visible_type_idx",
+          "columns": [
+            "issue_id",
+            "visible",
+            "entry_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_issue_id_issues_id_fk": {
+          "name": "issues_logs_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues": {
+      "name": "issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'a0'"
+        },
+        "parent_issue_id": {
+          "name": "parent_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "keep_alive": {
+          "name": "keep_alive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "engine_type": {
+          "name": "engine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_profile_id": {
+          "name": "engine_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_status": {
+          "name": "session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_project_id_idx": {
+          "name": "issues_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "issues_status_id_idx": {
+          "name": "issues_status_id_idx",
+          "columns": [
+            "status_id"
+          ],
+          "isUnique": false
+        },
+        "issues_parent_issue_id_idx": {
+          "name": "issues_parent_issue_id_idx",
+          "columns": [
+            "parent_issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_status_updated_at_idx": {
+          "name": "issues_project_id_status_updated_at_idx",
+          "columns": [
+            "project_id",
+            "status_updated_at"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_list_order_idx": {
+          "name": "issues_project_id_list_order_idx",
+          "columns": [
+            "project_id",
+            "is_deleted",
+            "is_pinned",
+            "status_updated_at",
+            "issue_number"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_issue_number_uniq": {
+          "name": "issues_project_id_issue_number_uniq",
+          "columns": [
+            "project_id",
+            "issue_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_parent_issue_id_issues_id_fk": {
+          "name": "issues_parent_issue_id_issues_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "issues_status_id_check": {
+          "name": "issues_status_id_check",
+          "value": "\"issues\".\"status_id\" IN ('todo','working','review','done')"
+        }
+      }
+    },
+    "issues_logs_tools_call": {
+      "name": "issues_logs_tools_call",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_result": {
+          "name": "is_result",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_tools_call_log_id_idx": {
+          "name": "issues_logs_tools_call_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_idx": {
+          "name": "issues_logs_tools_call_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_kind_idx": {
+          "name": "issues_logs_tools_call_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_tool_name_idx": {
+          "name": "issues_logs_tools_call_tool_name_idx",
+          "columns": [
+            "tool_name"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_kind_idx": {
+          "name": "issues_logs_tools_call_issue_id_kind_idx",
+          "columns": [
+            "issue_id",
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_tools_call_log_id_issues_logs_id_fk": {
+          "name": "issues_logs_tools_call_log_id_issues_logs_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_logs_tools_call_issue_id_issues_id_fk": {
+          "name": "issues_logs_tools_call_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_engine": {
+          "name": "default_engine",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'a0'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "projects_alias_unique": {
+          "name": "projects_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_created_at_idx": {
+          "name": "webhook_deliveries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_dedup_idx": {
+          "name": "webhook_deliveries_dedup_idx",
+          "columns": [
+            "webhook_id",
+            "dedup_key",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1779410149934,
       "tag": "0021_flowery_rockslide",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1780464320739,
+      "tag": "0022_chilly_kat_farrell",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -83,6 +83,15 @@ export const issues = sqliteTable(
     index('issues_status_id_idx').on(table.statusId),
     index('issues_parent_issue_id_idx').on(table.parentIssueId),
     index('issues_project_id_status_updated_at_idx').on(table.projectId, table.statusUpdatedAt),
+    // Covers the issue-list keyset query: WHERE project_id, is_deleted
+    // ORDER BY is_pinned DESC, status_updated_at DESC, issue_number DESC.
+    index('issues_project_id_list_order_idx').on(
+      table.projectId,
+      table.isDeleted,
+      table.isPinned,
+      table.statusUpdatedAt,
+      table.issueNumber,
+    ),
     check('issues_status_id_check', sql`${table.statusId} IN ('todo','working','review','done')`),
     uniqueIndex('issues_project_id_issue_number_uniq').on(table.projectId, table.issueNumber),
   ],

--- a/apps/api/src/openapi/routes.ts
+++ b/apps/api/src/openapi/routes.ts
@@ -27,6 +27,7 @@ import {
   IssueLogsResponseSchema,
   IssueSchema,
   NoteSchema,
+  paginatedSuccessResponse,
   ProbeResultSchema,
   ProcessCapacitySchema,
   ProcessInfoSchema,
@@ -225,9 +226,17 @@ export const listIssues = createRoute({
   tags: ['Issues'],
   summary: 'List issues in project',
   operationId: 'listIssues',
-  request: { params: projectParam },
+  request: {
+    params: projectParam,
+    query: z.object({
+      // Optional keyset pagination. Omit both to return the full list (default).
+      limit: z.coerce.number().int().min(1).max(200).optional(),
+      cursor: z.string().optional(),
+    }),
+  },
   responses: {
-    200: successResponse(z.array(IssueSchema), 'Issue list'),
+    200: paginatedSuccessResponse(z.array(IssueSchema), 'Issue list'),
+    400: errorResponse('Invalid cursor'),
     404: errorResponse('Project not found'),
   },
 })

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -27,6 +27,23 @@ export function successResponse(dataSchema: z.ZodType, description: string) {
   } as const
 }
 
+/** Success envelope for keyset-paginated lists (adds nextCursor/hasMore). */
+export function paginatedSuccessResponse(dataSchema: z.ZodType, description: string) {
+  return {
+    description,
+    content: {
+      'application/json': {
+        schema: z.object({
+          success: z.literal(true),
+          data: dataSchema,
+          nextCursor: z.string().nullable(),
+          hasMore: z.boolean(),
+        }),
+      },
+    },
+  } as const
+}
+
 /** Standard error envelope (reused across all error responses) */
 export const errorSchema = z.object({
   success: z.literal(false),

--- a/apps/api/src/routes/issues/query.ts
+++ b/apps/api/src/routes/issues/query.ts
@@ -1,14 +1,64 @@
-import { and, desc, eq } from 'drizzle-orm'
+import type { SQL } from 'drizzle-orm'
+import { and, desc, eq, lt, or } from 'drizzle-orm'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
 import { createOpenAPIRouter } from '@/openapi/hono'
 import * as R from '@/openapi/routes'
+import type { IssueRow } from './_shared'
 import { getProjectOwnedIssue, serializeIssue } from './_shared'
 
 const query = createOpenAPIRouter()
 
-// GET /api/projects/:projectId/issues — List issues
+// Keyset cursor for the (isPinned DESC, statusUpdatedAt DESC, issueNumber DESC)
+// ordering. statusUpdatedAt is stored at second resolution; issueNumber is the
+// unique tiebreaker that makes the ordering total.
+interface IssueCursor { p: number, t: number, n: number }
+
+function encodeCursor(row: IssueRow): string {
+  const payload: IssueCursor = {
+    p: row.isPinned ? 1 : 0,
+    t: Math.floor(row.statusUpdatedAt.getTime() / 1000),
+    n: row.issueNumber,
+  }
+  return Buffer.from(JSON.stringify(payload)).toString('base64url')
+}
+
+function decodeCursor(raw: string): IssueCursor | null {
+  try {
+    const obj = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown
+    if (
+      obj && typeof obj === 'object'
+      && typeof (obj as IssueCursor).p === 'number'
+      && typeof (obj as IssueCursor).t === 'number'
+      && typeof (obj as IssueCursor).n === 'number'
+    ) {
+      return obj as IssueCursor
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// Rows strictly "after" the cursor under the DESC ordering.
+function keysetCondition(cur: IssueCursor): SQL | undefined {
+  const pinned = cur.p === 1
+  const date = new Date(cur.t * 1000)
+  return or(
+    lt(issuesTable.isPinned, pinned),
+    and(eq(issuesTable.isPinned, pinned), lt(issuesTable.statusUpdatedAt, date)),
+    and(
+      eq(issuesTable.isPinned, pinned),
+      eq(issuesTable.statusUpdatedAt, date),
+      lt(issuesTable.issueNumber, cur.n),
+    ),
+  )
+}
+
+// GET /api/projects/:projectId/issues — List issues.
+// Without `limit`, returns the full list (default). With `limit`, returns a
+// keyset page plus `nextCursor`/`hasMore`; pass `cursor` to fetch the next page.
 query.openapi(R.listIssues, async (c) => {
   const projectId = c.req.param('projectId')!
   const project = await findProject(projectId)
@@ -16,18 +66,49 @@ query.openapi(R.listIssues, async (c) => {
     return c.json({ success: false, error: 'Project not found' }, 404 as const)
   }
 
-  const rows = await db
+  const { limit, cursor } = c.req.valid('query')
+
+  let keyset: SQL | undefined
+  if (cursor) {
+    const decoded = decodeCursor(cursor)
+    if (!decoded) {
+      return c.json({ success: false, error: 'Invalid cursor' }, 400 as const)
+    }
+    keyset = keysetCondition(decoded)
+  }
+
+  const where = and(
+    eq(issuesTable.projectId, project.id),
+    eq(issuesTable.isDeleted, 0),
+    keyset,
+  )
+
+  let q = db
     .select()
     .from(issuesTable)
-    .where(and(
-      eq(issuesTable.projectId, project.id),
-      eq(issuesTable.isDeleted, 0),
-    ))
-    .orderBy(desc(issuesTable.isPinned), desc(issuesTable.statusUpdatedAt))
+    .where(where)
+    .orderBy(
+      desc(issuesTable.isPinned),
+      desc(issuesTable.statusUpdatedAt),
+      desc(issuesTable.issueNumber),
+    )
+    .$dynamic()
+
+  // Over-fetch by one to detect whether a further page exists.
+  if (limit !== undefined) {
+    q = q.limit(limit + 1)
+  }
+
+  const rows = await q
+  const hasMore = limit !== undefined && rows.length > limit
+  const pageRows = hasMore ? rows.slice(0, limit) : rows
+  const nextCursor = hasMore ? encodeCursor(pageRows[pageRows.length - 1]!) : null
 
   return c.json({
     success: true,
-    data: rows.map(r => serializeIssue(r)),
+    data: pageRows.map(r => serializeIssue(r)),
+    nextCursor,
+    hasMore,
   }, 200 as const)
 })
 

--- a/apps/api/test/api-issues-pagination.test.ts
+++ b/apps/api/test/api-issues-pagination.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, test } from 'bun:test'
+import app from '@/app'
+import { createTestProject, patch, post } from './helpers'
+/**
+ * Keyset pagination for GET /api/projects/:projectId/issues.
+ */
+import './setup'
+
+interface IssueLite { id: string, issueNumber: number, isPinned: boolean }
+interface ListResponse {
+  success: boolean
+  data: IssueLite[]
+  nextCursor: string | null
+  hasMore: boolean
+  error?: string
+}
+
+async function listIssues(pid: string, qs = ''): Promise<{ status: number, json: ListResponse }> {
+  const res = await app.request(`http://localhost/api/projects/${pid}/issues${qs}`)
+  const json = (await res.json()) as ListResponse
+  return { status: res.status, json }
+}
+
+async function collectAllPages(pid: string, limit: number): Promise<string[]> {
+  const collected: string[] = []
+  let cursor: string | null = null
+  let guard = 0
+  do {
+    const qs = `?limit=${limit}${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+    const { json } = await listIssues(pid, qs)
+    expect(json.data.length).toBeLessThanOrEqual(limit)
+    collected.push(...json.data.map(i => i.id))
+    cursor = json.nextCursor
+    if (++guard > 50) throw new Error('pagination did not terminate')
+  } while (cursor)
+  return collected
+}
+
+const TOTAL = 5
+let projectId: string
+
+beforeAll(async () => {
+  projectId = await createTestProject('Pagination Test Project')
+  for (let i = 0; i < TOTAL; i++) {
+    await post(`/api/projects/${projectId}/issues`, { title: `Issue ${i}`, statusId: 'todo' })
+  }
+})
+
+describe('GET /api/projects/:projectId/issues — pagination', () => {
+  test('without limit returns the full list (backward compatible)', async () => {
+    const { status, json } = await listIssues(projectId)
+    expect(status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.data.length).toBe(TOTAL)
+    expect(json.hasMore).toBe(false)
+    expect(json.nextCursor).toBeNull()
+  })
+
+  test('limit caps the page and sets hasMore + nextCursor', async () => {
+    const { json } = await listIssues(projectId, '?limit=2')
+    expect(json.data.length).toBe(2)
+    expect(json.hasMore).toBe(true)
+    expect(json.nextCursor).toBeTruthy()
+  })
+
+  test('keyset traversal yields every issue once, in the full-list order', async () => {
+    const full = (await listIssues(projectId)).json.data.map(i => i.id)
+    const collected = await collectAllPages(projectId, 2)
+    expect(collected).toEqual(full)
+    expect(new Set(collected).size).toBe(TOTAL)
+  })
+
+  test('pinned issues sort first and pagination stays consistent', async () => {
+    const before = (await listIssues(projectId)).json.data
+    const target = before[before.length - 1]! // an older issue, currently last
+    await patch(`/api/projects/${projectId}/issues/${target.id}`, { isPinned: true })
+
+    const full = (await listIssues(projectId)).json.data
+    expect(full[0]!.id).toBe(target.id)
+    expect(full[0]!.isPinned).toBe(true)
+
+    const collected = await collectAllPages(projectId, 2)
+    expect(collected).toEqual(full.map(i => i.id))
+  })
+
+  test('invalid cursor returns 400', async () => {
+    const { status, json } = await listIssues(projectId, '?limit=2&cursor=%%%not-valid%%%')
+    expect(status).toBe(400)
+    expect(json.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

`GET /api/projects/:projectId/issues` previously ignored `?limit=` and always returned **all** non-deleted issues for the project (no `LIMIT`, no pagination). For projects with hundreds/thousands of issues this loads the entire set every request.

This adds **optional keyset pagination** while staying fully backward compatible.

## Behavior

- **No params** → returns the full list exactly as before. `hasMore: false`, `nextCursor: null`.
- **`?limit=N`** (1–200) → returns a page of N, plus `nextCursor` and `hasMore`.
- **`?limit=N&cursor=...`** → returns the next page.
- Malformed `cursor` → `400 Invalid cursor`.

Ordering is `isPinned DESC, statusUpdatedAt DESC, issueNumber DESC` — `issueNumber` is the unique tiebreaker that makes the keyset ordering total (previously ties were non-deterministic). The cursor encodes `(isPinned, statusUpdatedAt seconds, issueNumber)` as base64url.

The response keeps the `{ success, data }` envelope and adds sibling `nextCursor`/`hasMore` fields. The frontend API client reads `.data`, so the **kanban board and project stats are unaffected** — they continue to load the full list (which they need for column grouping / counts). No frontend changes.

## Changes

- `apps/api/src/openapi/routes.ts` — `listIssues` gains `limit`/`cursor` query params + paginated response schema
- `apps/api/src/openapi/schemas.ts` — `paginatedSuccessResponse` helper (mirrors `successResponse`)
- `apps/api/src/routes/issues/query.ts` — keyset pagination handler with cursor encode/decode
- `apps/api/test/api-issues-pagination.test.ts` — new tests

## Test plan

- [x] `api-issues-pagination.test.ts` (5 tests): full list, limit page, full keyset traversal (no dupes/gaps), pinned-first ordering, invalid cursor → 400
- [x] Related suites pass (api-issues, reconciler, db-repair, api-pending-messages) — no regression
- [x] ESLint + `tsc --noEmit` clean