### PR TITLE
refactor: use nanoid id as the only resource identifier in URLs and API

### DIFF
--- a/apps/api/src/db/helpers.ts
+++ b/apps/api/src/db/helpers.ts
@@ -12,39 +12,26 @@ type ProjectRow = typeof projectsTable.$inferSelect
 
 const PROJECT_CACHE_TTL = 60 // seconds
 
-export async function findProject(param: string) {
-  // Check cache first (param could be ID or alias)
-  const cacheKey = `project:lookup:${param}`
+export async function findProject(id: string) {
+  // Resolve strictly by nanoid id (alias is a display field, never an identifier)
+  const cacheKey = `project:lookup:${id}`
   const cached = await cacheGet<ProjectRow>(cacheKey)
   if (cached) return cached
 
-  // Single query: match by ID or alias
   const [row] = await db
     .select()
     .from(projectsTable)
-    .where(
-      and(
-        sql`(${projectsTable.id} = ${param} OR ${projectsTable.alias} = ${param})`,
-        eq(projectsTable.isDeleted, 0),
-      ),
-    )
+    .where(and(eq(projectsTable.id, id), eq(projectsTable.isDeleted, 0)))
 
   if (row) {
-    // Cache under both ID and alias keys
     await cacheSet(`project:lookup:${row.id}`, row, PROJECT_CACHE_TTL)
-    if (row.alias) {
-      await cacheSet(`project:lookup:${row.alias}`, row, PROJECT_CACHE_TTL)
-    }
   }
 
   return row
 }
 
-export async function invalidateProjectCache(id: string, alias?: string | null): Promise<void> {
+export async function invalidateProjectCache(id: string): Promise<void> {
   await cacheDel(`project:lookup:${id}`)
-  if (alias) {
-    await cacheDel(`project:lookup:${alias}`)
-  }
 }
 
 /**

--- a/apps/api/src/routes/cron.ts
+++ b/apps/api/src/routes/cron.ts
@@ -12,21 +12,24 @@ import type { TaskConfig } from '@/cron/executor'
 
 const cronRoute = createOpenAPIRouter()
 
-/** Find a non-deleted job by ID or name */
-function findJob(identifier: string) {
-  const [byId] = db
+/** Find a non-deleted job strictly by nanoid id (name is a display field, never an identifier) */
+function findJob(id: string) {
+  const [row] = db
     .select()
     .from(cronJobs)
-    .where(and(eq(cronJobs.isDeleted, 0), eq(cronJobs.id, identifier)))
+    .where(and(eq(cronJobs.isDeleted, 0), eq(cronJobs.id, id)))
     .all()
-  if (byId) return byId
+  return row ?? null
+}
 
-  const [byName] = db
-    .select()
+/** Check whether a non-deleted job with the given name already exists */
+function jobNameExists(name: string): boolean {
+  const [row] = db
+    .select({ id: cronJobs.id })
     .from(cronJobs)
-    .where(and(eq(cronJobs.isDeleted, 0), eq(cronJobs.name, identifier)))
+    .where(and(eq(cronJobs.isDeleted, 0), eq(cronJobs.name, name)))
     .all()
-  return byName ?? null
+  return !!row
 }
 
 // GET /api/cron/actions — list available cron actions (must be before /:param routes)
@@ -97,7 +100,7 @@ cronRoute.openapi(R.createCronJob, async (c) => {
   const { name, cron, action, config: rawConfig } = c.req.valid('json')
 
   // Check name uniqueness
-  if (findJob(name)) {
+  if (jobNameExists(name)) {
     return c.json({ success: false, error: `Job with name "${name}" already exists` }, 409 as const)
   }
 

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -163,7 +163,7 @@ projects.openapi(R.sortProject, async (c) => {
     .update(projectsTable)
     .set({ sortOrder })
     .where(eq(projectsTable.id, existing.id))
-  await invalidateProjectCache(existing.id, existing.alias)
+  await invalidateProjectCache(existing.id)
   return c.json({ success: true, data: null }, 200 as const)
 })
 
@@ -222,7 +222,7 @@ projects.openapi(R.updateProject, async (c) => {
   }
 
   // Invalidate cache for old ID and alias before updating
-  await invalidateProjectCache(existing.id, existing.alias)
+  await invalidateProjectCache(existing.id)
 
   const [row] = await db
     .update(projectsTable)
@@ -300,7 +300,7 @@ projects.openapi(R.deleteProject, async (c) => {
   })
 
   // Invalidate caches
-  await invalidateProjectCache(existing.id, existing.alias)
+  await invalidateProjectCache(existing.id)
   await cacheDelByPrefix(`projectIssueIds:${existing.id}`)
 
   logger.info({ projectId: existing.id }, 'project_deleted')
@@ -321,7 +321,7 @@ projects.openapi(R.archiveProject, async (c) => {
     .set({ isArchived: 1 })
     .where(eq(projectsTable.id, existing.id))
     .returning()
-  await invalidateProjectCache(existing.id, existing.alias)
+  await invalidateProjectCache(existing.id)
   logger.info({ projectId: existing.id }, 'project_archived')
   return c.json({ success: true, data: serializeProject(row!) }, 200 as const)
 })
@@ -339,7 +339,7 @@ projects.openapi(R.unarchiveProject, async (c) => {
     .set({ isArchived: 0 })
     .where(eq(projectsTable.id, existing.id))
     .returning()
-  await invalidateProjectCache(existing.id, existing.alias)
+  await invalidateProjectCache(existing.id)
   logger.info({ projectId: existing.id }, 'project_unarchived')
   return c.json({ success: true, data: serializeProject(row!) }, 200 as const)
 })

--- a/apps/api/test/api-projects.test.ts
+++ b/apps/api/test/api-projects.test.ts
@@ -94,17 +94,20 @@ describe('GET /api/projects/:id', () => {
     expect(data.name).toBe('GetById')
   })
 
-  test('gets a project by alias', async () => {
+  test('does not resolve a project by alias (id-only)', async () => {
     const created = expectSuccess(
       await post<Project>('/api/projects', {
         name: 'GetByAlias',
         alias: 'byalias',
       }),
     )
-    const result = await get<Project>(`/api/projects/${created.alias}`)
-    expect(result.status).toBe(200)
-    const data = expectSuccess(result)
-    expect(data.id).toBe(created.id)
+    // Alias is a display field, never an identifier — lookup by alias must 404
+    const byAlias = await get<Project>(`/api/projects/${created.alias}`)
+    expect(byAlias.status).toBe(404)
+    // The same project still resolves by its nanoid id
+    const byId = await get<Project>(`/api/projects/${created.id}`)
+    expect(byId.status).toBe(200)
+    expect(expectSuccess(byId).id).toBe(created.id)
   })
 
   test('returns 404 for nonexistent project', async () => {

--- a/apps/frontend/src/components/issue-detail/ReviewListPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/ReviewListPanel.tsx
@@ -42,7 +42,6 @@ export function ReviewListPanel({
       {
         projectId: string
         projectName: string
-        projectAlias: string
         issues: ReviewIssue[]
       }
     >()
@@ -54,7 +53,6 @@ export function ReviewListPanel({
         map.set(issue.projectId, {
           projectId: issue.projectId,
           projectName: issue.projectName,
-          projectAlias: issue.projectAlias,
           issues: [issue],
         })
       }
@@ -119,12 +117,12 @@ export function ReviewListPanel({
                   <ProjectGroup
                     key={group.projectId}
                     projectName={group.projectName}
-                    projectAlias={group.projectAlias}
+                    projectId={group.projectId}
                     issues={group.issues}
                     isCollapsed={!!collapsed[group.projectId]}
                     onToggle={() => toggleCollapse(group.projectId)}
                     activeIssueId={activeIssueId}
-                    onNavigate={(projectAlias, issueId) => navigate(`/review/${projectAlias}/${issueId}`)}
+                    onNavigate={(projectId, issueId) => navigate(`/review/${projectId}/${issueId}`)}
                   />
                 ))
               )}
@@ -146,7 +144,7 @@ export function ReviewListPanel({
 
 function ProjectGroup({
   projectName,
-  projectAlias,
+  projectId,
   issues,
   isCollapsed,
   onToggle,
@@ -154,12 +152,12 @@ function ProjectGroup({
   onNavigate,
 }: {
   projectName: string
-  projectAlias: string
+  projectId: string
   issues: ReviewIssue[]
   isCollapsed: boolean
   onToggle: () => void
   activeIssueId: string
-  onNavigate: (projectAlias: string, issueId: string) => void
+  onNavigate: (projectId: string, issueId: string) => void
 }) {
   const reviewColor = '#f59e0b' // amber — matches review status color
 
@@ -194,7 +192,7 @@ function ProjectGroup({
                   key={issue.id}
                   issue={issue}
                   isActive={issue.id === activeIssueId}
-                  onNavigate={() => onNavigate(projectAlias, issue.id)}
+                  onNavigate={() => onNavigate(projectId, issue.id)}
                 />
               ))}
             </div>

--- a/apps/frontend/src/components/kanban/AppSidebar.tsx
+++ b/apps/frontend/src/components/kanban/AppSidebar.tsx
@@ -93,7 +93,7 @@ export function AppSidebar({ activeProjectId }: { activeProjectId: string }) {
   const handleProjectCreated = useCallback(
     (project: Project) => {
       setShowCreate(false)
-      void navigate(projectPath(project.alias))
+      void navigate(projectPath(project.id))
     },
     [navigate, projectPath],
   )
@@ -122,8 +122,8 @@ export function AppSidebar({ activeProjectId }: { activeProjectId: string }) {
           <ProjectButton
             key={project.id}
             project={project}
-            isActive={activeProjectId === project.alias}
-            onClick={() => navigate(projectPath(project.alias))}
+            isActive={activeProjectId === project.id}
+            onClick={() => navigate(projectPath(project.id))}
           />
         ))}
       </div>

--- a/apps/frontend/src/components/kanban/KanbanHeader.tsx
+++ b/apps/frontend/src/components/kanban/KanbanHeader.tsx
@@ -48,7 +48,7 @@ export function KanbanHeader({
           {project.directory && (
             <button
               type="button"
-              onClick={() => toggleFileBrowser(project.alias, project.directory ?? undefined)}
+              onClick={() => toggleFileBrowser(project.id, project.directory ?? undefined)}
               className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.07] transition-colors shrink-0"
               aria-label={t('viewMode.files')}
               title={t('viewMode.files')}

--- a/apps/frontend/src/components/kanban/MobileSidebar.tsx
+++ b/apps/frontend/src/components/kanban/MobileSidebar.tsx
@@ -44,7 +44,7 @@ export function MobileSidebar({ activeProjectId }: { activeProjectId: string }) 
     (project: Project) => {
       setShowCreate(false)
       setOpen(false)
-      void navigate(mobileProjectPath(project.alias))
+      void navigate(mobileProjectPath(project.id))
     },
     [navigate, mobileProjectPath],
   )
@@ -78,14 +78,14 @@ export function MobileSidebar({ activeProjectId }: { activeProjectId: string }) 
             </div>
             <div className="flex-1 overflow-y-auto px-2" style={{ scrollbarWidth: 'none' }}>
               {projects?.map((project) => {
-                const isActive = activeProjectId === project.alias
+                const isActive = activeProjectId === project.id
                 return (
                   <button
                     key={project.id}
                     type="button"
                     onClick={() => {
                       setOpen(false)
-                      void navigate(mobileProjectPath(project.alias))
+                      void navigate(mobileProjectPath(project.id))
                     }}
                     className={`flex items-center gap-3 w-full px-2 min-h-[44px] rounded-md text-left transition-colors ${
                       isActive ?

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -80,7 +80,7 @@ function ProcessCard({ proc }: { proc: ProcessInfo }) {
         <button
           type="button"
           className="text-xs font-medium text-foreground truncate hover:underline cursor-pointer text-left min-w-0"
-          onClick={() => navigate(`/projects/${proc.projectAlias}/issues/${proc.issueId}`)}
+          onClick={() => navigate(`/projects/${proc.projectId}/issues/${proc.issueId}`)}
         >
           <span className="text-muted-foreground">
             #

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -216,7 +216,7 @@ if (!rootElement.innerHTML) {
                   )}
                 />
                 <Route
-                  path="/review/:projectAlias/:issueId"
+                  path="/review/:projectId/:issueId"
                   element={(
                     <ErrorBoundary>
                       <ReviewPage />

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -184,7 +184,7 @@ function SortableProjectCard({
 
 /* -- Archived projects section ------------------------- */
 
-function ArchivedProjectsSection({ projectPath }: { projectPath: (alias: string) => string }) {
+function ArchivedProjectsSection({ projectPath }: { projectPath: (projectId: string) => string }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [expanded, setExpanded] = useState(false)
@@ -243,7 +243,7 @@ function ArchivedProjectsSection({ projectPath }: { projectPath: (alias: string)
           >
             <Card
               className="h-full bg-card/40 hover:bg-card/60 cursor-pointer transition-all hover:shadow-md group opacity-70 hover:opacity-100"
-              onClick={() => navigate(projectPath(project.alias))}
+              onClick={() => navigate(projectPath(project.id))}
             >
               <CardHeader>
                 <div className="flex items-start gap-3">
@@ -552,7 +552,7 @@ export default function HomePage() {
 
   // Mobile always uses list mode
   const projectPath = useCallback(
-    (alias: string) => (isMobile ? `/projects/${alias}/issues` : globalProjectPath(alias)),
+    (projectId: string) => (isMobile ? `/projects/${projectId}/issues` : globalProjectPath(projectId)),
     [isMobile, globalProjectPath],
   )
 
@@ -619,7 +619,7 @@ export default function HomePage() {
                     key={project.id}
                     project={project}
                     index={index}
-                    onClick={() => navigate(projectPath(project.alias))}
+                    onClick={() => navigate(projectPath(project.id))}
                   />
                 ))}
               </div>

--- a/apps/frontend/src/pages/ReviewPage.tsx
+++ b/apps/frontend/src/pages/ReviewPage.tsx
@@ -20,16 +20,16 @@ const MAX_LIST_WIDTH = 400
 
 export default function ReviewPage() {
   const { t } = useTranslation()
-  const { projectAlias = '', issueId = '' } = useParams<{
-    projectAlias: string
+  const { projectId: projectIdParam = '', issueId = '' } = useParams<{
+    projectId: string
     issueId: string
   }>()
 
   const { data: reviewIssues } = useReviewIssues()
 
-  // Find the matching issue to get its projectId (alias)
+  // Prefer the resolved issue's projectId; fall back to the URL param
   const activeIssue = reviewIssues?.find(i => i.id === issueId)
-  const projectId = activeIssue?.projectAlias ?? projectAlias
+  const projectId = activeIssue?.projectId ?? projectIdParam
 
   const [showDiff, setShowDiff] = useState(false)
   const [diffWidth, setDiffWidth] = useState(DEFAULT_DIFF_WIDTH)

--- a/docs/task/UI-003.md
+++ b/docs/task/UI-003.md
@@ -1,0 +1,55 @@
+# UI-003 Use nanoid id as the only resource identifier in URLs and API
+
+- **status**: completed
+- **priority**: P2
+- **owner**: roy
+- **createdAt**: 2026-06-03 00:00
+
+## Description
+
+URLs mixed two kinds of identifiers: projects were addressed by their
+human-readable `alias` while issues/cron/attachments already used their
+nanoid/ULID `id`. The backend `findProject` (id OR alias) and cron `findJob`
+(id OR name) accepted both forms, producing inconsistent, "messy" URLs such as
+`/projects/<alias>/issues/<nanoid>`.
+
+Unify on the nanoid `id` everywhere:
+
+- **Frontend**: build every project URL from `project.id`; the `/review` route
+  param becomes `:projectId` (was `:projectAlias`) and navigation uses
+  `issue.projectId`; process list navigates with `proc.projectId`; active-project
+  highlight compares against `project.id`; file-browser drawer opens with
+  `project.id`.
+- **Backend (strict id-only, no dual lookup)**: `findProject` matches by `id`
+  only; cron `findJob` matches by `id` only. The create-cron name-uniqueness
+  check queries `cronJobs.name` directly instead of borrowing the resolver.
+  Scheduler-internal name keys (`syncJob`, `ensureDefaultJobs`, Baker
+  `add/remove/bake`) are legitimate and unchanged.
+
+`alias` (project) and `name` (cron) remain as display/uniqueness fields; they are
+no longer accepted as URL/API identifiers.
+
+Acceptance criteria:
+
+- Navigating the sidebar / home / process list / review yields URLs whose project
+  segment is the nanoid `id`, never the alias.
+- `GET /api/projects/<alias>` returns 404; `GET /api/projects/<id>` returns 200.
+- Cron pause/resume/run/logs/delete resolve by `id` only.
+- Creating a cron job with a duplicate name still returns 409.
+- `bun run lint`, `bun run typecheck`, `bun run test:api`, `bun run test:frontend`
+  pass.
+
+## ActiveForm
+
+Unifying URL/API identifiers on nanoid id and removing backend dual lookup.
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+No DB schema change, no migration. Breaking change for external API callers that
+addressed projects by alias or cron jobs by name (e.g. the bkd skill) — they must
+switch to id. Old alias bookmarks will 404 (intentional, per strict id-only).

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -64,3 +64,4 @@ Each task is a single line linking to its detail file. All detailed information 
 - [x] [**ENG-017 Fix PID-lock false "another instance running" on PID reuse**](ENG-017.md) `P1`
 - [x] [**ENG-018 Extract base64 image data-URIs from engine messages to attachments**](ENG-018.md) `P1`
 - [x] [**ENG-019 Normalize assistant image content blocks (Bifrost) to attachments**](ENG-019.md) `P1`
+- [x] [**UI-003 Use nanoid id as the only resource identifier in URLs and API**](UI-003.md) `P2`


### PR DESCRIPTION
## Summary

URLs mixed two kinds of identifiers: projects were addressed by their human-readable `alias` while issues, cron jobs and attachments already used their nanoid/ULID `id` — producing inconsistent URLs like `/projects/<alias>/issues/<nanoid>`. This unifies everything on the nanoid `id`.

### Backend — strict id-only, no dual lookup
- `findProject` resolves by `id` only (was `id OR alias`); cache keyed by `id`. `invalidateProjectCache` drops the alias arg.
- cron `findJob` resolves by `id` only (was `id OR name`). Create-time name-uniqueness now uses a dedicated `jobNameExists` query instead of borrowing the resolver.
- Scheduler-internal name keys (`syncJob`, `ensureDefaultJobs`, Baker `add/remove/bake`) are legitimate internal keys and remain unchanged.

### Frontend — always `project.id`
- Sidebar, mobile sidebar, home page, kanban header, process list: navigate and highlight by `project.id`.
- `/review` route param renamed `:projectAlias` → `:projectId`; navigation uses `issue.projectId`.

`alias` (project) and `name` (cron) remain display / uniqueness fields — they are no longer accepted as URL/API identifiers.

### Scope check (which entities were affected)
- **Projects** — the only real offender (URL used alias) → fixed.
- **Attachments** — already ULID `id` in URLs → no change.
- **Cron** — frontend already used `job.id`; only the backend name fallback was removed.
- **Issues** — already nanoid `id` only → no change.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `tsc` (frontend + api) — 0 errors
- [x] `bun run test:api` — 547 pass / 0 fail
- [x] `bun run test:frontend` — 40 pass / 0 fail
- [x] `api-projects.test.ts` updated: lookup by alias now 404s, lookup by id 200s

## ⚠️ Breaking change
The API no longer resolves projects by alias or cron jobs by name. Callers (including the bkd skill / MCP) must use the nanoid `id`; old alias-based URLs now return 404.

Closes task UI-003.