### PR TITLE
feat(engines): add Claude Opus 5 model and set as default

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -91,7 +91,13 @@ const CLAUDE_MODELS: EngineModel[] = [
     name: 'Claude Fable 5 (1M)',
     isDefault: false,
   },
-  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', isDefault: true },
+  { id: 'claude-opus-5', name: 'Claude Opus 5', isDefault: true },
+  {
+    id: 'claude-opus-5[1m]',
+    name: 'Claude Opus 5 (1M)',
+    isDefault: false,
+  },
+  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', isDefault: false },
   {
     id: 'claude-opus-4-8[1m]',
     name: 'Claude Opus 4.8 (1M)',


### PR DESCRIPTION
## Summary
- Add `claude-opus-5` and `claude-opus-5[1m]` to the known Claude models list
- Switch the default model from `claude-opus-4-8` to `claude-opus-5`