### PR TITLE
feat(engines): show model-scoped (Fable) usage windows in settings (ENG-021)

### DIFF
--- a/apps/api/src/engines/executors/claude/usage.ts
+++ b/apps/api/src/engines/executors/claude/usage.ts
@@ -1,4 +1,4 @@
-import type { ClaudeUsage, ClaudeUsageWindow } from '@bkd/shared'
+import type { ClaudeUsage, ClaudeUsageModelWindow, ClaudeUsageWindow } from '@bkd/shared'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '@/logger'
@@ -34,6 +34,30 @@ function parseWindow(raw: unknown): ClaudeUsageWindow | null {
     usedPercentage: pct,
     resetsAt: typeof w.resets_at === 'string' ? w.resets_at : null,
   }
+}
+
+/**
+ * Extract model-scoped weekly windows (e.g. Fable) from the upstream `limits`
+ * array. Malformed entries are dropped; never throws.
+ */
+export function parseModelWindows(raw: unknown): ClaudeUsageModelWindow[] {
+  if (!Array.isArray(raw)) return []
+  const windows: ClaudeUsageModelWindow[] = []
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue
+    const l = entry as Record<string, unknown>
+    if (l.kind !== 'weekly_scoped') continue
+    const scope = l.scope as Record<string, unknown> | null | undefined
+    const model = (scope?.model as Record<string, unknown> | null | undefined)?.display_name
+    if (typeof model !== 'string' || model.length === 0) continue
+    if (typeof l.percent !== 'number') continue
+    windows.push({
+      model,
+      usedPercentage: l.percent,
+      resetsAt: typeof l.resets_at === 'string' ? l.resets_at : null,
+    })
+  }
+  return windows
 }
 
 /**
@@ -79,6 +103,7 @@ export async function getClaudeUsage(): Promise<ClaudeUsage> {
       available: true,
       fiveHour: parseWindow(json.five_hour),
       sevenDay: parseWindow(json.seven_day),
+      modelWindows: parseModelWindows(json.limits),
     }
   } catch (error) {
     logger.warn({ error }, 'claude_usage_parse_failed')

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -327,11 +327,18 @@ const ClaudeUsageWindowSchema = z.object({
   resetsAt: z.string().nullable(),
 }).nullable()
 
+const ClaudeUsageModelWindowSchema = z.object({
+  model: z.string(),
+  usedPercentage: z.number(),
+  resetsAt: z.string().nullable(),
+})
+
 export const ClaudeUsageSchema = z.object({
   available: z.boolean(),
   reason: z.enum(['no_credentials', 'api_key_mode', 'token_expired', 'upstream_error']).optional(),
   fiveHour: ClaudeUsageWindowSchema.optional(),
   sevenDay: ClaudeUsageWindowSchema.optional(),
+  modelWindows: z.array(ClaudeUsageModelWindowSchema).optional(),
 }).openapi('ClaudeUsage')
 
 // ── Cron schemas ───────────────────────────────────────

--- a/apps/api/test/claude-usage.test.ts
+++ b/apps/api/test/claude-usage.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { getClaudeUsage } from '@/engines/executors/claude/usage'
+import { getClaudeUsage, parseModelWindows } from '@/engines/executors/claude/usage'
 
 /**
  * Offline degradation tests for the Claude usage proxy. Points HOME at an empty
@@ -40,5 +40,33 @@ describe('getClaudeUsage (offline degradation)', () => {
     const usage = await getClaudeUsage()
     expect(usage.available).toBe(false)
     expect(usage.reason).toBe('api_key_mode')
+  })
+})
+
+describe('parseModelWindows', () => {
+  // Shape observed in a live probe of GET /api/oauth/usage (2026-07-17)
+  const limits = [
+    { kind: 'session', group: 'session', percent: 6, severity: 'normal', resets_at: '2026-07-17T15:00:00Z', scope: null, is_active: false },
+    { kind: 'weekly_all', group: 'weekly', percent: 19, severity: 'normal', resets_at: '2026-07-20T00:00:00Z', scope: null, is_active: true },
+    { kind: 'weekly_scoped', group: 'weekly', percent: 17, severity: 'normal', resets_at: '2026-07-20T00:00:00Z', scope: { model: { id: null, display_name: 'Fable' }, surface: null }, is_active: false },
+  ]
+
+  test('extracts model-scoped weekly windows only', () => {
+    expect(parseModelWindows(limits)).toEqual([
+      { model: 'Fable', usedPercentage: 17, resetsAt: '2026-07-20T00:00:00Z' },
+    ])
+  })
+
+  test('drops malformed entries and tolerates non-array input', () => {
+    expect(parseModelWindows(undefined)).toEqual([])
+    expect(parseModelWindows('nope')).toEqual([])
+    expect(parseModelWindows([
+      null,
+      { kind: 'weekly_scoped', percent: 10, scope: null },
+      { kind: 'weekly_scoped', percent: 'high', scope: { model: { display_name: 'Fable' } } },
+      { kind: 'weekly_scoped', percent: 10, resets_at: 42, scope: { model: { display_name: 'Opus' } } },
+    ])).toEqual([
+      { model: 'Opus', usedPercentage: 10, resetsAt: null },
+    ])
   })
 })

--- a/apps/frontend/src/components/settings/UsageSection.tsx
+++ b/apps/frontend/src/components/settings/UsageSection.tsx
@@ -61,7 +61,8 @@ export function UsageSection({ open }: { open: boolean }) {
     return <div className="py-4 text-sm text-muted-foreground">{t('settings.usageLoadError')}</div>
   }
 
-  const hasWindows = data.available && (data.fiveHour || data.sevenDay)
+  const modelWindows = data.modelWindows ?? []
+  const hasWindows = data.available && (data.fiveHour || data.sevenDay || modelWindows.length > 0)
 
   return (
     <div className="space-y-4">
@@ -95,6 +96,9 @@ export function UsageSection({ open }: { open: boolean }) {
                 <div className="space-y-4 rounded-md border px-3 py-3">
                   {data.fiveHour ? <UsageBar label={t('settings.usageFiveHour')} window={data.fiveHour} /> : null}
                   {data.sevenDay ? <UsageBar label={t('settings.usageSevenDay')} window={data.sevenDay} /> : null}
+                  {modelWindows.map(w => (
+                    <UsageBar key={w.model} label={t('settings.usageSevenDayModel', { model: w.model })} window={w} />
+                  ))}
                 </div>
               )}
     </div>

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -337,6 +337,7 @@
     "usageRefresh": "Refresh",
     "usageFiveHour": "5-hour window",
     "usageSevenDay": "7-day window",
+    "usageSevenDayModel": "7-day window ({{model}})",
     "usageResetsAt": "Resets at {{time}}",
     "usageNoWindowData": "No utilization data is currently reported.",
     "usageUnavailableNoCredentials": "No Claude credentials found. Log in with a Pro/Max subscription in the terminal to view usage.",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -336,6 +336,7 @@
     "usageRefresh": "刷新",
     "usageFiveHour": "5 小时窗口",
     "usageSevenDay": "7 天窗口",
+    "usageSevenDayModel": "7 天窗口({{model}})",
     "usageResetsAt": "{{time}} 重置",
     "usageNoWindowData": "当前没有可用的用量数据。",
     "usageUnavailableNoCredentials": "未找到 Claude 凭证。请在终端用 Pro/Max 订阅登录后再查看用量。",

--- a/docs/task/ENG-021.md
+++ b/docs/task/ENG-021.md
@@ -1,0 +1,69 @@
+# ENG-021 Show model-scoped (Fable) usage windows in settings usage panel
+
+- **status**: completed
+- **priority**: P2
+- **owner**: deyang
+- **createdAt**: 2026-07-17
+
+## Problem
+
+The settings usage panel (ENG-020) only shows the top-level `five_hour` and
+`seven_day` windows. Anthropic now reports model-scoped weekly limits — e.g.
+the Fable (Claude Fable 5) weekly window — which the panel silently drops, so
+users cannot see how much of their Fable allowance is left.
+
+## Verified response shape (live probe, 2026-07-17)
+
+The top-level per-model fields (`seven_day_opus`, `seven_day_sonnet`, …) are
+all `null` on this account. Model-scoped usage is carried by the newer
+`limits` array instead:
+
+```jsonc
+"limits": [
+  { "kind": "session",       "group": "session", "percent": 6,  "resets_at": "<iso>", "scope": null },
+  { "kind": "weekly_all",    "group": "weekly",  "percent": 19, "resets_at": "<iso>", "scope": null },
+  { "kind": "weekly_scoped", "group": "weekly",  "percent": 17, "resets_at": "<iso>",
+    "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null } }
+]
+```
+
+`session` / `weekly_all` duplicate the existing `five_hour` / `seven_day`
+fields; the new information is the `weekly_scoped` entries with a
+`scope.model.display_name`.
+
+## Approach
+
+Parse `limits[]` for model-scoped entries generically (today that yields
+Fable; Opus/Sonnet-scoped entries would appear automatically) instead of
+hardcoding a Fable field.
+
+- **Shared**: add `ClaudeUsageModelWindow { model, usedPercentage, resetsAt }`
+  and optional `modelWindows` on `ClaudeUsage`.
+- **Backend** (`engines/executors/claude/usage.ts`): export
+  `parseModelWindows(limits)` — filter `kind === 'weekly_scoped'` entries with
+  a string `scope.model.display_name` and numeric `percent`; defensive, never
+  throws. Extend `openapi/schemas.ts` accordingly.
+- **Frontend** (`UsageSection.tsx`): render one bar per model window labeled
+  via i18n `settings.usageSevenDayModel` ("7-day ({{model}})" / "7 天
+  ({{model}})"); include `modelWindows` in the `hasWindows` check.
+- **Tests**: fixture-based unit test for `parseModelWindows` using the probed
+  response shape.
+
+## Scope
+
+- `packages/shared/src/index.ts`
+- `apps/api/src/engines/executors/claude/usage.ts`, `apps/api/src/openapi/schemas.ts`
+- `apps/api/test/claude-usage.test.ts`
+- `apps/frontend/src/components/settings/UsageSection.tsx`, `i18n/{en,zh}.json`
+
+## Out of scope
+
+- `extra_usage` credits / spend section.
+- Session-scoped or surface-scoped limits (none observed).
+- Migrating the existing 5h/7d parsing onto the `limits` array.
+
+## Risks
+
+- Endpoint is undocumented; `limits` may change shape — parsing is defensive
+  and drops malformed entries.
+- `display_name` is a free-form label from upstream; rendered as-is.

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -66,3 +66,4 @@ Each task is a single line linking to its detail file. All detailed information 
 - [x] [**ENG-019 Normalize assistant image content blocks (Bifrost) to attachments**](ENG-019.md) `P1`
 - [x] [**UI-003 Use nanoid id as the only resource identifier in URLs and API**](UI-003.md) `P2`
 - [x] [**ENG-020 Add Claude subscription usage panel in settings**](ENG-020.md) `P2`
+- [x] [**ENG-021 Show model-scoped (Fable) usage windows in settings usage panel**](ENG-021.md) `P2`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -385,6 +385,12 @@ export interface ClaudeUsageWindow {
   resetsAt: string | null
 }
 
+/** A model-scoped weekly rate-limit window (e.g. Fable). */
+export interface ClaudeUsageModelWindow extends ClaudeUsageWindow {
+  /** Upstream model display name, e.g. "Fable". */
+  model: string
+}
+
 /**
  * Claude subscription rate-limit utilization (the TUI `/usage` panel).
  * `available: false` carries a reason for the unavailable state.
@@ -396,6 +402,8 @@ export interface ClaudeUsage {
   fiveHour?: ClaudeUsageWindow | null
   /** 7-day window. */
   sevenDay?: ClaudeUsageWindow | null
