### PR TITLE
fix(frontend): show unarchive action in settings for archived projects

### DIFF
--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -1,5 +1,6 @@
 import {
   Archive,
+  ArchiveRestore,
   Check,
   ChevronDown,
   Copy,
@@ -57,6 +58,7 @@ import {
   useEngineProfiles,
   useEngineSettings,
   useProjectWorktrees,
+  useUnarchiveProject,
   useUpdateProject,
 } from '@/hooks/use-kanban'
 import { formatModelName } from '@/lib/format'
@@ -273,6 +275,7 @@ export function ProjectSettingsDialog({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const updateProject = useUpdateProject()
   const archiveProject = useArchiveProject()
+  const unarchiveProject = useUnarchiveProject()
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -364,22 +367,40 @@ export function ProjectSettingsDialog({
                     <Button variant="destructive" size="sm" onClick={() => setDeleteDialogOpen(true)}>
                       {t('project.delete')}
                     </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        archiveProject.mutate(project.id, {
-                          onSuccess: () => {
-                            onOpenChange(false)
-                            void navigate('/')
-                          },
-                        })
-                      }}
-                      disabled={archiveProject.isPending}
-                    >
-                      <Archive className="size-4" />
-                      {archiveProject.isPending ? t('project.archiving') : t('project.archive')}
-                    </Button>
+                    {project.isArchived ?
+                        (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              unarchiveProject.mutate(project.id, {
+                                onSuccess: () => onOpenChange(false),
+                              })
+                            }}
+                            disabled={unarchiveProject.isPending}
+                          >
+                            <ArchiveRestore className="size-4" />
+                            {unarchiveProject.isPending ? t('project.unarchiving') : t('project.unarchive')}
+                          </Button>
+                        ) :
+                        (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              archiveProject.mutate(project.id, {
+                                onSuccess: () => {
+                                  onOpenChange(false)
+                                  void navigate('/')
+                                },
+                              })
+                            }}
+                            disabled={archiveProject.isPending}
+                          >
+                            <Archive className="size-4" />
+                            {archiveProject.isPending ? t('project.archiving') : t('project.archive')}
+                          </Button>
+                        )}
                   </div>
                   <div className="flex gap-2">
                     <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -70,6 +70,7 @@
     "archive": "Archive",
     "archiving": "Archiving...",
     "unarchive": "Unarchive",
+    "unarchiving": "Unarchiving...",
     "archivedProjects": "Archived Projects",
     "noArchivedProjects": "No archived projects."
   },

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -70,6 +70,7 @@
     "archive": "归档",
     "archiving": "归档中...",
     "unarchive": "取消归档",
+    "unarchiving": "取消归档中...",
     "archivedProjects": "已归档项目",
     "noArchivedProjects": "暂无已归档项目。"
   },


### PR DESCRIPTION
## Summary
- The footer of the project settings dialog always rendered an **Archive** button, even when the project was already archived.
- When `project.isArchived` is true, the dialog now shows an **Unarchive** button (`ArchiveRestore` icon) wired to the existing `useUnarchiveProject` hook; on success it closes the dialog and stays on the current page.
- Active projects keep the existing behavior: archive, close the dialog, and navigate back to the home page.
- Added the missing `project.unarchiving` pending label to both `en.json` and `zh.json` (`unarchive` already existed).

## Testing
- `bun run test:frontend` — 40 tests pass
- `tsc --noEmit` — clean
- ESLint — no new issues