+  /** Model-scoped weekly windows from the upstream `limits` array. */
+  modelWindows?: ClaudeUsageModelWindow[]
 }
 
 // ── Event Bus ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The settings usage panel (ENG-020) only rendered the top-level `five_hour` / `seven_day` windows. The upstream `GET /api/oauth/usage` endpoint now reports model-scoped weekly limits in its `limits` array (`kind=weekly_scoped` with `scope.model.display_name`, e.g. "Fable"), which the panel silently dropped.

This parses those entries generically and renders one utilization bar per model window, so the Fable weekly allowance shows up alongside the 5-hour and 7-day windows. Any future model-scoped limits (Opus/Sonnet) appear automatically.

## Changes

- `packages/shared`: add `ClaudeUsageModelWindow` and optional `modelWindows` on `ClaudeUsage`
- `apps/api`: export `parseModelWindows(limits)` in `engines/executors/claude/usage.ts` (defensive, drops malformed entries); extend the OpenAPI response schema
- `apps/frontend`: render model window bars in `UsageSection`; include them in the empty-state check; new i18n key `settings.usageSevenDayModel` (en/zh)
- `docs/task`: ENG-021 task file

## Testing

- New fixture-based unit tests for `parseModelWindows` (real probed response shape + malformed-input tolerance): 4 pass in `claude-usage.test.ts`
- Frontend tests: 40 pass; lint: 0 errors
- Live end-to-end call returned `modelWindows: [{ model: "Fable", usedPercentage: 18, ... }]`
- Known pre-existing failure in `api-settings.test.ts` (workspace-path) reproduces on a clean tree; unrelated